### PR TITLE
chore(codeowners): allow lead-only review for /tests/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,5 +26,8 @@
 # Website and marketing site
 /www/                               @lane711
 
+# E2E and integration tests — project lead sign-off sufficient
+/tests/                             @lane711
+
 # Example app
 /my-sonicjs-app/                    @lane711 @mmcintosh


### PR DESCRIPTION
## Summary

- Adds a `/tests/` rule to CODEOWNERS owned by `@lane711` only.
- Test-only PRs (like #802) no longer block on co-maintainer review.

## Why

Test fixes typically need to land fast to unblock CI and are low-risk. Core (`/packages/core/`) and example app still require both maintainers — this scope change only applies to the E2E/integration test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)