### PR TITLE
fix: configurable JWT TTL with working refresh endpoint (#800)

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -66,7 +66,7 @@ SonicJS AI uses a modern authentication architecture built on:
 2. Check for duplicate email/username
 3. Password hashed with SHA-256 + salt
 4. User created with default role: `viewer`
-5. JWT token generated (24-hour expiration)
+5. JWT token generated (TTL from `JWT_EXPIRES_IN`, default 30 days)
 6. HTTP-only cookie set
 7. Token returned in response
 
@@ -100,7 +100,7 @@ SonicJS AI uses a modern authentication architecture built on:
 2. User lookup with KV caching
 3. Password verification with SHA-256
 4. JWT token generation
-5. HTTP-only cookie set (24-hour expiration)
+5. HTTP-only cookie set (TTL from `JWT_EXPIRES_IN`, default 30 days)
 6. `last_login_at` timestamp updated
 7. User cache invalidated to ensure fresh data
 
@@ -109,14 +109,21 @@ SonicJS AI uses a modern authentication architecture built on:
 **Endpoint:** `POST /auth/refresh`
 
 ```typescript
-// Headers
-Authorization: Bearer <current_token>
+// Headers (or cookie)
+Authorization: Bearer <current_or_recently_expired_token>
 
 // Response
 {
-  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "expiresIn": 2592000
 }
 ```
+
+Accepts a JWT that is either still valid or has expired within the grace
+window (`JWT_REFRESH_GRACE_SECONDS`, default 7 days). Re-validates the user
+in the database and issues a freshly-signed token — no password/OTP required.
+This supports sliding-session auth so a long-lived session cookie can keep
+a user logged in across JWT rotations.
 
 ## JWT Implementation
 
@@ -137,36 +144,36 @@ interface JWTPayload {
 ### Token Generation
 
 ```typescript
-import { AuthManager } from '../middleware/auth'
+import { AuthManager, getJwtExpirySeconds } from '../middleware/auth'
 
-// Generate a token
+// Generate a token with the environment-configured TTL
+const ttl = getJwtExpirySeconds(env)
 const token = await AuthManager.generateToken(
   userId,
   email,
-  role
+  role,
+  env.JWT_SECRET,
+  ttl
 )
-
-// Token expires in 24 hours
-// exp = Math.floor(Date.now() / 1000) + (60 * 60 * 24)
 ```
 
-**Implementation (`src/middleware/auth.ts`):**
+### Configuring JWT Expiration
 
-```typescript
-export class AuthManager {
-  static async generateToken(userId: string, email: string, role: string): Promise<string> {
-    const payload: JWTPayload = {
-      userId,
-      email,
-      role,
-      exp: Math.floor(Date.now() / 1000) + (60 * 60 * 24), // 24 hours
-      iat: Math.floor(Date.now() / 1000)
-    }
+JWT TTL is controlled by the `JWT_EXPIRES_IN` environment variable. It accepts
+a plain number of seconds or a duration string:
 
-    return await sign(payload, JWT_SECRET, 'HS256')
-  }
-}
-```
+| Example value | Meaning      |
+| ------------- | ------------ |
+| `2592000`     | 30 days (default) |
+| `30d`         | 30 days      |
+| `12h`         | 12 hours     |
+| `3600s`       | 1 hour       |
+
+If `JWT_EXPIRES_IN` is not set, SonicJS defaults to **30 days**.
+
+The refresh endpoint also honors `JWT_REFRESH_GRACE_SECONDS` (default 7 days),
+which controls how long after expiration a token can still be used to obtain a
+fresh one via `POST /auth/refresh`.
 
 ### Token Verification
 

--- a/packages/core/src/__tests__/middleware/auth.test.ts
+++ b/packages/core/src/__tests__/middleware/auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { AuthManager, requireAuth, requireRole, optionalAuth } from '../../middleware/auth'
+import { AuthManager, requireAuth, requireRole, optionalAuth, getJwtExpirySeconds } from '../../middleware/auth'
 import { Context, Next } from 'hono'
+import { sign } from 'hono/jwt'
 
 describe('AuthManager', () => {
   describe('generateToken', () => {
@@ -59,6 +60,101 @@ describe('AuthManager', () => {
 
       expect(payload?.iat).toBeTruthy()
       expect(payload?.iat).toBeLessThanOrEqual(Math.floor(Date.now() / 1000))
+    })
+
+    it('should honor custom expiresIn and default to 30 days', async () => {
+      // Default TTL is 30 days
+      const defaultToken = await AuthManager.generateToken('u', 'a@b.c', 'viewer')
+      const defaultPayload = await AuthManager.verifyToken(defaultToken)
+      const now = Math.floor(Date.now() / 1000)
+      const thirtyDays = 60 * 60 * 24 * 30
+      expect(defaultPayload?.exp).toBeGreaterThan(now + thirtyDays - 60)
+      expect(defaultPayload?.exp).toBeLessThanOrEqual(now + thirtyDays + 5)
+
+      // Custom TTL
+      const shortToken = await AuthManager.generateToken('u', 'a@b.c', 'viewer', undefined, 3600)
+      const shortPayload = await AuthManager.verifyToken(shortToken)
+      expect(shortPayload?.exp).toBeLessThanOrEqual(now + 3605)
+    })
+
+    it('should accept a recently-expired token when grace window is set', async () => {
+      const secret = 'test-grace-secret'
+      const now = Math.floor(Date.now() / 1000)
+      // Token that expired 60 seconds ago
+      const expiredPayload = {
+        userId: 'u1',
+        email: 'u1@test',
+        role: 'admin',
+        iat: now - 120,
+        exp: now - 60
+      }
+      const expiredToken = await sign(expiredPayload, secret, 'HS256')
+
+      // Without grace window, expired token is rejected
+      const strict = await AuthManager.verifyToken(expiredToken, secret)
+      expect(strict).toBeNull()
+
+      // With grace window of 300s, expired token is accepted
+      const lenient = await AuthManager.verifyToken(expiredToken, secret, 300)
+      expect(lenient).toBeTruthy()
+      expect(lenient?.userId).toBe('u1')
+    })
+
+    it('should reject tokens expired beyond grace window', async () => {
+      const secret = 'test-grace-secret'
+      const now = Math.floor(Date.now() / 1000)
+      const expiredPayload = {
+        userId: 'u1',
+        email: 'u1@test',
+        role: 'admin',
+        iat: now - 7200,
+        exp: now - 3600
+      }
+      const expiredToken = await sign(expiredPayload, secret, 'HS256')
+      // Grace window smaller than how long it has been expired
+      const result = await AuthManager.verifyToken(expiredToken, secret, 60)
+      expect(result).toBeNull()
+    })
+
+    it('should reject tokens with bad signature even within grace window', async () => {
+      const now = Math.floor(Date.now() / 1000)
+      const expiredPayload = {
+        userId: 'u1',
+        email: 'u1@test',
+        role: 'admin',
+        iat: now - 120,
+        exp: now - 60
+      }
+      const tokenWithOneSecret = await sign(expiredPayload, 'secret-A', 'HS256')
+      // Verify with a different secret — signature check must fail
+      const result = await AuthManager.verifyToken(tokenWithOneSecret, 'secret-B', 3600)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getJwtExpirySeconds', () => {
+    it('defaults to 30 days when env is empty', () => {
+      expect(getJwtExpirySeconds({})).toBe(60 * 60 * 24 * 30)
+      expect(getJwtExpirySeconds(null)).toBe(60 * 60 * 24 * 30)
+      expect(getJwtExpirySeconds(undefined)).toBe(60 * 60 * 24 * 30)
+    })
+
+    it('parses duration strings', () => {
+      expect(getJwtExpirySeconds({ JWT_EXPIRES_IN: '30d' })).toBe(60 * 60 * 24 * 30)
+      expect(getJwtExpirySeconds({ JWT_EXPIRES_IN: '12h' })).toBe(60 * 60 * 12)
+      expect(getJwtExpirySeconds({ JWT_EXPIRES_IN: '3600s' })).toBe(3600)
+      expect(getJwtExpirySeconds({ JWT_EXPIRES_IN: '15m' })).toBe(900)
+    })
+
+    it('parses bare seconds values', () => {
+      expect(getJwtExpirySeconds({ JWT_EXPIRES_IN: '7200' })).toBe(7200)
+      expect(getJwtExpirySeconds({ JWT_EXPIRES_IN: 7200 as any })).toBe(7200)
+    })
+
+    it('falls back to default on garbage input', () => {
+      expect(getJwtExpirySeconds({ JWT_EXPIRES_IN: 'nonsense' })).toBe(60 * 60 * 24 * 30)
+      expect(getJwtExpirySeconds({ JWT_EXPIRES_IN: '0' })).toBe(60 * 60 * 24 * 30)
+      expect(getJwtExpirySeconds({ JWT_EXPIRES_IN: '-5d' })).toBe(60 * 60 * 24 * 30)
     })
   })
 

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -67,6 +67,8 @@ export interface Bindings {
   ENVIRONMENT?: string
   CORS_ORIGINS?: string
   JWT_SECRET?: string
+  JWT_EXPIRES_IN?: string
+  JWT_REFRESH_GRACE_SECONDS?: string
   BUCKET_NAME?: string
   GOOGLE_MAPS_API_KEY?: string
 }

--- a/packages/core/src/middleware/auth.ts
+++ b/packages/core/src/middleware/auth.ts
@@ -13,28 +13,229 @@ type JWTPayload = {
 // Fallback JWT secret for local development only (no wrangler secret set)
 const JWT_SECRET_FALLBACK = 'your-super-secret-jwt-key-change-in-production'
 
+// Default JWT TTL: 30 days. Can be overridden via JWT_EXPIRES_IN env var.
+const DEFAULT_JWT_EXPIRES_IN_SECONDS = 60 * 60 * 24 * 30
+
+/**
+ * Parse a TTL string like "30d", "12h", "3600s", or a bare number-of-seconds
+ * into a seconds value. Returns null if the input is missing/unparseable.
+ */
+function parseDuration(input: string | number | undefined | null): number | null {
+  if (input === undefined || input === null || input === '') return null
+  if (typeof input === 'number' && Number.isFinite(input) && input > 0) {
+    return Math.floor(input)
+  }
+  const raw = String(input).trim()
+  if (/^\d+$/.test(raw)) {
+    const n = parseInt(raw, 10)
+    return n > 0 ? n : null
+  }
+  const match = raw.match(/^(\d+)\s*(s|sec|secs|seconds|m|min|mins|minutes|h|hr|hrs|hours|d|day|days)$/i)
+  if (!match) return null
+  const value = parseInt(match[1]!, 10)
+  const unit = match[2]!.toLowerCase()
+  if (unit.startsWith('s')) return value
+  if (unit.startsWith('m')) return value * 60
+  if (unit.startsWith('h')) return value * 60 * 60
+  if (unit.startsWith('d')) return value * 60 * 60 * 24
+  return null
+}
+
+/**
+ * Resolve the JWT expiry in seconds from the environment.
+ * Honors `JWT_EXPIRES_IN` (seconds or "30d"/"12h"/"3600s") with a 30-day default.
+ */
+export function getJwtExpirySeconds(env?: Record<string, any> | null): number {
+  const configured = parseDuration(env?.JWT_EXPIRES_IN)
+  return configured ?? DEFAULT_JWT_EXPIRES_IN_SECONDS
+}
+
+/**
+ * Resolve the JWT expiry in seconds. Precedence: `JWT_EXPIRES_IN` env var
+ * (authoritative ceiling) → `settings.security.jwtExpiresIn` DB value
+ * (admin-configurable) → 30-day default.
+ *
+ * The env var wins so operators can cap runtime overrides — admins can adjust
+ * the TTL from /admin/settings/security, but an env var, if set, always wins.
+ * DB failures fall back to env/default so auth never breaks if the settings
+ * table is unreachable.
+ */
+export async function getJwtExpirySecondsFromDb(
+  db: { prepare: (query: string) => any } | null | undefined,
+  env?: Record<string, any> | null
+): Promise<number> {
+  const envParsed = parseDuration(env?.JWT_EXPIRES_IN)
+  if (envParsed) return envParsed
+
+  if (db) {
+    try {
+      const row = await db
+        .prepare("SELECT value FROM settings WHERE category = 'security' AND key = 'jwtExpiresIn'")
+        .first() as { value: string } | null
+      if (row?.value) {
+        let stored: any = row.value
+        try { stored = JSON.parse(row.value) } catch { /* value may already be a bare string */ }
+        const parsed = parseDuration(stored)
+        if (parsed) return parsed
+      }
+    } catch (err) {
+      console.warn('Failed to read jwtExpiresIn from settings, falling back to default:', err)
+    }
+  }
+  return DEFAULT_JWT_EXPIRES_IN_SECONDS
+}
+
+/**
+ * Resolve the refresh grace window (seconds) for `/auth/refresh`. Precedence:
+ * `JWT_REFRESH_GRACE_SECONDS` env var → `settings.security.jwtRefreshGraceSeconds`
+ * DB value → 7-day default.
+ */
+export async function getJwtRefreshGraceSecondsFromDb(
+  db: { prepare: (query: string) => any } | null | undefined,
+  env?: Record<string, any> | null
+): Promise<number> {
+  const DEFAULT_GRACE = 60 * 60 * 24 * 7
+  const envParsed = parseDuration(env?.JWT_REFRESH_GRACE_SECONDS)
+  if (envParsed) return envParsed
+
+  if (db) {
+    try {
+      const row = await db
+        .prepare("SELECT value FROM settings WHERE category = 'security' AND key = 'jwtRefreshGraceSeconds'")
+        .first() as { value: string } | null
+      if (row?.value) {
+        let stored: any = row.value
+        try { stored = JSON.parse(row.value) } catch { /* may be bare */ }
+        const parsed = parseDuration(stored)
+        if (parsed) return parsed
+      }
+    } catch (err) {
+      console.warn('Failed to read jwtRefreshGraceSeconds from settings:', err)
+    }
+  }
+  return DEFAULT_GRACE
+}
+
+/**
+ * Decode a JWT payload without verifying the signature. Returns null on any
+ * parsing failure. Callers MUST independently verify the signature before
+ * trusting this value — used from the grace-window refresh path where the
+ * signature is verified explicitly via `verifyHs256Signature`.
+ */
+function decodeJwtPayload(token: string): JWTPayload | null {
+  try {
+    const parts = token.split('.')
+    if (parts.length !== 3) return null
+    const b64 = parts[1]!.replace(/-/g, '+').replace(/_/g, '/')
+    const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4)
+    const json = atob(padded)
+    const obj = JSON.parse(json)
+    if (!obj || typeof obj.exp !== 'number') return null
+    return obj as JWTPayload
+  } catch {
+    return null
+  }
+}
+
+function base64UrlToBytes(b64url: string): Uint8Array {
+  const b64 = b64url.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4)
+  const bin = atob(padded)
+  const bytes = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
+  return bytes
+}
+
+/**
+ * Verify a JWT's HS256 signature using Web Crypto, independent of hono/jwt.
+ * Returns true iff the signature matches the header.payload portion.
+ */
+async function verifyHs256Signature(token: string, secret: string): Promise<boolean> {
+  try {
+    const parts = token.split('.')
+    if (parts.length !== 3) return false
+    const encoder = new TextEncoder()
+    const key = await crypto.subtle.importKey(
+      'raw',
+      encoder.encode(secret),
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['verify']
+    )
+    const signature = base64UrlToBytes(parts[2]!)
+    const message = encoder.encode(`${parts[0]}.${parts[1]}`)
+    return await crypto.subtle.verify('HMAC', key, signature, message)
+  } catch {
+    return false
+  }
+}
+
 export class AuthManager {
-  static async generateToken(userId: string, email: string, role: string, secret?: string): Promise<string> {
+  static async generateToken(
+    userId: string,
+    email: string,
+    role: string,
+    secret?: string,
+    expiresInSeconds?: number
+  ): Promise<string> {
+    const ttl = expiresInSeconds && expiresInSeconds > 0
+      ? Math.floor(expiresInSeconds)
+      : DEFAULT_JWT_EXPIRES_IN_SECONDS
+    const now = Math.floor(Date.now() / 1000)
     const payload: JWTPayload = {
       userId,
       email,
       role,
-      exp: Math.floor(Date.now() / 1000) + (60 * 60 * 24), // 24 hours
-      iat: Math.floor(Date.now() / 1000)
+      exp: now + ttl,
+      iat: now
     }
 
     return await sign(payload, secret || JWT_SECRET_FALLBACK, 'HS256')
   }
 
-  static async verifyToken(token: string, secret?: string): Promise<JWTPayload | null> {
+  /**
+   * Verify a token's signature and expiration.
+   *
+   * If `graceSeconds` > 0, tokens whose `exp` is within the grace window
+   * (i.e. expired by no more than `graceSeconds`) are still returned. This
+   * supports a sliding-session refresh endpoint that accepts recently-expired
+   * tokens. Signature failures always return null.
+   */
+  static async verifyToken(
+    token: string,
+    secret?: string,
+    graceSeconds: number = 0
+  ): Promise<JWTPayload | null> {
+    const effectiveSecret = secret || JWT_SECRET_FALLBACK
     try {
-      const payload = await verify(token, secret || JWT_SECRET_FALLBACK, 'HS256') as JWTPayload
-      
-      // Check if token is expired
-      if (payload.exp < Math.floor(Date.now() / 1000)) {
+      let payload: JWTPayload | null = null
+      try {
+        payload = await verify(token, effectiveSecret, 'HS256') as JWTPayload
+      } catch (verifyError: any) {
+        // hono/jwt checks `exp` before signature, so a bad-signature token
+        // that happens to be expired will throw JwtTokenExpired here. For
+        // the grace window, we still require a valid HS256 signature before
+        // accepting the payload.
+        const name = verifyError?.name || ''
+        const message = String(verifyError?.message || '')
+        const isExpired = name === 'JwtTokenExpired' || message.includes('expired')
+        if (!isExpired || graceSeconds <= 0) {
+          throw verifyError
+        }
+        const signatureValid = await verifyHs256Signature(token, effectiveSecret)
+        if (!signatureValid) return null
+        const decoded = decodeJwtPayload(token)
+        if (!decoded) return null
+        payload = decoded
+      }
+
+      if (!payload) return null
+
+      const now = Math.floor(Date.now() / 1000)
+      if (payload.exp < now - Math.max(0, Math.floor(graceSeconds))) {
         return null
       }
-      
+
       return payload
     } catch (error) {
       console.error('Token verification failed:', error)
@@ -158,7 +359,7 @@ export class AuthManager {
       httpOnly: options?.httpOnly ?? true,
       secure: options?.secure ?? true,
       sameSite: options?.sameSite ?? 'Strict',
-      maxAge: options?.maxAge ?? (60 * 60 * 24) // 24 hours default
+      maxAge: options?.maxAge ?? getJwtExpirySeconds((c as any)?.env)
     })
   }
 }

--- a/packages/core/src/middleware/index.ts
+++ b/packages/core/src/middleware/index.ts
@@ -11,7 +11,15 @@
 export { bootstrapMiddleware, verifySecurityConfig } from './bootstrap'
 
 // Auth middleware
-export { AuthManager, requireAuth, requireRole, optionalAuth } from './auth'
+export {
+  AuthManager,
+  requireAuth,
+  requireRole,
+  optionalAuth,
+  getJwtExpirySeconds,
+  getJwtExpirySecondsFromDb,
+  getJwtRefreshGraceSecondsFromDb,
+} from './auth'
 
 // Metrics middleware
 export { metricsMiddleware } from './metrics'

--- a/packages/core/src/plugins/available/magic-link-auth/index.ts
+++ b/packages/core/src/plugins/available/magic-link-auth/index.ts
@@ -9,7 +9,7 @@ import { Hono } from 'hono'
 import { z } from 'zod'
 import type { Plugin, PluginContext } from '../../types'
 import type { D1Database } from '@cloudflare/workers-types'
-import { AuthManager } from '../../../middleware/auth'
+import { AuthManager, getJwtExpirySecondsFromDb } from '../../../middleware/auth'
 
 const magicLinkRequestSchema = z.object({
   email: z.string().email('Valid email is required')
@@ -201,15 +201,17 @@ export function createMagicLinkAuthPlugin(): Plugin {
       `).bind(Date.now(), magicLink.id).run()
 
       // Generate JWT token
+      const tokenTtl = await getJwtExpirySecondsFromDb((c.env as any).DB, c.env as any)
       const jwtToken = await AuthManager.generateToken(
         user.id,
         user.email,
         user.role,
-        (c.env as any).JWT_SECRET
+        (c.env as any).JWT_SECRET,
+        tokenTtl
       )
 
       // Set auth cookie
-      AuthManager.setAuthCookie(c, jwtToken)
+      AuthManager.setAuthCookie(c, jwtToken, { maxAge: tokenTtl })
 
       // Update last login
       await db.prepare(`

--- a/packages/core/src/plugins/core-plugins/oauth-providers/index.ts
+++ b/packages/core/src/plugins/core-plugins/oauth-providers/index.ts
@@ -23,6 +23,7 @@ import {
   type OAuthProviderConfig
 } from './oauth-service'
 import { AuthManager } from '../../../middleware'
+import { getJwtExpirySecondsFromDb } from '../../../middleware/auth'
 
 const STATE_COOKIE_NAME = 'oauth_state'
 const STATE_COOKIE_MAX_AGE = 600 // 10 minutes
@@ -217,12 +218,13 @@ export function createOAuthProvidersPlugin(): Plugin {
           return c.redirect('/auth/login?error=Account is deactivated')
         }
 
+        const tokenTtl = await getJwtExpirySecondsFromDb((c.env as any).DB, c.env as any)
         const jwt = await AuthManager.generateToken(
           user.id, user.email, user.role,
-          (c.env as any).JWT_SECRET
+          (c.env as any).JWT_SECRET, tokenTtl
         )
 
-        AuthManager.setAuthCookie(c, jwt, { sameSite: 'Lax' })
+        AuthManager.setAuthCookie(c, jwt, { sameSite: 'Lax', maxAge: tokenTtl })
         return c.redirect('/admin')
       }
 
@@ -245,12 +247,13 @@ export function createOAuthProvidersPlugin(): Plugin {
           profileData: JSON.stringify(profile)
         })
 
+        const tokenTtl = await getJwtExpirySecondsFromDb((c.env as any).DB, c.env as any)
         const jwt = await AuthManager.generateToken(
           existingUser.id, existingUser.email, existingUser.role,
-          (c.env as any).JWT_SECRET
+          (c.env as any).JWT_SECRET, tokenTtl
         )
 
-        AuthManager.setAuthCookie(c, jwt, { sameSite: 'Lax' })
+        AuthManager.setAuthCookie(c, jwt, { sameSite: 'Lax', maxAge: tokenTtl })
         return c.redirect('/admin')
       }
 
@@ -267,12 +270,13 @@ export function createOAuthProvidersPlugin(): Plugin {
         profileData: JSON.stringify(profile)
       })
 
+      const tokenTtl = await getJwtExpirySecondsFromDb((c.env as any).DB, c.env as any)
       const jwt = await AuthManager.generateToken(
         newUserId, profile.email.toLowerCase(), 'viewer',
-        (c.env as any).JWT_SECRET
+        (c.env as any).JWT_SECRET, tokenTtl
       )
 
-      AuthManager.setAuthCookie(c, jwt, { sameSite: 'Lax' })
+      AuthManager.setAuthCookie(c, jwt, { sameSite: 'Lax', maxAge: tokenTtl })
       return c.redirect('/admin')
 
     } catch (error) {

--- a/packages/core/src/plugins/core-plugins/otp-login-plugin/README.md
+++ b/packages/core/src/plugins/core-plugins/otp-login-plugin/README.md
@@ -55,6 +55,18 @@ Settings available in Admin → Plugins → OTP Login → Settings:
 - **Rate Limit**: 3-20 requests/hour (default: 5)
 - **Allow Registration**: Enable new user signup (default: false)
 
+### Session / JWT TTL
+
+The JWT issued by `/auth/otp/verify` uses the core SonicJS session config:
+
+- `JWT_EXPIRES_IN` — TTL for the issued JWT and cookie. Accepts seconds or a
+  duration string like `30d`, `12h`, `3600s`. Defaults to **30 days**.
+- `JWT_REFRESH_GRACE_SECONDS` — how long after expiration a token may still
+  be exchanged at `POST /auth/refresh` for a fresh one (default 7 days).
+
+Use `POST /auth/refresh` for sliding-session renewal instead of forcing the
+user back through OTP on every JWT expiration.
+
 ## Security
 
 - Crypto-secure random generation

--- a/packages/core/src/plugins/core-plugins/otp-login-plugin/index.ts
+++ b/packages/core/src/plugins/core-plugins/otp-login-plugin/index.ts
@@ -13,6 +13,7 @@ import type { Plugin } from '@sonicjs-cms/core'
 import { OTPService, type OTPSettings } from './otp-service'
 import { renderOTPEmail } from './email-templates'
 import { AuthManager } from '../../../middleware'
+import { getJwtExpirySecondsFromDb } from '../../../middleware/auth'
 import { SettingsService } from '../../../services/settings'
 
 // Validation schemas
@@ -299,14 +300,15 @@ export function createOTPLoginPlugin(): Plugin {
       }
 
       // Generate JWT token
-      const token = await AuthManager.generateToken(user.id, user.email, user.role, (c.env as any).JWT_SECRET)
+      const tokenTtl = await getJwtExpirySecondsFromDb(db, c.env as any)
+      const token = await AuthManager.generateToken(user.id, user.email, user.role, (c.env as any).JWT_SECRET, tokenTtl)
 
       // Set HTTP-only cookie
       setCookie(c, 'auth_token', token, {
         httpOnly: true,
         secure: true,
         sameSite: 'Strict',
-        maxAge: 60 * 60 * 24 // 24 hours
+        maxAge: tokenTtl
       })
 
       return c.json({

--- a/packages/core/src/routes/admin-settings.ts
+++ b/packages/core/src/routes/admin-settings.ts
@@ -143,15 +143,28 @@ adminSettingsRoutes.get('/appearance', (c) => {
 })
 
 // Security settings
-adminSettingsRoutes.get('/security', (c) => {
+adminSettingsRoutes.get('/security', async (c) => {
   const user = c.get('user')
+  const db = c.env.DB
+  const settingsService = new SettingsService(db)
+
+  // Load persisted security settings (JWT TTL + refresh grace)
+  const persisted = await settingsService.getSecuritySettings()
+
+  const mockSettings = getMockSettings(user)
+  mockSettings.security = {
+    ...mockSettings.security,
+    jwtExpiresIn: persisted.jwtExpiresIn,
+    jwtRefreshGraceSeconds: persisted.jwtRefreshGraceSeconds
+  } as any
+
   const pageData: SettingsPageData = {
     user: user ? {
       name: user.email,
       email: user.email,
       role: user.role
     } : undefined,
-    settings: getMockSettings(user),
+    settings: mockSettings,
     activeTab: 'security',
     version: c.get('appVersion')
   }
@@ -521,6 +534,65 @@ adminSettingsRoutes.post('/general', async (c) => {
     }
   } catch (error) {
     console.error('Error saving general settings:', error)
+    return c.json({
+      success: false,
+      error: 'Failed to save settings. Please try again.'
+    }, 500)
+  }
+})
+
+// Save security settings (JWT TTL + refresh grace)
+adminSettingsRoutes.post('/security', async (c) => {
+  try {
+    const user = c.get('user')
+
+    if (!user || user.role !== 'admin') {
+      return c.json({
+        success: false,
+        error: 'Unauthorized. Admin access required.'
+      }, 403)
+    }
+
+    const formData = await c.req.formData()
+    const db = c.env.DB
+    const settingsService = new SettingsService(db)
+
+    const jwtExpiresInRaw = (formData.get('jwtExpiresIn') as string | null)?.trim() || ''
+    const graceRaw = (formData.get('jwtRefreshGraceSeconds') as string | null)?.trim() || ''
+
+    // Validate jwtExpiresIn: bare seconds or <num><s|m|h|d>
+    if (!/^\d+(?:s|m|h|d)?$/i.test(jwtExpiresInRaw)) {
+      return c.json({
+        success: false,
+        error: 'JWT expiration must be a number optionally suffixed with s/m/h/d (e.g. 30d, 12h, 3600).'
+      }, 400)
+    }
+
+    const graceSeconds = Number.parseInt(graceRaw, 10)
+    if (!Number.isFinite(graceSeconds) || graceSeconds < 0 || graceSeconds > 60 * 60 * 24 * 90) {
+      return c.json({
+        success: false,
+        error: 'Refresh grace must be an integer between 0 and 7776000 seconds (90 days).'
+      }, 400)
+    }
+
+    const success = await settingsService.saveSecuritySettings({
+      jwtExpiresIn: jwtExpiresInRaw,
+      jwtRefreshGraceSeconds: graceSeconds
+    })
+
+    if (success) {
+      return c.json({
+        success: true,
+        message: 'Security settings saved successfully!'
+      })
+    }
+    return c.json({
+      success: false,
+      error: 'Failed to save settings'
+    }, 500)
+  } catch (error) {
+    console.error('Error saving security settings:', error)
     return c.json({
       success: false,
       error: 'Failed to save settings. Please try again.'

--- a/packages/core/src/routes/auth.ts
+++ b/packages/core/src/routes/auth.ts
@@ -1,9 +1,10 @@
 import { Hono } from 'hono'
 // import { zValidator } from '@hono/zod-validator'
 import { z } from 'zod'
-import { setCookie } from 'hono/cookie'
+import { getCookie, setCookie } from 'hono/cookie'
 import { html } from 'hono/html'
 import { AuthManager, requireAuth, generateCsrfToken, rateLimit } from '../middleware'
+import { getJwtExpirySecondsFromDb, getJwtRefreshGraceSecondsFromDb } from '../middleware/auth'
 import { renderLoginPage, LoginPageData } from '../templates/pages/auth-login.template'
 import { renderRegisterPage, RegisterPageData } from '../templates/pages/auth-register.template'
 import { getCacheService, CACHE_CONFIGS } from '../services'
@@ -15,16 +16,17 @@ import { getUserProfileConfig, getRegistrationFields, getProfileFieldDefaults, s
 const JWT_SECRET_FALLBACK = 'your-super-secret-jwt-key-change-in-production'
 
 /** Set a signed CSRF cookie alongside the auth cookie on login/register. */
-async function setCsrfCookie(c: any): Promise<void> {
+async function setCsrfCookie(c: any, maxAge?: number): Promise<void> {
   const secret = c.env?.JWT_SECRET || JWT_SECRET_FALLBACK
   const isDev = c.env?.ENVIRONMENT === 'development' || !c.env?.ENVIRONMENT
   const csrfToken = await generateCsrfToken(secret)
+  const cookieMaxAge = maxAge ?? (await getJwtExpirySecondsFromDb(c.env?.DB, c.env))
   setCookie(c, 'csrf_token', csrfToken, {
     httpOnly: false,
     secure: !isDev,
     sameSite: 'Strict',
     path: '/',
-    maxAge: 86400,
+    maxAge: cookieMaxAge,
   })
 }
 
@@ -195,14 +197,15 @@ authRoutes.post('/register',
       }
 
       // Generate JWT token
-      const token = await AuthManager.generateToken(userId, normalizedEmail, 'viewer', c.env.JWT_SECRET)
+      const tokenTtl = await getJwtExpirySecondsFromDb(c.env.DB, c.env)
+      const token = await AuthManager.generateToken(userId, normalizedEmail, 'viewer', c.env.JWT_SECRET, tokenTtl)
 
       // Set HTTP-only cookie
       setCookie(c, 'auth_token', token, {
         httpOnly: true,
         secure: true,
         sameSite: 'Strict',
-        maxAge: 60 * 60 * 24 // 24 hours
+        maxAge: tokenTtl
       })
 
       // Set CSRF cookie for browser sessions
@@ -288,14 +291,15 @@ authRoutes.post('/login',
       }
 
       // Generate JWT token
-      const token = await AuthManager.generateToken(user.id, user.email, user.role, c.env.JWT_SECRET)
+      const tokenTtl = await getJwtExpirySecondsFromDb(c.env.DB, c.env)
+      const token = await AuthManager.generateToken(user.id, user.email, user.role, c.env.JWT_SECRET, tokenTtl)
 
       // Set HTTP-only cookie
       setCookie(c, 'auth_token', token, {
         httpOnly: true,
         secure: true,
         sameSite: 'Strict',
-        maxAge: 60 * 60 * 24 // 24 hours
+        maxAge: tokenTtl
       })
 
       // Set CSRF cookie for browser sessions
@@ -380,30 +384,64 @@ authRoutes.get('/me', requireAuth(), async (c) => {
   }
 })
 
-// Refresh token
-authRoutes.post('/refresh', requireAuth(), async (c) => {
+// Refresh token (sliding session)
+//
+// Accepts a valid JWT — or one that has expired within the grace window
+// (`JWT_REFRESH_GRACE_SECONDS`, default 7 days) — and issues a fresh JWT
+// with a new `exp`. This lets a long-lived session cookie keep a user
+// logged in across JWT expirations without forcing a full re-login.
+//
+// Security: the caller must still present a valid-signature token that
+// recently belonged to an active user. Fully forged or long-expired tokens
+// are rejected.
+authRoutes.post('/refresh',
+  rateLimit({ max: 60, windowMs: 60 * 1000, keyPrefix: 'refresh' }),
+  async (c) => {
   try {
-    const user = c.get('user')
-    
-    if (!user) {
+    // Accept token from Authorization header or cookie
+    let token = c.req.header('Authorization')?.replace('Bearer ', '')
+    if (!token) token = getCookie(c, 'auth_token')
+
+    if (!token) {
       return c.json({ error: 'Not authenticated' }, 401)
     }
-    
-    // Generate new token
-    const token = await AuthManager.generateToken(user.userId, user.email, user.role, c.env.JWT_SECRET)
-    
+
+    const db = c.env.DB
+    const grace = await getJwtRefreshGraceSecondsFromDb(db, c.env)
+
+    const payload = await AuthManager.verifyToken(token, c.env.JWT_SECRET, grace)
+    if (!payload) {
+      return c.json({ error: 'Invalid or expired token' }, 401)
+    }
+
+    // Re-validate the user is still active, and pick up any role changes.
+    const row = await db.prepare('SELECT id, email, role, is_active FROM users WHERE id = ?')
+      .bind(payload.userId)
+      .first() as any
+
+    if (!row || !row.is_active) {
+      return c.json({ error: 'User is not active' }, 401)
+    }
+
+    // Generate new token with a fresh exp
+    const tokenTtl = await getJwtExpirySecondsFromDb(db, c.env)
+    const newToken = await AuthManager.generateToken(row.id, row.email, row.role, c.env.JWT_SECRET, tokenTtl)
+
     // Set new cookie
-    setCookie(c, 'auth_token', token, {
+    setCookie(c, 'auth_token', newToken, {
       httpOnly: true,
       secure: true,
       sameSite: 'Strict',
-      maxAge: 60 * 60 * 24 // 24 hours
+      maxAge: tokenTtl
     })
 
     // Set CSRF cookie for browser sessions
     await setCsrfCookie(c)
 
-    return c.json({ token })
+    return c.json({
+      token: newToken,
+      expiresIn: tokenTtl
+    })
   } catch (error) {
     console.error('Token refresh error:', error)
     return c.json({ error: 'Token refresh failed' }, 500)
@@ -525,14 +563,15 @@ authRoutes.post('/register/form',
     }
 
     // Generate JWT token
-    const token = await AuthManager.generateToken(userId, normalizedEmail, role, c.env.JWT_SECRET)
+    const tokenTtl = await getJwtExpirySecondsFromDb(c.env.DB, c.env)
+    const token = await AuthManager.generateToken(userId, normalizedEmail, role, c.env.JWT_SECRET, tokenTtl)
 
     // Set HTTP-only cookie
     setCookie(c, 'auth_token', token, {
       httpOnly: true,
       secure: false, // Set to true in production with HTTPS
       sameSite: 'Strict',
-      maxAge: 60 * 60 * 24 // 24 hours
+      maxAge: tokenTtl
     })
 
     // Set CSRF cookie for browser sessions
@@ -622,14 +661,15 @@ authRoutes.post('/login/form',
     }
 
     // Generate JWT token
-    const token = await AuthManager.generateToken(user.id, user.email, user.role, c.env.JWT_SECRET)
+    const tokenTtl = await getJwtExpirySecondsFromDb(c.env.DB, c.env)
+    const token = await AuthManager.generateToken(user.id, user.email, user.role, c.env.JWT_SECRET, tokenTtl)
 
     // Set HTTP-only cookie
     setCookie(c, 'auth_token', token, {
       httpOnly: true,
       secure: false, // Set to true in production with HTTPS
       sameSite: 'Strict',
-      maxAge: 60 * 60 * 24 // 24 hours
+      maxAge: tokenTtl
     })
 
     // Set CSRF cookie for browser sessions
@@ -995,14 +1035,15 @@ authRoutes.post('/accept-invitation', async (c) => {
     ).run()
 
     // Generate JWT token for auto-login
-    const authToken = await AuthManager.generateToken(invitedUser.id, invitedUser.email, invitedUser.role, c.env.JWT_SECRET)
-    
+    const tokenTtl = await getJwtExpirySecondsFromDb(c.env.DB, c.env)
+    const authToken = await AuthManager.generateToken(invitedUser.id, invitedUser.email, invitedUser.role, c.env.JWT_SECRET, tokenTtl)
+
     // Set HTTP-only cookie
     setCookie(c, 'auth_token', authToken, {
       httpOnly: true,
       secure: true,
       sameSite: 'Strict',
-      maxAge: 60 * 60 * 24 // 24 hours
+      maxAge: tokenTtl
     })
 
     // Set CSRF cookie for browser sessions

--- a/packages/core/src/routes/auth.ts
+++ b/packages/core/src/routes/auth.ts
@@ -403,7 +403,7 @@ authRoutes.post('/refresh',
     if (!token) token = getCookie(c, 'auth_token')
 
     if (!token) {
-      return c.json({ error: 'Not authenticated' }, 401)
+      return c.json({ error: 'Authentication required' }, 401)
     }
 
     const db = c.env.DB

--- a/packages/core/src/services/settings.ts
+++ b/packages/core/src/services/settings.ts
@@ -16,6 +16,11 @@ export interface GeneralSettings {
   maintenanceMode: boolean
 }
 
+export interface SecuritySettings {
+  jwtExpiresIn: string
+  jwtRefreshGraceSeconds: number
+}
+
 export class SettingsService {
   constructor(private db: D1Database) {}
 
@@ -149,5 +154,33 @@ export class SettingsService {
     if (settings.maintenanceMode !== undefined) settingsToSave.maintenanceMode = settings.maintenanceMode
 
     return await this.setMultipleSettings('general', settingsToSave)
+  }
+
+  /**
+   * Get security settings with defaults
+   */
+  async getSecuritySettings(): Promise<SecuritySettings> {
+    const settings = await this.getCategorySettings('security')
+
+    return {
+      jwtExpiresIn: settings.jwtExpiresIn || '30d',
+      jwtRefreshGraceSeconds:
+        typeof settings.jwtRefreshGraceSeconds === 'number'
+          ? settings.jwtRefreshGraceSeconds
+          : 60 * 60 * 24 * 7
+    }
+  }
+
+  /**
+   * Save security settings
+   */
+  async saveSecuritySettings(settings: Partial<SecuritySettings>): Promise<boolean> {
+    const settingsToSave: Record<string, any> = {}
+
+    if (settings.jwtExpiresIn !== undefined) settingsToSave.jwtExpiresIn = settings.jwtExpiresIn
+    if (settings.jwtRefreshGraceSeconds !== undefined)
+      settingsToSave.jwtRefreshGraceSeconds = settings.jwtRefreshGraceSeconds
+
+    return await this.setMultipleSettings('security', settingsToSave)
   }
 }

--- a/packages/core/src/templates/pages/admin-settings.template.ts
+++ b/packages/core/src/templates/pages/admin-settings.template.ts
@@ -47,6 +47,8 @@ export interface SecuritySettings {
     requireSymbols: boolean
   }
   ipWhitelist: string[]
+  jwtExpiresIn?: string
+  jwtRefreshGraceSeconds?: number
 }
 
 export interface NotificationSettings {
@@ -172,6 +174,43 @@ export function renderSettingsPage(data: SettingsPageData): string {
           saveBtn.disabled = false;
         }
       }
+
+      async function saveSecuritySettings() {
+        const formData = new FormData();
+        const expiry = document.getElementById('jwtExpiresIn');
+        const grace = document.getElementById('jwtRefreshGraceSeconds');
+        if (expiry) formData.append('jwtExpiresIn', expiry.value);
+        if (grace) formData.append('jwtRefreshGraceSeconds', grace.value);
+
+        const saveBtn = document.querySelector('button[onclick="saveSecuritySettings()"]');
+        const originalText = saveBtn ? saveBtn.innerHTML : '';
+        if (saveBtn) {
+          saveBtn.innerHTML = '<svg class="animate-spin -ml-0.5 mr-1.5 h-5 w-5 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>Saving...';
+          saveBtn.disabled = true;
+        }
+
+        try {
+          const response = await fetch('/admin/settings/security', {
+            method: 'POST',
+            body: formData
+          });
+          const result = await response.json();
+          if (result.success) {
+            showNotification(result.message || 'Security settings saved successfully!', 'success');
+          } else {
+            showNotification(result.error || 'Failed to save security settings', 'error');
+          }
+        } catch (error) {
+          console.error('Error saving security settings:', error);
+          showNotification('Failed to save security settings. Please try again.', 'error');
+        } finally {
+          if (saveBtn) {
+            saveBtn.innerHTML = originalText;
+            saveBtn.disabled = false;
+          }
+        }
+      }
+      window.saveSecuritySettings = saveSecuritySettings;
 
       // Migration functions
       window.refreshMigrationStatus = async function() {
@@ -765,9 +804,75 @@ function renderAppearanceSettings(settings?: AppearanceSettings): string {
 }
 
 function renderSecuritySettings(settings?: SecuritySettings): string {
+  const jwtExpiresIn = settings?.jwtExpiresIn ?? '30d'
+  const jwtRefreshGraceSeconds =
+    typeof settings?.jwtRefreshGraceSeconds === 'number'
+      ? settings.jwtRefreshGraceSeconds
+      : 60 * 60 * 24 * 7
+
   return `
     <div class="space-y-6">
-      <!-- WIP Notice -->
+      <!-- Session / JWT card (live) -->
+      <div class="rounded-lg bg-white dark:bg-white/5 p-6 ring-1 ring-inset ring-zinc-950/5 dark:ring-white/10">
+        <h3 class="text-lg/7 font-semibold text-zinc-950 dark:text-white">Session / JWT</h3>
+        <p class="mt-1 text-sm/6 text-zinc-500 dark:text-zinc-400">
+          Configure how long a signed-in session lasts and how long an expired token can still be refreshed.
+          The <code class="text-xs">JWT_EXPIRES_IN</code> and <code class="text-xs">JWT_REFRESH_GRACE_SECONDS</code>
+          environment variables, when set, override the values below.
+        </p>
+
+        <div class="mt-6 grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <label for="jwtExpiresIn" class="block text-sm/6 font-medium text-zinc-950 dark:text-white mb-2">
+              JWT Expiration
+            </label>
+            <input
+              type="text"
+              id="jwtExpiresIn"
+              name="jwtExpiresIn"
+              value="${jwtExpiresIn}"
+              placeholder="30d"
+              class="w-full rounded-lg bg-white dark:bg-white/5 px-3 py-2 text-sm/6 text-zinc-950 dark:text-white ring-1 ring-inset ring-zinc-950/10 dark:ring-white/10 placeholder:text-zinc-500 dark:placeholder:text-zinc-400 focus:ring-2 focus:ring-inset focus:ring-indigo-500 dark:focus:ring-indigo-400"
+            />
+            <p class="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+              Accepts <code>30d</code>, <code>12h</code>, <code>3600s</code>, or bare seconds. Default: 30 days.
+            </p>
+          </div>
+
+          <div>
+            <label for="jwtRefreshGraceSeconds" class="block text-sm/6 font-medium text-zinc-950 dark:text-white mb-2">
+              Refresh Grace Window (seconds)
+            </label>
+            <input
+              type="number"
+              id="jwtRefreshGraceSeconds"
+              name="jwtRefreshGraceSeconds"
+              value="${jwtRefreshGraceSeconds}"
+              min="0"
+              max="7776000"
+              class="w-full rounded-lg bg-white dark:bg-white/5 px-3 py-2 text-sm/6 text-zinc-950 dark:text-white ring-1 ring-inset ring-zinc-950/10 dark:ring-white/10 placeholder:text-zinc-500 dark:placeholder:text-zinc-400 focus:ring-2 focus:ring-inset focus:ring-indigo-500 dark:focus:ring-indigo-400"
+            />
+            <p class="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+              How long an expired token can still be exchanged at <code>/auth/refresh</code>. Default: 604800 (7 days).
+            </p>
+          </div>
+        </div>
+
+        <div class="mt-6 pt-4 border-t border-zinc-950/5 dark:border-white/10 flex justify-end">
+          <button
+            type="button"
+            onclick="saveSecuritySettings()"
+            class="inline-flex items-center justify-center rounded-lg bg-zinc-950 dark:bg-white px-3.5 py-2.5 text-sm font-semibold text-white dark:text-zinc-950 hover:bg-zinc-800 dark:hover:bg-zinc-100 transition-colors shadow-sm"
+          >
+            <svg class="-ml-0.5 mr-1.5 h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+            </svg>
+            Save Session Settings
+          </button>
+        </div>
+      </div>
+
+      <!-- WIP Notice for remaining fields -->
       <div class="rounded-lg bg-blue-50 dark:bg-blue-950/20 p-6 ring-1 ring-inset ring-blue-600/20 dark:ring-blue-500/30">
         <div class="flex items-start space-x-3">
           <svg class="w-6 h-6 text-blue-600 dark:text-blue-400 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -776,7 +881,7 @@ function renderSecuritySettings(settings?: SecuritySettings): string {
           <div class="flex-1">
             <h4 class="text-base/7 font-semibold text-blue-900 dark:text-blue-300">Work in Progress</h4>
             <p class="mt-1 text-sm/6 text-blue-700 dark:text-blue-200">
-              This settings section is currently under development and provided for reference and design feedback only. Changes made here will not be saved.
+              The fields below are under development and provided for reference and design feedback only. Changes made here will not be saved.
             </p>
           </div>
         </div>

--- a/tests/e2e/02b-authentication-api.spec.ts
+++ b/tests/e2e/02b-authentication-api.spec.ts
@@ -341,7 +341,8 @@ test.describe('Authentication API', () => {
       expect(cookies).toContain('auth_token');
       expect(cookies).toContain('HttpOnly');
       expect(cookies).toContain('SameSite=Strict');
-      expect(cookies).toContain('Max-Age=86400'); // 24 hours
+      // JWT TTL is configurable; assert a positive Max-Age rather than a hardcoded value.
+      expect(cookies).toMatch(/Max-Age=\d+/);
     });
 
     test('should update last login timestamp', async ({ request }) => {

--- a/www/src/app/authentication/page.mdx
+++ b/www/src/app/authentication/page.mdx
@@ -17,7 +17,8 @@ Secure your SonicJS application with JWT authentication and role-based access co
 
 SonicJS uses JWT (JSON Web Tokens) for authentication with:
 
-- **24-hour token expiration**
+- **Configurable token expiration** (default: 30 days, via env var or admin settings)
+- **Refresh endpoint with grace window** for seamless long-lived sessions
 - **HTTP-only cookie storage** for web clients
 - **Bearer token support** for API clients
 - **KV-based token caching** (5-minute TTL)
@@ -122,6 +123,52 @@ const response = await fetch('http://localhost:8787/admin/content', {
 </CodeGroup>
 
 For browser-based applications, the token is automatically stored as an HTTP-only cookie named `auth_token`.
+
+### Refreshing Tokens
+
+<ApiEndpoint method="POST" path="/auth/refresh" description="Exchange a valid or recently-expired token for a fresh one" auth={false} />
+
+`/auth/refresh` accepts a token from either the `Authorization: Bearer <token>` header or the `auth_token` cookie. A valid token is always accepted; an expired token is accepted if it expired within the configured refresh grace window. The signature is re-verified in both cases, and the user is re-validated against the database (active + existing) before a new token is issued.
+
+<CodeGroup title="Refresh Request">
+
+```bash {{title:'cURL'}}
+curl -X POST http://localhost:8787/auth/refresh \
+  -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+```
+
+```javascript
+const response = await fetch('http://localhost:8787/auth/refresh', {
+  method: 'POST',
+  credentials: 'include' // sends the auth_token cookie
+});
+
+const { token, expiresIn } = await response.json();
+```
+
+</CodeGroup>
+
+**Response (200 OK):**
+
+```json
+{
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "expiresIn": 2592000
+}
+```
+
+The new token is also set as an `auth_token` cookie. If the token is beyond the grace window, deactivated, or invalid, the endpoint returns `401 Unauthorized`.
+
+### Session Configuration
+
+JWT expiration and the refresh grace window are resolved in the order **environment variable → admin setting → default**. Environment variables act as a ceiling and are recommended for production:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `JWT_EXPIRES_IN` | Token lifetime. Accepts `30d`, `12h`, `3600s`, or bare seconds. | `30d` (2,592,000 seconds) |
+| `JWT_REFRESH_GRACE_SECONDS` | How long after expiration a token can still be refreshed. | `604800` (7 days) |
+
+Admins can also configure both values under **Admin → Settings → Security** in the **Session / JWT** card. Values set in the admin UI are used only when the corresponding environment variable is not set.
 
 ---
 
@@ -669,7 +716,7 @@ SonicJS implements a **signed double-submit cookie pattern** for CSRF protection
 - Tokens are HMAC-SHA256 signed using the `JWT_SECRET`
 - Validation checks the `X-CSRF-Token` header against the `csrf_token` cookie
 - Falls back to reading `_csrf` from form body for traditional form submissions
-- Cookie settings: `sameSite: 'Strict'`, `secure: true` in production, 24-hour expiry
+- Cookie settings: `sameSite: 'Strict'`, `secure: true` in production; expiry matches the configured JWT lifetime (see [Session Configuration](#jwt-authentication))
 
 **Exempt paths:** Login, registration, public form submissions, and API-key-only requests are exempt from CSRF validation.
 


### PR DESCRIPTION
## Summary
- Replace hardcoded 24h JWT expiration with configurable TTL (default 30d) via `JWT_EXPIRES_IN` env var or **Admin → Settings → Security** UI. Env var acts as a ceiling.
- Rewrite `/auth/refresh` to accept valid or recently-expired tokens within a configurable grace window (default 7d). Re-verifies HS256 via Web Crypto (hono/jwt checks `exp` before signature) and re-validates the user in the DB before issuing a new token.
- Wire every token-minting site (auth routes, OTP, magic-link, OAuth) through the DB-aware helper. Document the new surface in repo docs and on the doc site.

Fixes #800.

## Changes
- `packages/core/src/middleware/auth.ts` — `parseDuration`, `getJwtExpirySeconds`, `getJwtExpirySecondsFromDb`, `getJwtRefreshGraceSecondsFromDb`, manual HS256 verify helper, grace-window support in `verifyToken`, configurable TTL in `generateToken`/`setAuthCookie`.
- `packages/core/src/routes/auth.ts` — removed hardcoded 24h TTLs, rewrote `POST /auth/refresh` with rate limit + grace window + DB re-validation, made `setCsrfCookie` DB-aware.
- `packages/core/src/app.ts` — added `JWT_EXPIRES_IN` and `JWT_REFRESH_GRACE_SECONDS` bindings.
- `packages/core/src/middleware/index.ts` — exported new helpers.
- `packages/core/src/plugins/core-plugins/otp-login-plugin/index.ts`, `plugins/available/magic-link-auth/index.ts`, `plugins/core-plugins/oauth-providers/index.ts` — switched to DB-aware TTL helper.
- `packages/core/src/services/settings.ts` — `SecuritySettings` interface, `getSecuritySettings`/`saveSecuritySettings`.
- `packages/core/src/routes/admin-settings.ts` — load persisted security settings, added validated `POST /admin/settings/security`.
- `packages/core/src/templates/pages/admin-settings.template.ts` — live Session / JWT card with TTL + grace inputs, new `saveSecuritySettings()` client handler.
- `packages/core/src/__tests__/middleware/auth.test.ts` — 8 new tests covering custom TTL, default TTL, grace accept/reject, bad-sig rejection within grace, and `getJwtExpirySeconds` duration parsing.
- `docs/authentication.md`, `packages/core/src/plugins/core-plugins/otp-login-plugin/README.md`, `www/src/app/authentication/page.mdx` — documentation updates.

## Testing
- [x] `npm run type-check` clean
- [x] Auth middleware tests: 48/48 passing
- [ ] E2E tests (pending CI)

## Checklist
- [x] Code follows project conventions
- [x] No new TypeScript errors introduced
- [x] Tests added for new functionality (TTL config, grace window, bad-sig rejection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)