### PR TITLE
fix(bootstrap): ensure bootstrap runs only once for concurrent requests

### DIFF
--- a/packages/core/src/middleware/bootstrap.test.ts
+++ b/packages/core/src/middleware/bootstrap.test.ts
@@ -2,8 +2,8 @@
  * Bootstrap Middleware Tests
  */
 
-import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { Hono } from 'hono'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { bootstrapMiddleware, resetBootstrap } from './bootstrap'
 
 // Mock the services that bootstrap depends on
@@ -11,10 +11,14 @@ vi.mock('../services/collection-sync', () => ({
   syncCollections: vi.fn().mockResolvedValue([])
 }))
 
+vi.mock('../services/form-collection-sync', () => ({
+  syncAllFormCollections: vi.fn().mockResolvedValue(undefined)
+}))
+
 vi.mock('../services/migrations', () => {
   const mockRunPendingMigrations = vi.fn().mockResolvedValue(undefined)
   return {
-    MigrationService: vi.fn().mockImplementation(function() {
+    MigrationService: vi.fn().mockImplementation(function () {
       this.runPendingMigrations = mockRunPendingMigrations
       return this
     })
@@ -25,7 +29,7 @@ vi.mock('../services/plugin-bootstrap', () => {
   const mockIsBootstrapNeeded = vi.fn().mockResolvedValue(true)
   const mockBootstrapCorePlugins = vi.fn().mockResolvedValue(undefined)
   return {
-    PluginBootstrapService: vi.fn().mockImplementation(function() {
+    PluginBootstrapService: vi.fn().mockImplementation(function () {
       this.isBootstrapNeeded = mockIsBootstrapNeeded
       this.bootstrapCorePlugins = mockBootstrapCorePlugins
       return this
@@ -35,6 +39,7 @@ vi.mock('../services/plugin-bootstrap', () => {
 
 // Import the mocked modules after mocking
 import { syncCollections } from '../services/collection-sync'
+import { syncAllFormCollections } from '../services/form-collection-sync'
 import { MigrationService } from '../services/migrations'
 import { PluginBootstrapService } from '../services/plugin-bootstrap'
 
@@ -64,8 +69,8 @@ describe('bootstrapMiddleware', () => {
     // Reset bootstrap state before each test
     resetBootstrap()
     vi.clearAllMocks()
-    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => { })
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { })
   })
 
   afterEach(() => {
@@ -232,6 +237,58 @@ describe('bootstrapMiddleware', () => {
     expect(consoleSpy).toHaveBeenCalledWith('[Bootstrap] Plugin bootstrap skipped (disableAll is true)')
   })
 
+  it('should run bootstrap only once for concurrent cold-start requests', async () => {
+    const app = new Hono()
+    const env = createMockEnv()
+
+    let releaseMigration: (() => void) | undefined
+    let markMigrationStarted: (() => void) | undefined
+    const migrationGate = new Promise<void>((resolve) => {
+      releaseMigration = resolve
+    })
+    const migrationStarted = new Promise<void>((resolve) => {
+      markMigrationStarted = resolve
+    })
+
+    const migrationServiceMock = vi.mocked(MigrationService)
+    migrationServiceMock.mockImplementation(function () {
+      this.runPendingMigrations = vi.fn().mockImplementation(async () => {
+        markMigrationStarted?.()
+        await migrationGate
+      })
+      return this
+    })
+
+    app.use('*', async (c, next) => {
+      c.env = env as any
+      await next()
+    })
+    app.use('*', bootstrapMiddleware())
+    app.get('/test', (c) => c.json({ ok: true }))
+
+    const firstRequest = app.request('/test')
+    await migrationStarted
+    const secondRequest = app.request('/test')
+
+    expect(MigrationService).toHaveBeenCalledTimes(1)
+
+    releaseMigration?.()
+    const [firstResponse, secondResponse] = await Promise.all([firstRequest, secondRequest])
+
+    expect(firstResponse.status).toBe(200)
+    expect(secondResponse.status).toBe(200)
+    expect(MigrationService).toHaveBeenCalledTimes(1)
+    expect(syncCollections).toHaveBeenCalledTimes(1)
+    expect(syncAllFormCollections).toHaveBeenCalledTimes(1)
+    expect(PluginBootstrapService).toHaveBeenCalledTimes(1)
+
+    migrationServiceMock.mockReset()
+    migrationServiceMock.mockImplementation(function () {
+      this.runPendingMigrations = vi.fn().mockResolvedValue(undefined)
+      return this
+    })
+  })
+
   it('should continue on fatal bootstrap error', async () => {
     const app = new Hono()
     const env = createMockEnv()
@@ -258,6 +315,7 @@ describe('bootstrapMiddleware', () => {
 
 describe('resetBootstrap', () => {
   beforeEach(() => {
+    resetBootstrap()
     vi.clearAllMocks()
   })
 
@@ -266,7 +324,7 @@ describe('resetBootstrap', () => {
   })
 
   it('should allow bootstrap to run again after reset', async () => {
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => { })
     const app = new Hono()
     const env = createMockEnv()
 

--- a/packages/core/src/middleware/bootstrap.ts
+++ b/packages/core/src/middleware/bootstrap.ts
@@ -1,9 +1,9 @@
 import { Context, Next } from "hono";
+import type { SonicJSConfig } from "../app";
 import { syncCollections } from "../services/collection-sync";
 import { syncAllFormCollections } from "../services/form-collection-sync";
 import { MigrationService } from "../services/migrations";
 import { PluginBootstrapService } from "../services/plugin-bootstrap";
-import type { SonicJSConfig } from "../app";
 
 type Bindings = {
   DB: D1Database;
@@ -15,6 +15,7 @@ type Bindings = {
 
 // Track if bootstrap has been run in this worker instance
 let bootstrapComplete = false;
+let bootstrapInFlight: Promise<void> | null = null;
 
 /**
  * Verify security-critical environment configuration at startup.
@@ -67,7 +68,7 @@ export function verifySecurityConfig(env: Bindings): void {
     if (hasCritical) {
       throw new Error(
         "[SonicJS Security] CRITICAL: Production deployment is missing a secure JWT_SECRET. " +
-          "Set it via `wrangler secret put JWT_SECRET` before deploying."
+        "Set it via `wrangler secret put JWT_SECRET` before deploying."
       );
     }
   }
@@ -99,52 +100,59 @@ export function bootstrapMiddleware(config: SonicJSConfig = {}) {
       return next();
     }
 
-    try {
-      console.log("[Bootstrap] Starting system initialization...");
+    if (!bootstrapInFlight) {
+      bootstrapInFlight = (async () => {
+        try {
+          console.log("[Bootstrap] Starting system initialization...");
 
-      // 1. Run database migrations first
-      console.log("[Bootstrap] Running database migrations...");
-      const migrationService = new MigrationService(c.env.DB);
-      await migrationService.runPendingMigrations();
+          // 1. Run database migrations first
+          console.log("[Bootstrap] Running database migrations...");
+          const migrationService = new MigrationService(c.env.DB);
+          await migrationService.runPendingMigrations();
 
-      // 2. Sync collection configurations
-      console.log("[Bootstrap] Syncing collection configurations...");
-      try {
-        await syncCollections(c.env.DB);
-      } catch (error) {
-        console.error("[Bootstrap] Error syncing collections:", error);
-        // Continue bootstrap even if collection sync fails
-      }
+          // 2. Sync collection configurations
+          console.log("[Bootstrap] Syncing collection configurations...");
+          try {
+            await syncCollections(c.env.DB);
+          } catch (error) {
+            console.error("[Bootstrap] Error syncing collections:", error);
+            // Continue bootstrap even if collection sync fails
+          }
 
-      // 2b. Sync form-derived shadow collections
-      console.log("[Bootstrap] Syncing form collections...");
-      try {
-        await syncAllFormCollections(c.env.DB);
-      } catch (error) {
-        console.error("[Bootstrap] Error syncing form collections:", error);
-      }
+          // 2b. Sync form-derived shadow collections
+          console.log("[Bootstrap] Syncing form collections...");
+          try {
+            await syncAllFormCollections(c.env.DB);
+          } catch (error) {
+            console.error("[Bootstrap] Error syncing form collections:", error);
+          }
 
-      // 3. Bootstrap core plugins (unless disableAll is set)
-      if (!config.plugins?.disableAll) {
-        console.log("[Bootstrap] Bootstrapping core plugins...");
-        const bootstrapService = new PluginBootstrapService(c.env.DB);
+          // 3. Bootstrap core plugins (unless disableAll is set)
+          if (!config.plugins?.disableAll) {
+            console.log("[Bootstrap] Bootstrapping core plugins...");
+            const bootstrapService = new PluginBootstrapService(c.env.DB);
 
-        // Check if bootstrap is needed
-        const needsBootstrap = await bootstrapService.isBootstrapNeeded();
-        if (needsBootstrap) {
-          await bootstrapService.bootstrapCorePlugins();
+            // Check if bootstrap is needed
+            const needsBootstrap = await bootstrapService.isBootstrapNeeded();
+            if (needsBootstrap) {
+              await bootstrapService.bootstrapCorePlugins();
+            }
+          } else {
+            console.log("[Bootstrap] Plugin bootstrap skipped (disableAll is true)");
+          }
+
+          // Mark bootstrap as complete for this worker instance
+          bootstrapComplete = true;
+          console.log("[Bootstrap] System initialization completed");
+        } catch (error) {
+          console.error("[Bootstrap] Error during system initialization:", error);
+          // Don't prevent the app from starting, but log the error
+        } finally {
+          bootstrapInFlight = null;
         }
-      } else {
-        console.log("[Bootstrap] Plugin bootstrap skipped (disableAll is true)");
-      }
-
-      // Mark bootstrap as complete for this worker instance
-      bootstrapComplete = true;
-      console.log("[Bootstrap] System initialization completed");
-    } catch (error) {
-      console.error("[Bootstrap] Error during system initialization:", error);
-      // Don't prevent the app from starting, but log the error
+      })();
     }
+    await bootstrapInFlight;
 
     // 4. Verify security configuration (outside try/catch so critical
     // errors in production propagate and prevent insecure deployments)
@@ -159,4 +167,5 @@ export function bootstrapMiddleware(config: SonicJSConfig = {}) {
  */
 export function resetBootstrap() {
   bootstrapComplete = false;
+  bootstrapInFlight = null;
 }


### PR DESCRIPTION
## Description 

This pull request improves the reliability of the bootstrap process in the middleware by ensuring that system initialization is only executed once, even under concurrent cold-start requests. It introduces a mechanism to prevent duplicate bootstrap runs, adds a comprehensive test for concurrency, and updates the reset logic to support repeated testing.

These changes make the bootstrap process more robust and the tests more reliable.

Fixes: not applicable, improvementqq 1

## Changes
Concurrency handling and bootstrap logic:

* Added a `bootstrapInFlight` promise to the bootstrap middleware in `bootstrap.ts` to ensure that concurrent requests during cold start will wait for the same initialization process, preventing multiple bootstrap executions.  Q[[1]](diffhunk://#diff-c3eced6061eeaae93bc3794674ea807eba5ea5cb3607cb91c26601cceddc69e1R18) [[2]](diffhunk://#diff-c3eced6061eeaae93bc3794674ea807eba5ea5cb3607cb91c26601cceddc69e1R103-R104) [[3]](diffhunk://#diff-c3eced6061eeaae93bc3794674ea807eba5ea5cb3607cb91c26601cceddc69e1R150-R155)
* Updated the `resetBootstrap` function to clear both `bootstrapComplete` and `bootstrapInFlight`, ensuring tests and future requests start with a clean state.

## Testing
* Added a new test in `bootstrap.test.ts` to verify that concurrent cold-start requests only trigger a single bootstrap run, and that all dependent services are only called once.
* Ensured all mocks are cleared and bootstrap state is reset before each test in the `resetBootstrap` test suite for better isolation.
* Added missing mock for the `syncAllFormCollections` service and imported it for use in assertions. [[1]](diffhunk://#diff-a8e9bf8b2093efff239663a92b1dd5903517fcd70da365beed53ba43273f5448L5-R17) [[2]](diffhunk://#diff-a8e9bf8b2093efff239663a92b1dd5903517fcd70da365beed53ba43273f5448R42)

### Unit Tests
- [x] Added/updated unit tests
- [ ] All unit tests passing

### E2E Tests
- [ ] Added/updated E2E tests
- [ ] All E2E tests passing

## Screenshots/Videos
<!-- If this PR includes UI changes, add screenshots or videos -->

## Checklist
- [ ] Code follows project conventions
- [ ] Tests added/updated and passing
- [ ] Type checking passes
- [ ] No console errors or warnings
- [ ] Documentation updated (if needed)

---
Generated with Claude Code in Conductor
