### PR TITLE
Update README and wrangler.toml for Cloudflare binding options

### DIFF
--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -112,10 +112,10 @@ cd my-app
 ### 2. Create Cloudflare resources (if skipped)
 
 ```bash
-wrangler d1 create my-app-db --binder DB
+wrangler d1 create my-app-db --binding DB
 # Copy the database_id to wrangler.toml
 
-wrangler r2 bucket create my-app-media --binder MEDIA_BUCKET
+wrangler r2 bucket create my-app-media --binding MEDIA_BUCKET
 ```
 
 ### 3. Run database migrations

--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -112,10 +112,10 @@ cd my-app
 ### 2. Create Cloudflare resources (if skipped)
 
 ```bash
-wrangler d1 create my-app-db
+wrangler d1 create my-app-db --binder DB
 # Copy the database_id to wrangler.toml
 
-wrangler r2 bucket create my-app-media
+wrangler r2 bucket create my-app-media --binder MEDIA_BUCKET
 ```
 
 ### 3. Run database migrations
@@ -172,7 +172,7 @@ If you create resources during setup, a D1 database is automatically created and
 
 **Manual creation:**
 ```bash
-wrangler d1 create my-app-db
+wrangler d1 create my-app-db --binding DB
 ```
 
 ### R2 Bucket
@@ -181,7 +181,7 @@ For media storage, an R2 bucket is created.
 
 **Manual creation:**
 ```bash
-wrangler r2 bucket create my-app-media
+wrangler r2 bucket create my-app-media --binding MEDIA_BUCKET
 ```
 
 ## Troubleshooting

--- a/packages/create-app/templates/starter/README.md
+++ b/packages/create-app/templates/starter/README.md
@@ -19,14 +19,14 @@ A modern headless CMS built with [SonicJS](https://sonicjs.com) on Cloudflare's 
 
 2. **Create your D1 database:**
    ```bash
-   npx wrangler d1 create my-sonicjs-db
+   npx wrangler d1 create my-sonicjs-db --binding DB
    ```
 
    Copy the `database_id` from the output and update it in `wrangler.toml`.
 
 3. **Create your R2 bucket:**
    ```bash
-   npx wrangler r2 bucket create my-sonicjs-media
+   npx wrangler r2 bucket create my-sonicjs-media --binding MEDIA_BUCKET
    ```
 
 4. **Run migrations:**

--- a/packages/create-app/templates/starter/wrangler.toml
+++ b/packages/create-app/templates/starter/wrangler.toml
@@ -10,12 +10,12 @@ workers_dev = true
 [[d1_databases]]
 binding = "DB"
 database_name = "my-sonicjs-db"
-database_id = "YOUR_DATABASE_ID" # Run: wrangler d1 create my-sonicjs-db
+database_id = "YOUR_DATABASE_ID"
 migrations_dir = "./node_modules/@sonicjs-cms/core/migrations"
 
 # R2 Bucket for media storage
 [[r2_buckets]]
-binding = "BUCKET"
+binding = "MEDIA_BUCKET"
 bucket_name = "my-sonicjs-media"
 
 # Environment variables


### PR DESCRIPTION
## Description
This PR fixes a fresh-install mismatch where the generated Cloudflare R2 binding name didn’t match what SonicJS expects for media uploads.

New projects created from `packages/create-app` templates could end up with an R2 bucket binding named `BUCKET`, while the admin media upload feature expects `MEDIA_BUCKET`. As a result, media uploads fail on a brand-new install until the user manually renames the binding.

Fixes #815

## Changes
- Update the create-app **starter `wrangler.toml` template** to bind the R2 bucket as `MEDIA_BUCKET` (instead of `BUCKET`) so fresh installs work out of the box.
- Update create-app documentation/examples to use the correct Wrangler resource creation commands and `--binding MEDIA_BUCKET` (and `--binding DB` for D1) to match the expected bindings.

## Testing
Manual verification (local):

- Created/verified resources with Wrangler directly:
  - `wrangler d1 create … --binding DB`
  - `wrangler r2 bucket create … --binding MEDIA_BUCKET`
- Confirmed the generated `wrangler.toml` template contains:
  - `[[d1_databases]] binding = "DB"`
  - `[[r2_buckets]] binding = "MEDIA_BUCKET"`

### Unit Tests
- [ ] Added/updated unit tests
- [ ] All unit tests passing  
  *(Not applicable — template/docs change only)*

### E2E Tests
- [ ] Added/updated E2E tests
- [ ] All E2E tests passing  
  *(Not run — see note below)*

**Note on `test-cli`:** I attempted to use the CLI test flow, but it currently halts awaiting an interactive prompt (re: seeding). It likely needs a bit of maintenance to run autonomously in CI. I’d prefer to get confirmation from maintainers before adjusting CLI behavior/test harness.

## Screenshots/Videos
N/A (no UI changes)

## Checklist
- [x] Code follows project conventions
- [ ] Tests added/updated and passing *(N/A — template/docs change only)*
- [x] Type checking passes *(N/A — no TS changes)*
- [x] No console errors or warnings *(N/A — no runtime code changes)*
- [x] Documentation updated (if needed)

---
Generated with Claude Code in Conductor