### PR TITLE
chore(create-app): clean up docs after #824

### DIFF
--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -112,10 +112,10 @@ cd my-app
 ### 2. Create Cloudflare resources (if skipped)
 
 ```bash
-wrangler d1 create my-app-db --binding DB
+wrangler d1 create my-app-db
 # Copy the database_id to wrangler.toml
 
-wrangler r2 bucket create my-app-media --binding MEDIA_BUCKET
+wrangler r2 bucket create my-app-media
 ```
 
 ### 3. Run database migrations
@@ -172,7 +172,7 @@ If you create resources during setup, a D1 database is automatically created and
 
 **Manual creation:**
 ```bash
-wrangler d1 create my-app-db --binding DB
+wrangler d1 create my-app-db
 ```
 
 ### R2 Bucket
@@ -181,7 +181,7 @@ For media storage, an R2 bucket is created.
 
 **Manual creation:**
 ```bash
-wrangler r2 bucket create my-app-media --binding MEDIA_BUCKET
+wrangler r2 bucket create my-app-media
 ```
 
 ## Troubleshooting

--- a/packages/create-app/templates/starter/README.md
+++ b/packages/create-app/templates/starter/README.md
@@ -19,14 +19,14 @@ A modern headless CMS built with [SonicJS](https://sonicjs.com) on Cloudflare's 
 
 2. **Create your D1 database:**
    ```bash
-   npx wrangler d1 create my-sonicjs-db --binding DB
+   npx wrangler d1 create my-sonicjs-db
    ```
 
    Copy the `database_id` from the output and update it in `wrangler.toml`.
 
 3. **Create your R2 bucket:**
    ```bash
-   npx wrangler r2 bucket create my-sonicjs-media --binding MEDIA_BUCKET
+   npx wrangler r2 bucket create my-sonicjs-media
    ```
 
 4. **Run migrations:**

--- a/packages/create-app/templates/starter/wrangler.toml
+++ b/packages/create-app/templates/starter/wrangler.toml
@@ -10,7 +10,7 @@ workers_dev = true
 [[d1_databases]]
 binding = "DB"
 database_name = "my-sonicjs-db"
-database_id = "YOUR_DATABASE_ID"
+database_id = "YOUR_DATABASE_ID" # Run: wrangler d1 create my-sonicjs-db
 migrations_dir = "./node_modules/@sonicjs-cms/core/migrations"
 
 # R2 Bucket for media storage


### PR DESCRIPTION
## Summary
Small follow-up to #824 (which is already merged — thanks @author):

- Restore the `# Run: wrangler d1 create my-sonicjs-db` comment in the starter `wrangler.toml` so fresh-install users still get the inline hint about how to populate `database_id`.
- Drop the `--binding DB` / `--binding MEDIA_BUCKET` flags from the create-app README and starter README. The flags are valid for `wrangler d1 create` / `wrangler r2 bucket create`, but they're effectively no-ops without `--update-config`, and the surrounding docs already instruct users to copy the values into `wrangler.toml` manually — so the flags are misleading rather than helpful.
- Restore the trailing newlines on both README files.

No runtime code changes.

## Test plan
- [x] `git diff` reviewed — touches only the three intended files
- [ ] Visual check that `wrangler.toml` rendered in fresh installs still shows the D1 hint comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)