### PR TITLE
fix(filter): support bracket-syntax filter[field][op]=value on content API

### DIFF
--- a/docs/api-filtering.md
+++ b/docs/api-filtering.md
@@ -14,15 +14,33 @@ SonicJS AI provides a powerful and flexible filtering system for querying conten
 
 ## Basic Usage
 
-Filters are passed as query parameters to the API endpoints. The main filter parameter is `where`, which accepts a JSON-encoded filter object.
+Filters can be passed to the API in two equivalent forms:
 
-### Simple Example
+1. **Bracket syntax** — `filter[field][operator]=value` (concise, recommended for simple queries)
+2. **`where` parameter** — a JSON-encoded filter object (required for OR groups and complex logic)
+
+Both forms can be combined in the same request; their conditions are combined with AND.
+
+### Bracket Syntax
+
+```bash
+GET /api/content?filter[status][equals]=published
+GET /api/content?filter[title][contains]=lyme&filter[status][equals]=published
+```
+
+When the operator is omitted, it defaults to `equals`:
+
+```bash
+GET /api/content?filter[slug]=about
+```
+
+### `where` Parameter (JSON)
 
 ```bash
 GET /api/content?where={"and":[{"field":"status","operator":"equals","value":"published"}]}
 ```
 
-### With URL Encoding
+URL-encoded:
 
 ```bash
 GET /api/content?where=%7B%22and%22%3A%5B%7B%22field%22%3A%22status%22%2C%22operator%22%3A%22equals%22%2C%22value%22%3A%22published%22%7D%5D%7D
@@ -203,6 +221,42 @@ Must contain the value entered, case-insensitive. Simpler than `like` - just che
         "field": "description",
         "operator": "contains",
         "value": "javascript"
+      }
+    ]
+  }
+}
+```
+
+### starts_with
+
+The field value must begin with the provided value. Case-insensitive.
+
+```json
+{
+  "where": {
+    "and": [
+      {
+        "field": "title",
+        "operator": "starts_with",
+        "value": "How to"
+      }
+    ]
+  }
+}
+```
+
+### ends_with
+
+The field value must end with the provided value. Case-insensitive.
+
+```json
+{
+  "where": {
+    "and": [
+      {
+        "field": "slug",
+        "operator": "ends_with",
+        "value": "-guide"
       }
     ]
   }

--- a/packages/core/src/__tests__/utils/query-filter.test.ts
+++ b/packages/core/src/__tests__/utils/query-filter.test.ts
@@ -97,6 +97,38 @@ describe('QueryFilterBuilder', () => {
     expect(result.params).toEqual(['%example%'])
   })
 
+  it('should support starts_with operator', () => {
+    const builder = new QueryFilterBuilder()
+    const filter: QueryFilter = {
+      where: {
+        and: [
+          { field: 'title', operator: 'starts_with', value: 'Intro' }
+        ]
+      }
+    }
+
+    const result = builder.build('posts', filter)
+
+    expect(result.sql).toBe('SELECT * FROM posts WHERE (title LIKE ?)')
+    expect(result.params).toEqual(['Intro%'])
+  })
+
+  it('should support ends_with operator', () => {
+    const builder = new QueryFilterBuilder()
+    const filter: QueryFilter = {
+      where: {
+        and: [
+          { field: 'slug', operator: 'ends_with', value: '-guide' }
+        ]
+      }
+    }
+
+    const result = builder.build('posts', filter)
+
+    expect(result.sql).toBe('SELECT * FROM posts WHERE (slug LIKE ?)')
+    expect(result.params).toEqual(['%-guide'])
+  })
+
   it('should support IN operator with array', () => {
     const builder = new QueryFilterBuilder()
     const filter: QueryFilter = {
@@ -853,6 +885,141 @@ describe('QueryFilterBuilder.parseFromQuery - Edge Cases', () => {
     const filter = QueryFilterBuilder.parseFromQuery(query)
 
     expect(filter.where).toEqual({ and: [] })
+  })
+})
+
+describe('QueryFilterBuilder.parseFromQuery - Bracket Syntax', () => {
+  it('should parse filter[field][contains]=value', () => {
+    const filter = QueryFilterBuilder.parseFromQuery({
+      'filter[title][contains]': 'lyme'
+    })
+
+    expect(filter.where?.and).toContainEqual({
+      field: 'title',
+      operator: 'contains',
+      value: 'lyme'
+    })
+  })
+
+  it('should parse filter[field][equals]=value', () => {
+    const filter = QueryFilterBuilder.parseFromQuery({
+      'filter[status][equals]': 'published'
+    })
+
+    expect(filter.where?.and).toContainEqual({
+      field: 'status',
+      operator: 'equals',
+      value: 'published'
+    })
+  })
+
+  it('should default to equals when no operator is specified', () => {
+    const filter = QueryFilterBuilder.parseFromQuery({
+      'filter[slug]': 'about'
+    })
+
+    expect(filter.where?.and).toContainEqual({
+      field: 'slug',
+      operator: 'equals',
+      value: 'about'
+    })
+  })
+
+  it('should parse multiple bracket filters into AND conditions', () => {
+    const filter = QueryFilterBuilder.parseFromQuery({
+      'filter[status][equals]': 'published',
+      'filter[category][equals]': 'blog',
+      'filter[price][less_than]': '100'
+    })
+
+    expect(filter.where?.and).toHaveLength(3)
+    expect(filter.where?.and).toContainEqual({ field: 'status', operator: 'equals', value: 'published' })
+    expect(filter.where?.and).toContainEqual({ field: 'category', operator: 'equals', value: 'blog' })
+    expect(filter.where?.and).toContainEqual({ field: 'price', operator: 'less_than', value: '100' })
+  })
+
+  it('should parse starts_with via bracket syntax', () => {
+    const filter = QueryFilterBuilder.parseFromQuery({
+      'filter[title][starts_with]': 'How to'
+    })
+
+    expect(filter.where?.and).toContainEqual({
+      field: 'title',
+      operator: 'starts_with',
+      value: 'How to'
+    })
+  })
+
+  it('should parse ends_with via bracket syntax', () => {
+    const filter = QueryFilterBuilder.parseFromQuery({
+      'filter[slug][ends_with]': '-guide'
+    })
+
+    expect(filter.where?.and).toContainEqual({
+      field: 'slug',
+      operator: 'ends_with',
+      value: '-guide'
+    })
+  })
+
+  it('should coerce exists operator value to boolean', () => {
+    const trueFilter = QueryFilterBuilder.parseFromQuery({
+      'filter[avatar][exists]': 'true'
+    })
+    expect(trueFilter.where?.and).toContainEqual({
+      field: 'avatar',
+      operator: 'exists',
+      value: true
+    })
+
+    const falseFilter = QueryFilterBuilder.parseFromQuery({
+      'filter[avatar][exists]': 'false'
+    })
+    expect(falseFilter.where?.and).toContainEqual({
+      field: 'avatar',
+      operator: 'exists',
+      value: false
+    })
+  })
+
+  it('should ignore unknown operators silently', () => {
+    const filter = QueryFilterBuilder.parseFromQuery({
+      'filter[title][bogus_op]': 'value'
+    })
+
+    expect(filter.where?.and).toEqual([])
+  })
+
+  it('should ignore keys that do not match the filter[...] pattern', () => {
+    const filter = QueryFilterBuilder.parseFromQuery({
+      'something[else]': 'foo',
+      'filter': 'bar',
+      'filter[]': 'empty',
+      'filter[title][contains][extra]': 'too-deep'
+    })
+
+    expect(filter.where?.and).toEqual([])
+  })
+
+  it('should produce SQL when combined with the builder', () => {
+    const filter = QueryFilterBuilder.parseFromQuery({
+      'filter[title][contains]': 'lyme'
+    })
+
+    const result = new QueryFilterBuilder().build('content', filter)
+
+    expect(result.sql).toBe('SELECT * FROM content WHERE (title LIKE ?)')
+    expect(result.params).toEqual(['%lyme%'])
+  })
+
+  it('should combine bracket filters with simple field filters and where param', () => {
+    const filter = QueryFilterBuilder.parseFromQuery({
+      status: 'published',
+      'filter[title][contains]': 'lyme'
+    })
+
+    expect(filter.where?.and).toContainEqual({ field: 'status', operator: 'equals', value: 'published' })
+    expect(filter.where?.and).toContainEqual({ field: 'title', operator: 'contains', value: 'lyme' })
   })
 })
 

--- a/packages/core/src/utils/query-filter.ts
+++ b/packages/core/src/utils/query-filter.ts
@@ -13,6 +13,8 @@ export type FilterOperator =
   | 'less_than_equal'
   | 'like'
   | 'contains'
+  | 'starts_with'
+  | 'ends_with'
   | 'in'
   | 'not_in'
   | 'all'
@@ -20,6 +22,26 @@ export type FilterOperator =
   | 'near'
   | 'within'
   | 'intersects'
+
+const VALID_FILTER_OPERATORS: ReadonlySet<FilterOperator> = new Set<FilterOperator>([
+  'equals',
+  'not_equals',
+  'greater_than',
+  'greater_than_equal',
+  'less_than',
+  'less_than_equal',
+  'like',
+  'contains',
+  'starts_with',
+  'ends_with',
+  'in',
+  'not_in',
+  'all',
+  'exists',
+  'near',
+  'within',
+  'intersects'
+])
 
 export interface FilterCondition {
   field: string
@@ -176,6 +198,12 @@ export class QueryFilterBuilder {
       case 'contains':
         return this.buildContains(field, condition.value)
 
+      case 'starts_with':
+        return this.buildStartsWith(field, condition.value)
+
+      case 'ends_with':
+        return this.buildEndsWith(field, condition.value)
+
       case 'in':
         return this.buildIn(field, condition.value)
 
@@ -259,6 +287,22 @@ export class QueryFilterBuilder {
    */
   private buildContains(field: string, value: string): string {
     this.params.push(`%${value}%`)
+    return `${field} LIKE ?`
+  }
+
+  /**
+   * Build STARTS_WITH condition (case-insensitive prefix match)
+   */
+  private buildStartsWith(field: string, value: string): string {
+    this.params.push(`${value}%`)
+    return `${field} LIKE ?`
+  }
+
+  /**
+   * Build ENDS_WITH condition (case-insensitive suffix match)
+   */
+  private buildEndsWith(field: string, value: string): string {
+    this.params.push(`%${value}`)
     return `${field} LIKE ?`
   }
 
@@ -424,6 +468,26 @@ export class QueryFilterBuilder {
           value: query[queryParam]
         })
       }
+    }
+
+    // Parse bracket-syntax filters: filter[field][operator]=value or filter[field]=value
+    const bracketFilterRegex = /^filter\[([^\]]+)\](?:\[([^\]]+)\])?$/
+    for (const [key, rawValue] of Object.entries(query)) {
+      const match = key.match(bracketFilterRegex)
+      if (!match) continue
+
+      const field = match[1]
+      const operator = (match[2] || 'equals') as FilterOperator
+
+      if (!field || !VALID_FILTER_OPERATORS.has(operator)) continue
+      if (rawValue === undefined || rawValue === null) continue
+
+      let value: any = rawValue
+      if (operator === 'exists') {
+        value = value === 'true' || value === true || value === '1' || value === 1
+      }
+
+      filter.where.and.push({ field, operator, value })
     }
 
     // Parse limit

--- a/tests/e2e/20-content-api-collection-filter.spec.ts
+++ b/tests/e2e/20-content-api-collection-filter.spec.ts
@@ -109,6 +109,55 @@ test.describe('Content API Collection Filtering', () => {
     console.log('✓ Non-existent collection returns empty array');
   });
 
+  test('should filter using bracket-syntax filter[field][contains] on collection content', async ({ request }) => {
+    const collectionsResponse = await request.get('/api/collections');
+    const collectionsData = await collectionsResponse.json();
+
+    if (collectionsData.data.length === 0) {
+      console.log('No collections found, skipping test');
+      return;
+    }
+
+    // Find a collection that has content with a title we can filter on
+    let collectionName: string | null = null;
+    let probeTitle: string | null = null;
+    for (const c of collectionsData.data) {
+      const probe = await request.get(`/api/collections/${c.name}/content?limit=100`);
+      if (!probe.ok()) continue;
+      const body = await probe.json();
+      const titled = body.data?.find((row: any) => typeof row.title === 'string' && row.title.length >= 3);
+      if (titled) {
+        collectionName = c.name;
+        probeTitle = titled.title;
+        break;
+      }
+    }
+
+    if (!collectionName || !probeTitle) {
+      console.log('No content with a usable title found, skipping bracket-syntax test');
+      return;
+    }
+
+    // Take a substring of the title that's unlikely to match every row
+    const needle = probeTitle.slice(0, Math.min(4, probeTitle.length));
+    const url = `/api/collections/${collectionName}/content?limit=100&filter[title][contains]=${encodeURIComponent(needle)}`;
+
+    const response = await request.get(url);
+    expect(response.ok()).toBeTruthy();
+    const data = await response.json();
+
+    expect(Array.isArray(data.data)).toBeTruthy();
+    expect(data.data.length).toBeGreaterThan(0);
+
+    const needleLower = needle.toLowerCase();
+    for (const item of data.data) {
+      expect(typeof item.title).toBe('string');
+      expect(item.title.toLowerCase()).toContain(needleLower);
+    }
+
+    console.log(`✓ Bracket-syntax filter[title][contains]=${needle} returned ${data.data.length} matching items`);
+  });
+
   test('should work with sort and order parameters', async ({ request }) => {
     // Get collections
     const collectionsResponse = await request.get('/api/collections');

--- a/www/src/app/api/page.mdx
+++ b/www/src/app/api/page.mdx
@@ -917,6 +917,8 @@ SonicJS provides powerful filtering capabilities for content queries.
 | `less_than` | Less than | `filter[price][less_than]=1000` |
 | `like` | Case-insensitive search | `filter[title][like]=javascript` |
 | `contains` | String contains | `filter[tags][contains]=tutorial` |
+| `starts_with` | String starts with | `filter[title][starts_with]=How to` |
+| `ends_with` | String ends with | `filter[slug][ends_with]=-guide` |
 | `in` | Value in list | `filter[category][in]=blog,news` |
 | `not_in` | Value not in list | `filter[status][not_in]=draft,archived` |
 | `exists` | Field exists | `filter[featuredImage][exists]=true` |

--- a/www/src/app/changelog/page.mdx
+++ b/www/src/app/changelog/page.mdx
@@ -39,6 +39,18 @@ export const sections = [
   <div className="space-y-4">
     <div>
       <h4 className="text-sm font-bold text-gray-800 dark:text-gray-300 mb-2 flex items-center gap-2">
+        <span className="text-lg">🛠️</span> Fixed
+      </h4>
+      <ul className="space-y-2 ml-6">
+        <li className="text-sm text-gray-700 dark:text-gray-300 flex items-start gap-2">
+          <span className="text-gray-500 mt-0.5">▸</span>
+          <span><strong className="font-semibold">API Filter Bracket Syntax</strong> - <code>filter[field][operator]=value</code> on the public content and collections endpoints now correctly applies WHERE conditions instead of silently returning unfiltered data. Adds <code>starts_with</code> and <code>ends_with</code> operators alongside the existing <code>equals</code>, <code>contains</code>, <code>like</code>, <code>in</code>, <code>greater_than</code>, etc. (#807)</span>
+        </li>
+      </ul>
+    </div>
+
+    <div>
+      <h4 className="text-sm font-bold text-gray-800 dark:text-gray-300 mb-2 flex items-center gap-2">
         <span className="text-lg">🚀</span> Planned
       </h4>
       <ul className="space-y-2 ml-6">


### PR DESCRIPTION
## Description

The public-facing collections content endpoint (and the wider `/api/content` API) documented bracket-syntax filters at https://sonicjs.com/api#filtering, e.g.:

```
GET /api/collections/programs/content?filter[title][contains]=lyme
```

…but `QueryFilterBuilder.parseFromQuery` silently dropped them — only `where=` (JSON), `status`, and `collection_id` were recognized. As a result every filter example in the public docs returned **unfiltered** data. Reproed live against `https://api-v2.rifeplayer.com`.

This PR adds bracket-syntax parsing alongside the existing JSON `where=` form (both can be combined; conditions are AND'd) and adds two new operators (`starts_with`, `ends_with`) requested for partial-match queries.

Fixes # <!-- attach issue number if one exists -->

## Changes
- `packages/core/src/utils/query-filter.ts` — parse `filter[field][operator]=value` query keys into `where.and`; default operator is `equals`; `exists` is coerced to boolean. Add `starts_with` and `ends_with` to `FilterOperator` and the SQL builder (LIKE `value%` / LIKE `%value`).
- `packages/core/src/__tests__/utils/query-filter.test.ts` — 13 new unit tests covering bracket parsing for each operator, edge cases (empty regex match, unknown operator, deeper bracket nesting, default-equals), and the two new SQL builders.
- `tests/e2e/20-content-api-collection-filter.spec.ts` — new test exercising `filter[title][contains]` against the public `/api/collections/:slug/content` endpoint.
- `www/src/app/api/page.mdx` — adds `starts_with` / `ends_with` rows to the public operator table.
- `docs/api-filtering.md` — reconciled to document **both** bracket syntax and the JSON `where=` form, plus the two new operators.

No source-tracked dist artifacts are changed in this PR; release tooling regenerates them at version-bump time per recent main history.

## Testing

### Unit Tests
- [x] Added/updated unit tests
- [x] All unit tests passing (`packages/core`: 89/89 pass, was 76)

```
$ npx vitest --run src/__tests__/utils/query-filter.test.ts
Test Files  1 passed (1)
     Tests  89 passed (89)
```

`npm run type-check` passes.

### E2E Tests
- [x] Added/updated E2E tests
- [x] All filter-related E2E tests passing locally

```
$ npx playwright test tests/e2e/20-content-api-collection-filter.spec.ts
  5 passed (2.4s)
```

Full local suite: **286 passed, 292 skipped, 2 flaky** (pre-existing flakes in `03-admin-dashboard.spec.ts` `loginAsAdmin` HTMX path; both passed on re-run; unrelated to filter code).

### Manual verification against live local server
With 3 seeded rows in `pages` collection (`Lyme Disease Awareness`, `Cardiovascular Health`, `Treating Chronic Lyme`):

| Query | Returned |
|---|---|
| no filter | 3 rows |
| `filter[title][contains]=lyme` | 2 (both Lyme titles) |
| `filter[title][starts_with]=Treating` | 1 |
| `filter[title][ends_with]=Awareness` | 1 |

## Checklist
- [x] Code follows project conventions
- [x] Tests added/updated and passing
- [x] Type checking passes
- [x] No console errors or warnings
- [x] Documentation updated (in-repo + public www)

---
Generated with Claude Code in Conductor