### PR TITLE
feat(plugins): cron surface — declarations + scheduled() handler (Phase 4)

### DIFF
--- a/PLUGIN_SYSTEM_OVERHAUL_PLAN.md
+++ b/PLUGIN_SYSTEM_OVERHAUL_PLAN.md
@@ -630,6 +630,22 @@ Extend the existing specs (`15-plugins`, `29-email-plugin-settings`, `43-cache-p
 
 ---
 
+## Appendix F — Phase 4 status (cron surface)
+
+Built on the stacked branch `lane711/plugin-system-cron` (PR base = the foundation branch / #841).
+
+**Landed (infrastructure; no consumer change yet):**
+- `plugins/cron.ts` — `CronDeclaration` (`{ schedule, hookFamily }`) + structural `CronablePlugin` (`crons[]` + async `onCronTick`). `collectCrons()` / `collectCronSchedules()` flatten declarations (for wrangler sync + diagnostics). `dispatchCronTick(plugins, cron, scheduledTime, ctx)` fans a fired expression out to matching plugins, tagging each `onCronTick` with the matched `hookFamily`, one call per matching declaration, error-isolated. `createScheduledHandler({ plugins, getHooks, disabled })` returns a Cloudflare `scheduled(controller, env, ctx)` handler that reaches services via the **env-independent singletons** (cron has no `c.env`), passes the Worker `env` into the cron context, and `waitUntil`s the work.
+- Exported from `plugins/index.ts`.
+
+**Design note (matches Payload jobs):** declaring a `schedule` runs nothing by itself — the execution mechanism is the Cloudflare Cron Trigger delivered to `scheduled()`. The consumer still lists the expressions in `wrangler.toml [triggers]`; the plugin `crons[]` are the source of truth for which plugin owns which expression (`collectCronSchedules()` can generate the wrangler list).
+
+**Tests:** `cron.test.ts` (12): collect/flatten + malformed-entry skipping, dispatch matches only the fired cron, well-formed event, unmatched reporting, multi-cron fan-out (one call per declaration), error isolation, and the `scheduled` handler (dispatch + `waitUntil` + env passthrough + lazy list + `disabled` no-op). Full core suite **1552 passed, 0 failed**; `tsc` clean.
+
+**Deferred:** wiring `scheduled` into the consumer Worker export (`export default { fetch, scheduled }`) + the starter template + `wrangler.toml` trigger generation — a DX change bundled with `definePlugin()`/docs (Phase 5/7), since it changes how consumers export their Worker.
+
+---
+
 ### Appendix A — Source references
 - **Infowall v3 Plugin Architecture · Progress Update, May 13 2026** (companion architecture overview) — two-phase boot, SmartRouter fix, capabilities, cron, email reference.
 - **Strapi v5** — docs.strapi.io (plugin-structure, server-api, admin-panel-api, configurations/plugins, document-service middlewares) + `strapi/strapi` `main` (`loaders/plugins/*`, `registries/plugins.ts`, `types/.../strapi-server/*`).

--- a/packages/core/src/__tests__/plugins/cron.test.ts
+++ b/packages/core/src/__tests__/plugins/cron.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest'
+import { HookSystemImpl } from '../../plugins/hook-system'
+import {
+  collectCrons,
+  collectCronSchedules,
+  dispatchCronTick,
+  createScheduledHandler,
+  type CronablePlugin,
+  type CronContext,
+  type CronTickEvent,
+} from '../../plugins/cron'
+
+function ctx(): CronContext {
+  return { hooks: new HookSystemImpl() }
+}
+
+const EVERY_15 = '*/15 * * * *'
+const DAILY = '0 0 * * *'
+
+describe('collectCrons', () => {
+  it('flattens crons across plugins', () => {
+    const plugins: CronablePlugin[] = [
+      { name: 'email', crons: [{ schedule: EVERY_15, hookFamily: 'email-reconciliation' }] },
+      { name: 'reports', crons: [{ schedule: DAILY, hookFamily: 'daily-report' }] },
+      { name: 'no-crons' },
+    ]
+    expect(collectCrons(plugins)).toEqual([
+      { plugin: 'email', schedule: EVERY_15, hookFamily: 'email-reconciliation' },
+      { plugin: 'reports', schedule: DAILY, hookFamily: 'daily-report' },
+    ])
+  })
+
+  it('skips malformed cron entries and null plugins', () => {
+    const plugins: any[] = [
+      null,
+      { name: 'bad', crons: [{ schedule: EVERY_15 /* missing hookFamily */ }, { hookFamily: 'x' }] },
+    ]
+    expect(collectCrons(plugins)).toEqual([])
+  })
+
+  it('collectCronSchedules returns distinct expressions', () => {
+    const plugins: CronablePlugin[] = [
+      { name: 'a', crons: [{ schedule: EVERY_15, hookFamily: 'a' }] },
+      { name: 'b', crons: [{ schedule: EVERY_15, hookFamily: 'b' }] },
+      { name: 'c', crons: [{ schedule: DAILY, hookFamily: 'c' }] },
+    ]
+    expect(collectCronSchedules(plugins).sort()).toEqual([DAILY, EVERY_15].sort())
+  })
+})
+
+describe('dispatchCronTick', () => {
+  it('invokes onCronTick only for plugins matching the fired cron', async () => {
+    const fired: string[] = []
+    const plugins: CronablePlugin[] = [
+      {
+        name: 'email',
+        crons: [{ schedule: EVERY_15, hookFamily: 'email-reconciliation' }],
+        onCronTick: (e) => void fired.push(`email:${e.hookFamily}`),
+      },
+      {
+        name: 'reports',
+        crons: [{ schedule: DAILY, hookFamily: 'daily-report' }],
+        onCronTick: (e) => void fired.push(`reports:${e.hookFamily}`),
+      },
+    ]
+
+    const result = await dispatchCronTick(plugins, EVERY_15, 1000, ctx())
+
+    expect(fired).toEqual(['email:email-reconciliation'])
+    expect(result.invoked).toEqual([{ plugin: 'email', hookFamily: 'email-reconciliation' }])
+    expect(result.unmatched).toBe(false)
+  })
+
+  it('passes a well-formed event (cron, scheduledTime, hookFamily)', async () => {
+    let seen: CronTickEvent | undefined
+    const plugins: CronablePlugin[] = [
+      {
+        name: 'p',
+        crons: [{ schedule: EVERY_15, hookFamily: 'fam' }],
+        onCronTick: (e) => void (seen = e),
+      },
+    ]
+    await dispatchCronTick(plugins, EVERY_15, 1717200000000, ctx())
+    expect(seen).toEqual({ cron: EVERY_15, scheduledTime: 1717200000000, hookFamily: 'fam' })
+  })
+
+  it('reports unmatched when the fired cron matches nothing', async () => {
+    const plugins: CronablePlugin[] = [
+      { name: 'p', crons: [{ schedule: EVERY_15, hookFamily: 'fam' }], onCronTick: () => {} },
+    ]
+    const result = await dispatchCronTick(plugins, '0 3 * * *', 1, ctx())
+    expect(result.unmatched).toBe(true)
+    expect(result.invoked).toEqual([])
+  })
+
+  it('fires once per matching declaration for a multi-cron plugin', async () => {
+    const families: string[] = []
+    const plugins: CronablePlugin[] = [
+      {
+        name: 'multi',
+        crons: [
+          { schedule: EVERY_15, hookFamily: 'fast' },
+          { schedule: EVERY_15, hookFamily: 'also-fast' },
+          { schedule: DAILY, hookFamily: 'slow' },
+        ],
+        onCronTick: (e) => void families.push(e.hookFamily),
+      },
+    ]
+    await dispatchCronTick(plugins, EVERY_15, 1, ctx())
+    expect(families).toEqual(['fast', 'also-fast'])
+  })
+
+  it('isolates a throwing onCronTick — others still run', async () => {
+    const ran: string[] = []
+    const plugins: CronablePlugin[] = [
+      {
+        name: 'bad',
+        crons: [{ schedule: EVERY_15, hookFamily: 'bad' }],
+        onCronTick: () => {
+          throw new Error('boom')
+        },
+      },
+      {
+        name: 'good',
+        crons: [{ schedule: EVERY_15, hookFamily: 'good' }],
+        onCronTick: () => void ran.push('good'),
+      },
+    ]
+    const result = await dispatchCronTick(plugins, EVERY_15, 1, ctx())
+    expect(ran).toEqual(['good'])
+    expect(result.invoked).toEqual([{ plugin: 'good', hookFamily: 'good' }])
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatchObject({ plugin: 'bad', hookFamily: 'bad' })
+  })
+})
+
+describe('createScheduledHandler', () => {
+  it('dispatches the fired controller.cron and calls waitUntil', async () => {
+    const fired: string[] = []
+    const plugin: CronablePlugin = {
+      name: 'email',
+      crons: [{ schedule: EVERY_15, hookFamily: 'email-reconciliation' }],
+      onCronTick: (e) => void fired.push(e.hookFamily),
+    }
+    const hooks = new HookSystemImpl()
+    const handler = createScheduledHandler({ plugins: [plugin], getHooks: () => hooks })
+
+    const waited: Promise<unknown>[] = []
+    const result = await handler(
+      { cron: EVERY_15, scheduledTime: 42 },
+      { SOME_BINDING: 'x' },
+      { waitUntil: (p) => void waited.push(p) }
+    )
+
+    expect(fired).toEqual(['email-reconciliation'])
+    expect(result.invoked).toHaveLength(1)
+    expect(waited).toHaveLength(1)
+  })
+
+  it('passes the Worker env through to the cron context', async () => {
+    let seenEnv: unknown
+    const plugin: CronablePlugin = {
+      name: 'p',
+      crons: [{ schedule: EVERY_15, hookFamily: 'fam' }],
+      onCronTick: (_e, c) => void (seenEnv = c.env),
+    }
+    const handler = createScheduledHandler({ plugins: [plugin], getHooks: () => new HookSystemImpl() })
+    await handler({ cron: EVERY_15, scheduledTime: 0 }, { DB: 'binding' })
+    expect(seenEnv).toEqual({ DB: 'binding' })
+  })
+
+  it('evaluates a lazy plugin list at fire time', async () => {
+    let calls = 0
+    const handler = createScheduledHandler({
+      plugins: () => {
+        calls++
+        return [{ name: 'p', crons: [{ schedule: EVERY_15, hookFamily: 'f' }], onCronTick: () => {} }]
+      },
+      getHooks: () => new HookSystemImpl(),
+    })
+    await handler({ cron: EVERY_15, scheduledTime: 0 }, {})
+    expect(calls).toBe(1)
+  })
+
+  it('is a no-op when disabled (mirrors disableAll)', async () => {
+    let ran = false
+    const plugin: CronablePlugin = {
+      name: 'p',
+      crons: [{ schedule: EVERY_15, hookFamily: 'f' }],
+      onCronTick: () => void (ran = true),
+    }
+    const handler = createScheduledHandler({
+      plugins: [plugin],
+      getHooks: () => new HookSystemImpl(),
+      disabled: true,
+    })
+    const result = await handler({ cron: EVERY_15, scheduledTime: 0 }, {})
+    expect(ran).toBe(false)
+    expect(result.invoked).toEqual([])
+  })
+})

--- a/packages/core/src/plugins/cron.ts
+++ b/packages/core/src/plugins/cron.ts
@@ -1,0 +1,184 @@
+/**
+ * Plugin cron surface
+ *
+ * A plugin declares scheduled work as data:
+ *
+ *   crons: [{ schedule: '*\/15 * * * *', hookFamily: 'email-reconciliation' }]
+ *   async onCronTick(event, ctx) {
+ *     if (event.hookFamily !== 'email-reconciliation') return
+ *     ...
+ *   }
+ *
+ * Declaring a schedule does NOT by itself run anything (same as Payload's jobs
+ * queue): on Cloudflare Workers the execution mechanism is a Cron Trigger, which
+ * the runtime delivers to the Worker's `scheduled()` handler. `createScheduledHandler`
+ * builds that handler; it fans a fired trigger out to the plugins whose declared
+ * schedule matches, tagging each call with the matching `hookFamily` so a plugin
+ * with several crons can branch on it.
+ *
+ * The consumer must still register the cron expressions in `wrangler.toml`
+ * (`[triggers] crons = [...]`); the schedules declared here are the source of
+ * truth for which plugin handles which expression.
+ *
+ * Cron runs OUTSIDE the HTTP request context (no per-request `c.env`), which is
+ * exactly why services are reached through env-independent singletons.
+ */
+
+import type { HookSystemLike } from './hooks/typed-hooks'
+
+/** A scheduled-work declaration on a plugin. */
+export interface CronDeclaration {
+  /** Cron expression, e.g. `'*\/15 * * * *'`. Must also be in wrangler.toml triggers. */
+  schedule: string
+  /** Logical family the handler branches on (e.g. `'email-reconciliation'`). */
+  hookFamily: string
+}
+
+/** The event passed to a plugin's `onCronTick`. */
+export interface CronTickEvent {
+  /** The cron expression that fired. */
+  cron: string
+  /** Epoch ms the trigger was scheduled for. */
+  scheduledTime: number
+  /** The matching declaration's family, so a multi-cron plugin can branch. */
+  hookFamily: string
+}
+
+/** Context handed to `onCronTick`. Mirrors the boot context; carries no request env. */
+export interface CronContext {
+  /** The live hook system (so cron work can dispatch/observe hooks). */
+  hooks: HookSystemLike
+  /** Runtime bindings supplied by the Worker's scheduled() invocation. */
+  env?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+/**
+ * Structural contract this module needs from a plugin. Deliberately minimal (not
+ * the full `Plugin`) so the `src`/`dist` duplicate identities and user plugins all
+ * satisfy it without casts.
+ */
+export interface CronablePlugin {
+  name?: string
+  crons?: CronDeclaration[]
+  onCronTick?: (event: CronTickEvent, context: CronContext) => void | Promise<void>
+}
+
+/** A flattened view of every declared cron across a set of plugins. */
+export interface CollectedCron {
+  plugin: string
+  schedule: string
+  hookFamily: string
+}
+
+/** Flatten every plugin's `crons[]` into one list (for diagnostics / wrangler sync). */
+export function collectCrons(plugins: Array<CronablePlugin | undefined | null>): CollectedCron[] {
+  const out: CollectedCron[] = []
+  for (const plugin of plugins) {
+    if (!plugin || !Array.isArray(plugin.crons)) continue
+    const name = plugin.name ?? 'unknown'
+    for (const cron of plugin.crons) {
+      if (cron && typeof cron.schedule === 'string' && typeof cron.hookFamily === 'string') {
+        out.push({ plugin: name, schedule: cron.schedule, hookFamily: cron.hookFamily })
+      }
+    }
+  }
+  return out
+}
+
+/** The set of distinct cron expressions declared across plugins. */
+export function collectCronSchedules(plugins: Array<CronablePlugin | undefined | null>): string[] {
+  return [...new Set(collectCrons(plugins).map((c) => c.schedule))]
+}
+
+/** Outcome of a cron dispatch. */
+export interface CronDispatchResult {
+  /** Plugins whose `onCronTick` ran successfully (one entry per matching declaration). */
+  invoked: Array<{ plugin: string; hookFamily: string }>
+  /** Per-plugin errors (dispatch never throws). */
+  errors: Array<{ plugin: string; hookFamily: string; error: unknown }>
+  /** True if the fired cron matched no declared schedule. */
+  unmatched: boolean
+}
+
+/**
+ * Dispatch one fired cron expression to the plugins that declared it.
+ *
+ * For each plugin whose `crons[]` contains a declaration with `schedule === cron`,
+ * its `onCronTick` is invoked once per matching declaration, with the event's
+ * `hookFamily` set to that declaration's family. Errors are isolated per plugin.
+ */
+export async function dispatchCronTick(
+  plugins: Array<CronablePlugin | undefined | null>,
+  cron: string,
+  scheduledTime: number,
+  context: CronContext
+): Promise<CronDispatchResult> {
+  const result: CronDispatchResult = { invoked: [], errors: [], unmatched: true }
+
+  for (const plugin of plugins) {
+    if (!plugin || typeof plugin.onCronTick !== 'function' || !Array.isArray(plugin.crons)) continue
+    const name = plugin.name ?? 'unknown'
+    const matches = plugin.crons.filter((c) => c && c.schedule === cron)
+    for (const match of matches) {
+      result.unmatched = false
+      const event: CronTickEvent = { cron, scheduledTime, hookFamily: match.hookFamily }
+      try {
+        await plugin.onCronTick(event, context)
+        result.invoked.push({ plugin: name, hookFamily: match.hookFamily })
+      } catch (error) {
+        result.errors.push({ plugin: name, hookFamily: match.hookFamily, error })
+      }
+    }
+  }
+
+  return result
+}
+
+/** Minimal shape of a Cloudflare `ScheduledController`. */
+export interface ScheduledControllerLike {
+  cron: string
+  scheduledTime: number
+}
+
+/** Minimal shape of a Cloudflare `ExecutionContext`. */
+export interface ExecutionContextLike {
+  waitUntil?(promise: Promise<unknown>): void
+}
+
+export interface CreateScheduledHandlerOptions {
+  /** Plugins to consider (evaluated lazily at fire time). */
+  plugins: Array<CronablePlugin | undefined | null> | (() => Array<CronablePlugin | undefined | null>)
+  /** Provides the hook system (e.g. the singleton getter). */
+  getHooks: () => HookSystemLike
+  /** Optional: when true, skip dispatch entirely (mirrors plugins.disableAll). */
+  disabled?: boolean
+}
+
+/**
+ * Build a Cloudflare `scheduled(controller, env, ctx)` handler that fans cron
+ * triggers out to plugins.
+ *
+ * Usage in a Worker entry:
+ *   export default {
+ *     fetch: app.fetch,
+ *     scheduled: createScheduledHandler({ plugins, getHooks: getHookSystem }),
+ *   }
+ */
+export function createScheduledHandler(
+  options: CreateScheduledHandlerOptions
+): (controller: ScheduledControllerLike, env: Record<string, unknown>, ctx?: ExecutionContextLike) => Promise<CronDispatchResult> {
+  return async (controller, env, ctx) => {
+    if (options.disabled) {
+      return { invoked: [], errors: [], unmatched: true }
+    }
+    const plugins = typeof options.plugins === 'function' ? options.plugins() : options.plugins
+    const work = dispatchCronTick(plugins, controller.cron, controller.scheduledTime, {
+      hooks: options.getHooks(),
+      env,
+    })
+    // Keep the Worker alive until cron work settles, when the runtime supports it.
+    ctx?.waitUntil?.(work.catch(() => {}))
+    return work
+  }
+}

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -74,6 +74,25 @@ export type {
 export { createServiceSingleton } from './singletons/service-singleton'
 export type { ServiceSingleton } from './singletons/service-singleton'
 
+// Cron surface
+export {
+  collectCrons,
+  collectCronSchedules,
+  dispatchCronTick,
+  createScheduledHandler,
+} from './cron'
+export type {
+  CronDeclaration,
+  CronTickEvent,
+  CronContext,
+  CronablePlugin,
+  CollectedCron,
+  CronDispatchResult,
+  ScheduledControllerLike,
+  ExecutionContextLike,
+  CreateScheduledHandlerOptions,
+} from './cron'
+
 // Core Plugins
 export { 
   verifyTurnstile, 


### PR DESCRIPTION
## Summary

Adds the plugin **cron surface** on top of the foundation (#841). Plugins declare scheduled work as data; a `scheduled()` handler fans fired Cron Triggers out to the matching plugins.

> **Stacked on #841** (base = `lane711/plugin-system-issues`). Review/merge that first.

**Infrastructure only — no consumer change yet.** Like the other foundation phases, this is live-but-inert: no plugin declares `crons` yet, and the `scheduled` export isn't wired into the consumer Worker.

## What's here

- `plugins/cron.ts`:
  - `CronDeclaration { schedule, hookFamily }` + structural `CronablePlugin` (`crons[]` + async `onCronTick`).
  - `collectCrons()` / `collectCronSchedules()` — flatten declarations (for wrangler-trigger sync + diagnostics).
  - `dispatchCronTick()` — matches a fired expression to the plugins that declared it, tags each `onCronTick` with the matched `hookFamily` (one call per matching declaration), error-isolated.
  - `createScheduledHandler({ plugins, getHooks, disabled })` — returns a Cloudflare `scheduled(controller, env, ctx)` handler that reaches services via the **env-independent singletons** (cron has no `c.env`), passes Worker `env` through, and `waitUntil`s the work.

## Design note

Matches Payload's jobs model: declaring a `schedule` runs nothing by itself — the execution mechanism is the Cloudflare Cron Trigger delivered to `scheduled()`. The consumer still lists the expressions in `wrangler.toml [triggers]`; the plugin `crons[]` are the source of truth for which plugin owns which expression.

## Tests

`cron.test.ts` (12): collect/flatten + malformed-entry skipping, match-only-fired-cron, well-formed event, unmatched reporting, multi-cron fan-out (one call per declaration), error isolation, and the `scheduled` handler (dispatch + `waitUntil` + env passthrough + lazy list + `disabled` no-op).

- Full core suite: **1552 passed, 0 failed**
- `tsc --noEmit`: clean

## Deferred

Wiring `scheduled` into the consumer Worker export (`export default { fetch, scheduled }`) + starter template + `wrangler.toml` trigger generation — bundled with `definePlugin()`/docs (Phase 5/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)