### PR TITLE
fix(media): allow SVG uploads by binding null instead of undefined to D1

### DIFF
--- a/packages/core/src/routes/admin-media.ts
+++ b/packages/core/src/routes/admin-media.ts
@@ -496,9 +496,9 @@ adminMediaRoutes.post('/upload', async (c) => {
         }
 
         // Extract image dimensions if it's an image
-        let width: number | undefined
-        let height: number | undefined
-        
+        let width: number | null = null
+        let height: number | null = null
+
         if (file.type.startsWith('image/') && !file.type.includes('svg')) {
           try {
             const dimensions = await getImageDimensions(arrayBuffer)
@@ -511,7 +511,7 @@ adminMediaRoutes.post('/upload', async (c) => {
 
         // Generate URLs - use public serving route
         const publicUrl = `/files/${r2Key}`
-        const thumbnailUrl = file.type.startsWith('image/') ? publicUrl : undefined
+        const thumbnailUrl = file.type.startsWith('image/') ? publicUrl : null
 
         // Save to database
         const stmt = c.env.DB.prepare(`


### PR DESCRIPTION
## Summary
- SVG uploads via the admin media library failed with `D1_TYPE_ERROR: Type 'undefined' not supported for value 'undefined'`.
- Root cause: `packages/core/src/routes/admin-media.ts` declared `width`/`height` as `number | undefined` and used `thumbnail_url = ... : undefined`. D1's `stmt.bind()` rejects `undefined` (it accepts `null` for nullable columns). Non-SVG images dodged this because the dimension extractor populated the values; SVGs intentionally skip extraction, so they hit the bind with `undefined`.
- Fix: initialize `width`/`height` to `null` and default `thumbnail_url` to `null` instead of `undefined`. Mirrors the already-correct pattern in `api-media.ts`.

## Test plan
- [ ] Upload a `.svg` file via the admin media library and confirm it succeeds and renders.
- [ ] Re-upload a `.png`/`.jpg` to confirm dimension extraction still populates `width`/`height`.
- [ ] Upload a non-image (e.g. `.pdf`) to confirm `thumbnail_url` is stored as NULL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)