### PR TITLE
fix(admin): prevent crash on array fields with media items

### DIFF
--- a/packages/core/src/__tests__/templates/dynamic-field.test.ts
+++ b/packages/core/src/__tests__/templates/dynamic-field.test.ts
@@ -306,3 +306,104 @@ describe('renderDynamicField - Media', () => {
     expect(html).toContain('hidden'); // Preview grid should be hidden
   });
 });
+
+/**
+ * Array-of-media regression test
+ *
+ * Bug: A collection field configured as `type: 'array'` with `items: { type: 'media' }`
+ * crashed the new-content form with `TypeError: url.toLowerCase is not a function`.
+ *
+ * Root cause: renderStructuredArrayField renders an empty-item template with itemValue={}.
+ * For non-object item types, renderStructuredItemFields passed that `{}` straight through
+ * to the media renderer, which then called `({}).toLowerCase()` inside isVideoUrl.
+ */
+describe('renderDynamicField - array of media items', () => {
+  it('should render an empty array of media items without throwing', () => {
+    const field: FieldDefinition = {
+      id: 'images-field',
+      field_name: 'images',
+      field_type: 'array',
+      field_label: 'Images',
+      field_options: {
+        items: {
+          type: 'media',
+          title: 'Image',
+          accept: 'image/*',
+          maxSize: '10MB',
+        },
+      },
+      field_order: 1,
+      is_required: false,
+      is_searchable: false,
+    };
+
+    // Previously threw "TypeError: url.toLowerCase is not a function" while rendering
+    // the empty-item <template> server-side.
+    const html = renderDynamicField(field, { value: [] });
+
+    expect(html).toContain('data-structured-array');
+    expect(html).toContain('data-field-name="images"');
+    expect(html).toContain('data-structured-array-template');
+  });
+
+  it('should render an array of media items with existing string values', () => {
+    const field: FieldDefinition = {
+      id: 'images-field',
+      field_name: 'images',
+      field_type: 'array',
+      field_label: 'Images',
+      field_options: {
+        items: { type: 'media', title: 'Image' },
+      },
+      field_order: 1,
+      is_required: false,
+      is_searchable: false,
+    };
+
+    const html = renderDynamicField(field, {
+      value: ['https://example.com/a.jpg', 'https://example.com/b.png'],
+    });
+
+    expect(html).toContain('data-structured-array');
+    expect(html).toContain('https://example.com/a.jpg');
+    expect(html).toContain('https://example.com/b.png');
+  });
+});
+
+describe('renderDynamicField - media field defensive handling', () => {
+  const baseField: FieldDefinition = {
+    id: 'media-field',
+    field_name: 'photo',
+    field_type: 'media',
+    field_label: 'Photo',
+    field_options: {},
+    field_order: 1,
+    is_required: false,
+    is_searchable: false,
+  };
+
+  it('should not throw when value is an empty object (single mode)', () => {
+    expect(() =>
+      renderDynamicField(baseField, { value: {} as unknown as string }),
+    ).not.toThrow();
+  });
+
+  it('should not throw when value is an empty object (multiple mode)', () => {
+    const multipleField = { ...baseField, field_options: { multiple: true } };
+    expect(() =>
+      renderDynamicField(multipleField, { value: {} as unknown as string }),
+    ).not.toThrow();
+  });
+
+  it('should ignore non-string entries in a multiple-mode array', () => {
+    const multipleField = { ...baseField, field_options: { multiple: true } };
+    const html = renderDynamicField(multipleField, {
+      value: ['https://example.com/a.jpg', {} as unknown as string, ''],
+    });
+
+    expect(html).toContain('https://example.com/a.jpg');
+    // Empty/object values shouldn't produce stray <img>/<video> tags
+    expect(html).not.toContain('<img src=""');
+    expect(html).not.toContain('<img src="[object');
+  });
+});

--- a/packages/core/src/templates/components/dynamic-field.template.ts
+++ b/packages/core/src/templates/components/dynamic-field.template.ts
@@ -827,19 +827,22 @@ export function renderDynamicField(field: FieldDefinition, options: FieldRenderO
       const mediaValues =
         isMultiple && value
           ? Array.isArray(value)
-            ? value
+            ? value.filter((url) => typeof url === 'string' && url !== '')
             : String(value).split(',').filter(Boolean)
           : []
-      const singleValue = !isMultiple ? value : ''
+      const singleValue =
+        !isMultiple && typeof value === 'string' ? value : ''
 
       // Helper to detect if URL is a video
-      const isVideoUrl = (url: string) => {
+      const isVideoUrl = (url: unknown) => {
+        if (typeof url !== 'string') return false
         const videoExtensions = ['.mp4', '.webm', '.ogg', '.mov', '.avi']
         return videoExtensions.some((ext) => url.toLowerCase().endsWith(ext))
       }
 
       // Helper to render media element
-      const renderMediaPreview = (url: string, alt: string, classes: string) => {
+      const renderMediaPreview = (url: unknown, alt: string, classes: string) => {
+        if (typeof url !== 'string' || url === '') return ''
         if (isVideoUrl(url)) {
           return `<video src="${url}" class="${classes}" muted></video>`
         }
@@ -1325,7 +1328,17 @@ function renderStructuredItemFields(
   }
 
   const normalizedField = normalizeBlockField(itemConfig, 'Item')
-  const fieldValue = itemValue ?? normalizedField.defaultValue ?? ''
+  // The empty-item template is rendered with itemValue={} (see renderStructuredArrayField).
+  // For non-object item types, treat an empty plain object as "no value" so downstream
+  // renderers (e.g. media) don't receive `{}` and crash on string operations.
+  const isEmptyPlainObject =
+    itemValue !== null &&
+    typeof itemValue === 'object' &&
+    !Array.isArray(itemValue) &&
+    Object.keys(itemValue).length === 0
+  const fieldValue = isEmptyPlainObject
+    ? (normalizedField.defaultValue ?? '')
+    : (itemValue ?? normalizedField.defaultValue ?? '')
   const fieldDefinition: FieldDefinition = {
     id: `array-${field.field_name}-${index}-value`,
     field_name: `array-${field.field_name}-${index}-value`,


### PR DESCRIPTION
## Summary
Fixes a `TypeError: url.toLowerCase is not a function` crash that prevented the new-content form from loading whenever a collection had a field configured as `type: 'array'` with `items: { type: 'media' }` (a pattern explicitly shown in `docs/collections-config.md:515-519`).

Reported by a new user in Discord on their first day with SonicJS.

## Root cause
- `renderStructuredArrayField` renders an empty-item `<template>` by calling `renderStructuredArrayItem(..., {}, ...)`.
- In `renderStructuredItemFields`, for non-object item types, `const fieldValue = itemValue ?? normalizedField.defaultValue ?? ''` left the empty object as-is (since `{}` is not nullish).
- That `{}` flowed into the `media` case as `singleValue`, was truthy, and got passed to `isVideoUrl({})`, which called `({}).toLowerCase()` and threw — breaking server-side rendering of the entire form.

## Changes
- `packages/core/src/templates/components/dynamic-field.template.ts`
  - `renderStructuredItemFields`: treat an empty plain-object `itemValue` as "no value" for non-object item types, falling back to `defaultValue` or `''`.
  - `media` case: `isVideoUrl` and `renderMediaPreview` short-circuit on non-string input; multiple-mode arrays filter out non-string entries; `singleValue` only kept when it's a string.
- `packages/core/src/__tests__/templates/dynamic-field.test.ts`
  - Regression test for `type: 'array'` + `items: { type: 'media' }` rendering an empty array.
  - Tests for arrays of media with existing string values.
  - Defensive tests that empty objects and non-string entries don't throw or produce stray `<img>`/`<video>` tags.

## Workaround
Until this lands, users can either:
- Use the single-field variant `type: 'media'` with `multiple: true` (stores comma-separated URLs in one column).
- Wrap each media in an object: `items: { type: 'object', properties: { image: { type: 'media' } } }` — that path doesn't hit the bug.

## Testing
- [x] All 1482 core unit tests pass locally
- [x] `npm run type-check` clean
- [x] `npm run build:core` clean
- [x] New regression tests reproduce the original failure on the unpatched code and pass on the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)