### PR TITLE
feat: allow blank first/last name when editing users

### DIFF
--- a/packages/core/src/routes/admin-users.ts
+++ b/packages/core/src/routes/admin-users.ts
@@ -964,10 +964,10 @@ userRoutes.put('/users/:id', async (c) => {
     }
 
     // Validate required fields
-    if (!firstName || !lastName || !username || !email) {
+    if (!username || !email) {
       return c.html(renderAlert({
         type: 'error',
-        message: 'First name, last name, username, and email are required.',
+        message: 'Username and email are required.',
         dismissible: true
       }))
     }

--- a/packages/core/src/templates/pages/admin-user-edit.template.ts
+++ b/packages/core/src/templates/pages/admin-user-edit.template.ts
@@ -102,7 +102,6 @@ export function renderUserEditPage(data: UserEditPageData): string {
                       type="text"
                       name="first_name"
                       value="${escapeHtml(data.userToEdit.firstName || '')}"
-                      required
                       class="w-full rounded-lg bg-white dark:bg-zinc-800 px-3 py-2 text-sm text-zinc-950 dark:text-white shadow-sm ring-1 ring-inset ring-zinc-950/10 dark:ring-white/10 placeholder:text-zinc-400 dark:placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-950 dark:focus:ring-white transition-shadow"
                     />
                   </div>
@@ -113,7 +112,6 @@ export function renderUserEditPage(data: UserEditPageData): string {
                       type="text"
                       name="last_name"
                       value="${escapeHtml(data.userToEdit.lastName || '')}"
-                      required
                       class="w-full rounded-lg bg-white dark:bg-zinc-800 px-3 py-2 text-sm text-zinc-950 dark:text-white shadow-sm ring-1 ring-inset ring-zinc-950/10 dark:ring-white/10 placeholder:text-zinc-400 dark:placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-950 dark:focus:ring-white transition-shadow"
                     />
                   </div>


### PR DESCRIPTION
## Summary
- Removes the `required` attribute from First Name and Last Name inputs on the admin user edit form.
- Drops the server-side validation in `PUT /admin/users/:id` that rejected blank first/last names.
- Username and email remain required; the user profile self-edit route is unchanged.

## Changes
- `packages/core/src/templates/pages/admin-user-edit.template.ts` — drop `required` from `first_name` and `last_name` inputs.
- `packages/core/src/routes/admin-users.ts` — only require `username` and `email` in the admin user update handler.

## Testing
- [ ] Edit a user, blank out First Name and/or Last Name, save — expect success and persisted blank values.
- [ ] Edit a user, blank out Username or Email — expect validation error.

## Checklist
- [x] Code follows project conventions
- [x] No new TypeScript errors introduced
- [ ] Tests added for new functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)