### PR TITLE
test(e2e): seed registration enabled in 37-disable-registration

### DIFF
--- a/tests/e2e/37-disable-registration.spec.ts
+++ b/tests/e2e/37-disable-registration.spec.ts
@@ -58,6 +58,31 @@ test.describe('Disable User Registration', () => {
   });
 
   test.describe('Registration when enabled (default)', () => {
+    // Ensure registration is enabled before these tests run. Without this, a
+    // prior test run that died before its `finally` could leave the shared
+    // preview DB with registration disabled, causing these defaults-assuming
+    // tests to fail permanently.
+    test.beforeAll(async ({ browser }) => {
+      const context = await browser.newContext();
+      const page = await context.newPage();
+      try {
+        await loginAsAdmin(page);
+        await page.request.post('/admin/plugins/core-auth/settings', {
+          data: {
+            registration: {
+              enabled: true,
+              requireEmailVerification: false,
+              defaultRole: 'viewer'
+            }
+          },
+          timeout: 10000
+        });
+        await logout(page);
+      } finally {
+        await context.close();
+      }
+    });
+
     test('should allow API registration when registration is enabled', async ({ request }) => {
       const uniqueUser = {
         ...testUser,


### PR DESCRIPTION
## Summary

- Adds a `beforeAll` to the "Registration when enabled (default)" describe block that explicitly POSTs `registration.enabled: true` to `/admin/plugins/core-auth/settings` before the default-assuming tests run.
- Fixes persistent flakiness where the shared preview DB stayed in a `disabled` state if a prior test run died mid-suite before its `finally` cleanup re-enabled registration.

## Why

Observed on the post-release doc commit (`721108b`) — `PR Tests` failed because `curl -I /auth/register` returned 302 to `/auth/login?error=Registration%20is%20currently%20disabled`. The "when enabled" tests had no setup and relied on default state that was no longer true on the shared preview.

## Test plan

- [ ] PR Tests workflow passes on this branch
- [ ] `37-disable-registration.spec.ts` `Registration when enabled (default)` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)