### PR TITLE
Add headless CMS comparison matrix page (/compare)

### DIFF
--- a/www/content/blog/comparisons/directus-vs-payload-vs-sonicjs.mdx
+++ b/www/content/blog/comparisons/directus-vs-payload-vs-sonicjs.mdx
@@ -16,7 +16,7 @@ tags:
   - "open-source"
   - "typescript"
 publishedAt: "2026-01-23"
-updatedAt: "2026-01-23"
+updatedAt: "2026-06-02"
 author:
   name: "SonicJS Team"
   twitter: "sonicjs"
@@ -44,6 +44,9 @@ canonical: "https://sonicjs.com/blog/comparisons/directus-vs-payload-vs-sonicjs"
 - SonicJS: Under 50ms globally, zero cold starts
 - All three: MIT/GPL licensed, truly open source
 </TLDRBox>
+
+> 📊 **See the full feature matrix:** [SonicJS vs Payload, Strapi, Directus, Sanity & Contentful](/compare) — a side-by-side inventory of 125+ capabilities across 13 categories, from APIs and auth to i18n and pricing.
+
 
 Looking for an open source headless CMS? Directus, Payload, and SonicJS represent three different philosophies. This comparison covers the real-world trade-offs based on developer feedback and production experiences.
 

--- a/www/content/blog/comparisons/directus-vs-sanity-vs-sonicjs.mdx
+++ b/www/content/blog/comparisons/directus-vs-sanity-vs-sonicjs.mdx
@@ -16,7 +16,7 @@ tags:
   - "open-source"
   - "database"
 publishedAt: "2026-01-23"
-updatedAt: "2026-01-23"
+updatedAt: "2026-06-02"
 author:
   name: "SonicJS Team"
   twitter: "sonicjs"
@@ -44,6 +44,9 @@ canonical: "https://sonicjs.com/blog/comparisons/directus-vs-sanity-vs-sonicjs"
 - SonicJS: Under 50ms globally, zero cold starts
 - Directus: GPL v3 (copyleft) vs SonicJS MIT (permissive)
 </TLDRBox>
+
+> 📊 **See the full feature matrix:** [SonicJS vs Payload, Strapi, Directus, Sanity & Contentful](/compare) — a side-by-side inventory of 125+ capabilities across 13 categories, from APIs and auth to i18n and pricing.
+
 
 Directus and Sanity take fundamentally different approaches: database wrapper vs cloud-native SaaS. SonicJS offers a third path with edge-first architecture. Here's how they compare.
 

--- a/www/content/blog/comparisons/nestjs-vs-sonicjs-vs-hono.mdx
+++ b/www/content/blog/comparisons/nestjs-vs-sonicjs-vs-hono.mdx
@@ -18,7 +18,7 @@ tags:
   - "edge-computing"
   - "typescript"
 publishedAt: "2026-01-23"
-updatedAt: "2026-01-23"
+updatedAt: "2026-06-02"
 author:
   name: "SonicJS Team"
   twitter: "sonicjs"
@@ -43,6 +43,9 @@ canonical: "https://sonicjs.com/blog/nestjs-vs-sonicjs-vs-hono"
 - Hono: 14kB bundle size, handles 100k+ requests/second on Cloudflare Workers
 - SonicJS: Under 50ms global latency with zero cold starts via V8 isolates
 </TLDRBox>
+
+> 📊 **See the full feature matrix:** [SonicJS vs Payload, Strapi, Directus, Sanity & Contentful](/compare) — a side-by-side inventory of 125+ capabilities across 13 categories, from APIs and auth to i18n and pricing.
+
 
 The JavaScript backend ecosystem in 2026 has never been more diverse. Developers choosing between frameworks face a fundamental architectural decision: do you want the structure of enterprise frameworks, the raw speed of minimalist ones, or something purpose-built for the edge?
 

--- a/www/content/blog/comparisons/sanity-vs-contentful-vs-sonicjs.mdx
+++ b/www/content/blog/comparisons/sanity-vs-contentful-vs-sonicjs.mdx
@@ -16,7 +16,7 @@ tags:
   - "enterprise"
   - "real-time"
 publishedAt: "2026-01-23"
-updatedAt: "2026-01-23"
+updatedAt: "2026-06-02"
 author:
   name: "SonicJS Team"
   twitter: "sonicjs"
@@ -44,6 +44,9 @@ canonical: "https://sonicjs.com/blog/comparisons/sanity-vs-contentful-vs-sonicjs
 - SonicJS: Under 50ms globally, zero cold starts
 - Both Sanity & Contentful: Usage-based pricing with escalating costs
 </TLDRBox>
+
+> 📊 **See the full feature matrix:** [SonicJS vs Payload, Strapi, Directus, Sanity & Contentful](/compare) — a side-by-side inventory of 125+ capabilities across 13 categories, from APIs and auth to i18n and pricing.
+
 
 Sanity and Contentful are two leading SaaS headless CMS platforms with overlapping enterprise focus but different strengths. SonicJS offers a fundamentally different approach with edge-first architecture.
 

--- a/www/content/blog/comparisons/sonicjs-vs-ghost.mdx
+++ b/www/content/blog/comparisons/sonicjs-vs-ghost.mdx
@@ -44,6 +44,9 @@ openGraph:
 - Both are MIT-licensed open source
 </TLDRBox>
 
+> 📊 **See the full feature matrix:** [SonicJS vs Payload, Strapi, Directus, Sanity & Contentful](/compare) — a side-by-side inventory of 125+ capabilities across 13 categories, from APIs and auth to i18n and pricing.
+
+
 If you've spent any time in the indie publishing world, you've probably bumped into [Ghost](https://ghost.org). It's a beloved, focused, beautifully-designed platform that turned writing-and-publishing into a first-class product. For a lot of newsletter-driven blogs and creator businesses, Ghost is a near-perfect fit — and we don't think anything in this post changes that.
 
 But "I want to publish a blog" and "I want to build a content-driven product" are very different sentences. Ghost is unapologetically the answer to the first one. **SonicJS** is built for the second.

--- a/www/content/blog/comparisons/sonicjs-vs-strapi.mdx
+++ b/www/content/blog/comparisons/sonicjs-vs-strapi.mdx
@@ -37,6 +37,9 @@ featuredImage:
 - Both: MIT licensed, open source
 </TLDRBox>
 
+> 📊 **See the full feature matrix:** [SonicJS vs Payload, Strapi, Directus, Sanity & Contentful](/compare) — a side-by-side inventory of 125+ capabilities across 13 categories, from APIs and auth to i18n and pricing.
+
+
 Choosing the right headless CMS is a critical decision for any project. In this comparison, we'll examine two popular options: SonicJS, an edge-first CMS built for Cloudflare Workers, and Strapi, the established open-source headless CMS.
 
 ## Quick Comparison

--- a/www/content/blog/comparisons/sonicjs-vs-wordpress.mdx
+++ b/www/content/blog/comparisons/sonicjs-vs-wordpress.mdx
@@ -46,6 +46,9 @@ openGraph:
 - WordPress core uses PHP + MySQL/MariaDB; SonicJS uses TypeScript + Cloudflare D1
 </TLDRBox>
 
+> 📊 **See the full feature matrix:** [SonicJS vs Payload, Strapi, Directus, Sanity & Contentful](/compare) — a side-by-side inventory of 125+ capabilities across 13 categories, from APIs and auth to i18n and pricing.
+
+
 WordPress and SonicJS sit at opposite ends of the CMS spectrum. WordPress is the mature, ecosystem-rich, "anyone can run a site" platform that has been refined over more than two decades. SonicJS is a modern, edge-first, code-first headless CMS designed for developers who want full control of their stack and sub-50ms responses worldwide.
 
 This post is not a takedown — WordPress is a serious, capable platform, and pretending otherwise would be silly. But the two tools are optimized for very different jobs. Below, we'll compare them honestly across architecture, performance, hosting cost, scalability, content modeling, security, and developer ergonomics, and give you a clear "when to choose which" at the end.

--- a/www/content/blog/comparisons/strapi-vs-contentful-vs-sonicjs.mdx
+++ b/www/content/blog/comparisons/strapi-vs-contentful-vs-sonicjs.mdx
@@ -16,7 +16,7 @@ tags:
   - "enterprise"
   - "open-source"
 publishedAt: "2026-01-23"
-updatedAt: "2026-01-23"
+updatedAt: "2026-06-02"
 author:
   name: "SonicJS Team"
   twitter: "sonicjs"
@@ -44,6 +44,9 @@ canonical: "https://sonicjs.com/blog/comparisons/strapi-vs-contentful-vs-sonicjs
 - SonicJS: Under 50ms globally, zero cold starts
 - Contentful Premium: $60,000/year list price
 </TLDRBox>
+
+> 📊 **See the full feature matrix:** [SonicJS vs Payload, Strapi, Directus, Sanity & Contentful](/compare) — a side-by-side inventory of 125+ capabilities across 13 categories, from APIs and auth to i18n and pricing.
+
 
 Strapi and Contentful represent two ends of the headless CMS spectrum: self-hosted open source vs managed enterprise SaaS. SonicJS offers a third path: edge-first architecture with the benefits of both.
 

--- a/www/content/blog/comparisons/strapi-vs-directus-vs-sonicjs.mdx
+++ b/www/content/blog/comparisons/strapi-vs-directus-vs-sonicjs.mdx
@@ -18,7 +18,7 @@ tags:
   - "edge-computing"
   - "open-source"
 publishedAt: "2026-01-23"
-updatedAt: "2026-01-23"
+updatedAt: "2026-06-02"
 author:
   name: "SonicJS Team"
   twitter: "sonicjs"
@@ -45,6 +45,9 @@ canonical: "https://sonicjs.com/blog/strapi-vs-directus-vs-sonicjs"
 - Strapi v5: Content versioning requires paid plan ($99+/month)
 - Directus: Supports 6 database types vs Strapi's 4
 </TLDRBox>
+
+> 📊 **See the full feature matrix:** [SonicJS vs Payload, Strapi, Directus, Sanity & Contentful](/compare) — a side-by-side inventory of 125+ capabilities across 13 categories, from APIs and auth to i18n and pricing.
+
 
 If you're searching "Strapi vs Directus," you're likely evaluating the two most popular open-source headless CMS options. Both are excellent projects with years of production use. But in 2025, there's a third option worth considering: edge-first architecture.
 

--- a/www/content/blog/comparisons/strapi-vs-payload-vs-sonicjs.mdx
+++ b/www/content/blog/comparisons/strapi-vs-payload-vs-sonicjs.mdx
@@ -18,7 +18,7 @@ tags:
   - "edge-computing"
   - "typescript"
 publishedAt: "2026-01-23"
-updatedAt: "2026-01-23"
+updatedAt: "2026-06-02"
 author:
   name: "SonicJS Team"
   twitter: "sonicjs"
@@ -45,6 +45,9 @@ canonical: "https://sonicjs.com/blog/strapi-vs-payload-vs-sonicjs"
 - Strapi v5 migration: 50+ breaking changes documented
 - Payload: 15x slower than Mongoose for populated queries (GitHub Issue #11325)
 </TLDRBox>
+
+> 📊 **See the full feature matrix:** [SonicJS vs Payload, Strapi, Directus, Sanity & Contentful](/compare) — a side-by-side inventory of 125+ capabilities across 13 categories, from APIs and auth to i18n and pricing.
+
 
 Choosing a headless CMS in 2025 is harder than ever. The ecosystem has matured, but with maturity comes complexity, pricing tiers, and the dreaded migration headaches that can consume weeks of developer time.
 

--- a/www/content/blog/comparisons/strapi-vs-sanity-vs-sonicjs.mdx
+++ b/www/content/blog/comparisons/strapi-vs-sanity-vs-sonicjs.mdx
@@ -14,7 +14,7 @@ tags:
   - "comparison"
   - "headless-cms"
 publishedAt: "2026-01-23"
-updatedAt: "2026-01-23"
+updatedAt: "2026-06-02"
 author:
   name: "SonicJS Team"
   twitter: "sonicjs"
@@ -42,6 +42,9 @@ canonical: "https://sonicjs.com/blog/comparisons/strapi-vs-sanity-vs-sonicjs"
 - Sanity: Custom roles only on $949/month enterprise plan
 - SonicJS: 100k requests/day free, then $5/month flat
 </TLDRBox>
+
+> 📊 **See the full feature matrix:** [SonicJS vs Payload, Strapi, Directus, Sanity & Contentful](/compare) — a side-by-side inventory of 125+ capabilities across 13 categories, from APIs and auth to i18n and pricing.
+
 
 Choosing between Strapi, Sanity, and SonicJS? Each takes a fundamentally different approach to content management. This comparison breaks down the real-world differences based on developer feedback, production experiences, and architectural trade-offs.
 

--- a/www/package.json
+++ b/www/package.json
@@ -8,8 +8,8 @@
     "npm": ">=10.0.0"
   },
   "scripts": {
-    "predev": "node scripts/generate-sections.mjs",
-    "dev": "next dev -p 3010",
+    "predev": "kill -9 $(lsof -ti:3010) 2>/dev/null || true; node scripts/generate-sections.mjs",
+    "dev": "next dev --webpack -p 3010",
     "prebuild": "node scripts/generate-sections.mjs",
     "build": "next build --webpack",
     "start": "next start -p 3010",

--- a/www/src/app/compare/layout.tsx
+++ b/www/src/app/compare/layout.tsx
@@ -1,0 +1,61 @@
+import { Metadata } from 'next'
+import { CompareStructuredData } from './structured-data'
+
+export const metadata: Metadata = {
+  title: 'Headless CMS Comparison: SonicJS vs Payload, Strapi, Directus, Sanity & Contentful',
+  description:
+    'A side-by-side comparison of SonicJS, Payload, Strapi, Directus, Sanity, and Contentful across 125+ features — architecture, pricing, content modeling, APIs, auth, media, i18n, and performance. See how an edge-native CMS stacks up against the Node.js and SaaS incumbents.',
+  keywords: [
+    'sonicjs vs strapi',
+    'sonicjs vs payload',
+    'sonicjs vs directus',
+    'sonicjs vs sanity',
+    'sonicjs vs contentful',
+    'payload vs strapi',
+    'strapi vs directus',
+    'sanity vs contentful',
+    'headless cms comparison',
+    'best headless cms 2026',
+    'strapi alternative',
+    'payload cms alternative',
+    'directus alternative',
+    'contentful alternative',
+    'sanity alternative',
+    'edge headless cms',
+    'open source cms comparison',
+  ],
+  alternates: {
+    canonical: '/compare',
+  },
+  openGraph: {
+    title: 'SonicJS vs Payload, Strapi, Directus, Sanity & Contentful',
+    description:
+      'Side-by-side headless CMS comparison: 125 features across architecture, pricing, APIs, auth, and performance.',
+    url: '/compare',
+    type: 'article',
+    images: [
+      {
+        url: '/sonicjs-og.png',
+        width: 1792,
+        height: 1024,
+        alt: 'SonicJS vs Payload vs Strapi vs Directus comparison',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'SonicJS vs Payload, Strapi, Directus, Sanity & Contentful',
+    description:
+      'Side-by-side headless CMS comparison: 125 features across architecture, pricing, APIs, auth, and performance.',
+    images: ['/sonicjs-og.png'],
+  },
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <CompareStructuredData />
+      {children}
+    </>
+  )
+}

--- a/www/src/app/compare/page.mdx
+++ b/www/src/app/compare/page.mdx
@@ -1,0 +1,104 @@
+import { ComparisonMatrix } from '@/components/ComparisonMatrix'
+
+# Headless CMS Comparison: SonicJS vs Payload, Strapi, Directus, Sanity & Contentful
+
+These six are among the most popular headless CMSs — but they make very different trade-offs. **SonicJS** runs on **Cloudflare Workers** with a **D1 (SQLite)** database. **Payload, Strapi, and Directus** are mature, self-hostable **Node.js** platforms. **Sanity and Contentful** are hosted **SaaS** content platforms with deep enterprise features but no self-hosting and significant plan-gating. The table below is a full inventory of 125+ capabilities across 13 categories — meant as an honest reference, including the many places where the others are still ahead of SonicJS.
+
+<ComparisonMatrix />
+
+## How to read this
+
+The matrix isn't scored or weighted — pick the rows that matter for *your* project. A few things worth knowing as context:
+
+### Architecture is the real fork in the road
+
+SonicJS compiles to Cloudflare Workers, so there's no server to keep warm — cold starts are effectively **0–5 ms** and reads are served from the global edge. Payload, Strapi, and Directus run as Node.js processes you host in a single region — flexible on database choice and battle-tested, but cold starts and global latency depend on your infrastructure. Directus is **database-first** (it layers onto an existing SQL database). **Sanity and Contentful** sidestep hosting entirely: their content lives in a managed cloud delivered over a global CDN, so you never run a server — but you also can't self-host, and you're billed per seat/usage.
+
+### Feature maturity: the incumbents lead in many areas
+
+This is the honest part. Compared to SonicJS, the older platforms ship a number of things SonicJS **doesn't have yet or only partially supports** — most notably **GraphQL**, **real-time/WebSockets**, **internationalization**, **soft-delete/trash**, **conditional fields**, an **official SDK**, **SSO/SAML**, and **richer relationship modeling**. Directus in particular is very deep (Flows automation, Insights dashboards, GraphQL subscriptions). Strapi and Directus also have far larger ecosystems and longer track records.
+
+### Where SonicJS is differentiated
+
+Its edge-native runtime (sub-50ms global reads, near-zero cold starts), built-in three-tier caching, and the fact that everything ships in the open-source core with no paywalls. Note the trade-offs that come with the edge model: a single database engine (D1/SQLite) and Cloudflare-only hosting rather than run-anywhere Docker.
+
+### Pricing & feature gating
+
+The self-hostable four are free to run (Directus requires a commercial license above $5M revenue). What's gated differs: **Strapi** puts version history, scheduled publishing, Live Preview, audit logs, advanced RBAC, and SSO behind paid Growth/Enterprise tiers; **Payload** is fully open-source (managed Cloud currently paused post-Figma-acquisition); **Directus** is source-available with a small-org grant; **SonicJS** has no feature paywalls and runs on Cloudflare's free tier. The two SaaS platforms gate more heavily: **Sanity** charges per seat and gates SSO, custom roles, comments, and content releases; **Contentful** has a usable free tier but reserves scheduled publishing, workflows, SSO, RBAC, and visual editing for plans starting around $300/mo.
+
+## Which should you pick?
+
+<div className="grid grid-cols-1 md:grid-cols-3 gap-4 my-8 not-prose">
+  <div className="p-5 rounded-xl border border-blue-200 dark:border-blue-800 bg-blue-50/50 dark:bg-blue-900/20">
+    <h3 className="font-bold text-gray-900 dark:text-white mb-2">Choose SonicJS if…</h3>
+    <ul className="text-sm text-gray-600 dark:text-gray-300 space-y-1 list-disc pl-5">
+      <li>You want global edge performance with near-zero cold starts</li>
+      <li>You're already on (or moving to) Cloudflare</li>
+      <li>You want every feature free, with no per-seat or Enterprise gating</li>
+      <li>You value AI-agent-ready docs and a TypeScript-first codebase</li>
+    </ul>
+  </div>
+  <div className="p-5 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50/50 dark:bg-gray-800/30">
+    <h3 className="font-bold text-gray-900 dark:text-white mb-2">Choose Payload / Strapi / Directus if…</h3>
+    <ul className="text-sm text-gray-600 dark:text-gray-300 space-y-1 list-disc pl-5">
+      <li>You need GraphQL or real-time today</li>
+      <li>You depend on Postgres, MySQL, or MongoDB specifically</li>
+      <li>You want a large ecosystem and the control of self-hosting</li>
+      <li>Your traffic is regional and edge latency isn't a priority</li>
+    </ul>
+  </div>
+  <div className="p-5 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50/50 dark:bg-gray-800/30">
+    <h3 className="font-bold text-gray-900 dark:text-white mb-2">Choose Sanity / Contentful if…</h3>
+    <ul className="text-sm text-gray-600 dark:text-gray-300 space-y-1 list-disc pl-5">
+      <li>You'd rather not run any infrastructure at all</li>
+      <li>You need enterprise governance (audit, SSO, workflows) and have budget</li>
+      <li>Sanity: real-time multiplayer editing and GROQ matter to you</li>
+      <li>Contentful: you're standardizing a large org on a composable platform</li>
+    </ul>
+  </div>
+</div>
+
+<div className="flex flex-col sm:flex-row gap-4 my-8 not-prose">
+  <Button href="/quickstart" arrow="right">
+    <>Try SonicJS in 60 seconds</>
+  </Button>
+  <Button href="/architecture" variant="outline">
+    <>Read the architecture</>
+  </Button>
+</div>
+
+## Deep-dive comparisons
+
+Want a closer look at a specific matchup? These guides go beyond the matrix with benchmarks, migration notes, and real-world developer feedback:
+
+- [SonicJS vs Strapi](/blog/sonicjs-vs-strapi)
+- [Strapi vs Payload vs SonicJS](/blog/strapi-vs-payload-vs-sonicjs)
+- [Directus vs Payload vs SonicJS](/blog/directus-vs-payload-vs-sonicjs)
+- [Strapi vs Directus vs SonicJS](/blog/strapi-vs-directus-vs-sonicjs)
+- [Sanity vs Contentful vs SonicJS](/blog/sanity-vs-contentful-vs-sonicjs)
+- [Strapi vs Contentful vs SonicJS](/blog/strapi-vs-contentful-vs-sonicjs)
+- [Browse all CMS comparisons →](/blog/category/comparisons)
+
+## Frequently asked questions
+
+### Is SonicJS a good alternative to Strapi, Payload, or Directus?
+
+SonicJS is a strong fit when you want an edge-native CMS on Cloudflare Workers with near-zero cold starts and no feature paywalls. The Node.js incumbents (Payload, Strapi, Directus) are more mature and still lead in areas like GraphQL, internationalization, real-time, and database flexibility — several of which are on the SonicJS [roadmap](/roadmap). Pick based on whether edge performance or breadth of features matters more for your project.
+
+### Which headless CMS is the fastest?
+
+Architecturally, SonicJS has the lowest cold start (0–5 ms) because it runs on Cloudflare Workers at the edge rather than a single-region Node.js server, so reads are served close to users worldwide. Payload, Strapi, and Directus performance depends on your hosting and caching setup. Real-world numbers vary by workload, so benchmark for your own use case.
+
+### Which of these headless CMSs are free and open source?
+
+SonicJS, Payload, Strapi, and Directus are all self-hostable. SonicJS and Payload are MIT licensed. Strapi's Community edition is MIT but gates features like version history, scheduled publishing, Live Preview, audit logs, advanced RBAC, and SSO behind paid tiers. Directus uses the source-available MSCL license (free under $5M revenue). Sanity and Contentful are **hosted SaaS** — only Sanity's Studio editor is open source (MIT); their content backends are proprietary and can't be self-hosted, and Contentful is fully closed-source.
+
+### Does SonicJS support GraphQL and internationalization (i18n)?
+
+Not yet — GraphQL and i18n are on the SonicJS roadmap. Today SonicJS ships a REST API with an OpenAPI spec. Payload, Strapi, and Directus all offer GraphQL and i18n today (Directus also offers GraphQL subscriptions and real-time over WebSockets).
+
+### Which headless CMS should I choose?
+
+Choose SonicJS for global edge performance on Cloudflare with everything in the free core. Choose Payload for a Next.js-native, deeply typed developer experience. Choose Strapi for the largest plugin ecosystem and a mature admin. Choose Directus to layer a CMS and visual automation onto an existing SQL database. Choose Sanity for real-time multiplayer editing and the GROQ query language, or Contentful for an enterprise-grade composable platform you don't have to operate. The feature matrix above breaks down all six across 125+ capabilities.
+
+> Spot something out of date? Competitor pricing and features change fast. Open an issue or PR on [GitHub](https://github.com/lane711/sonicjs) and we'll correct it.

--- a/www/src/app/compare/structured-data.tsx
+++ b/www/src/app/compare/structured-data.tsx
@@ -1,0 +1,60 @@
+// JSON-LD structured data for the /compare page.
+// The FAQ entries below MUST stay in sync with the visible FAQ section in
+// page.mdx — Google requires FAQPage markup to match on-page content.
+
+const FAQ: { q: string; a: string }[] = [
+  {
+    q: 'Is SonicJS a good alternative to Strapi, Payload, or Directus?',
+    a: 'SonicJS is a strong fit when you want an edge-native CMS on Cloudflare Workers with near-zero cold starts and no feature paywalls. The Node.js incumbents (Payload, Strapi, Directus) are more mature and still lead in areas like GraphQL, internationalization, real-time, and database flexibility — several of which are on the SonicJS roadmap. Pick based on whether edge performance or breadth of features matters more for your project.',
+  },
+  {
+    q: 'Which headless CMS is the fastest?',
+    a: 'Architecturally, SonicJS has the lowest cold start (0–5 ms) because it runs on Cloudflare Workers at the edge rather than a single-region Node.js server, so reads are served close to users worldwide. Payload, Strapi, and Directus performance depends on your hosting and caching setup. Real-world numbers vary by workload, so benchmark for your own use case.',
+  },
+  {
+    q: 'Which of these headless CMSs are free and open source?',
+    a: 'SonicJS, Payload, Strapi, and Directus are all self-hostable. SonicJS and Payload are MIT licensed. Strapi’s Community edition is MIT but gates features like version history, scheduled publishing, Live Preview, audit logs, advanced RBAC, and SSO behind paid tiers. Directus uses the source-available MSCL license (free under $5M revenue). Sanity and Contentful are hosted SaaS — only Sanity’s Studio editor is open source; their content backends are proprietary and cannot be self-hosted, and Contentful is fully closed-source.',
+  },
+  {
+    q: 'Does SonicJS support GraphQL and internationalization (i18n)?',
+    a: 'Not yet — GraphQL and i18n are on the SonicJS roadmap. Today SonicJS ships a REST API with an OpenAPI spec. Payload, Strapi, and Directus all offer GraphQL and i18n today (Directus also offers GraphQL subscriptions and real-time over WebSockets).',
+  },
+  {
+    q: 'Which headless CMS should I choose?',
+    a: 'Choose SonicJS for global edge performance on Cloudflare with everything in the free core. Choose Payload for a Next.js-native, deeply typed developer experience. Choose Strapi for the largest plugin ecosystem and a mature admin. Choose Directus to layer a CMS and visual automation onto an existing SQL database. Choose Sanity for real-time multiplayer editing and the GROQ query language, or Contentful for an enterprise-grade composable platform you don’t have to operate. The feature matrix on this page breaks down all six across 125+ capabilities.',
+  },
+]
+
+export function CompareStructuredData() {
+  const breadcrumb = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://sonicjs.com' },
+      { '@type': 'ListItem', position: 2, name: 'Compare', item: 'https://sonicjs.com/compare' },
+    ],
+  }
+
+  const faqPage = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: FAQ.map(({ q, a }) => ({
+      '@type': 'Question',
+      name: q,
+      acceptedAnswer: { '@type': 'Answer', text: a },
+    })),
+  }
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPage) }}
+      />
+    </>
+  )
+}

--- a/www/src/app/layout.tsx
+++ b/www/src/app/layout.tsx
@@ -9,6 +9,7 @@ import '@/styles/tailwind.css'
 import allSections from './allSections.json'
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://sonicjs.com'),
   title: {
     template: '%s | SonicJS Docs',
     default: 'SonicJS - Modern Headless CMS for Cloudflare Workers',

--- a/www/src/app/sitemap.ts
+++ b/www/src/app/sitemap.ts
@@ -43,6 +43,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     // Examples and guides
     { url: '/examples', priority: 0.7, changeFrequency: 'weekly' as const },
 
+    // Comparison / evaluation - high priority (search-intent landing page)
+    { url: '/compare', priority: 0.8, changeFrequency: 'monthly' as const },
+
     // Community and support
     { url: '/faq', priority: 0.6, changeFrequency: 'weekly' as const },
     { url: '/community', priority: 0.6, changeFrequency: 'monthly' as const },

--- a/www/src/components/Code.tsx
+++ b/www/src/components/Code.tsx
@@ -142,7 +142,12 @@ function CodePanel({
   label?: string
   code?: string
 }) {
-  let child = Children.only(children)
+  // MDX can hand us more than a single child here (e.g. stray whitespace
+  // text nodes around the <code> element), which makes Children.only throw and
+  // 500s the page. Pick the first real element instead; the `code` prop is
+  // supplied on the <pre> by rehypeShiki regardless, so the copy button and
+  // highlighting still work.
+  let child = Children.toArray(children).find(isValidElement)
 
   if (isValidElement(child)) {
     const props = child.props as { tag?: string; label?: string; code?: string }

--- a/www/src/components/ComparisonMatrix.tsx
+++ b/www/src/components/ComparisonMatrix.tsx
@@ -296,7 +296,7 @@ function LegendItem({ swatch, label }: { swatch: React.ReactNode; label: string 
 
 export function ComparisonMatrix() {
   return (
-    <div className="not-prose my-10">
+    <div className="not-prose my-10 w-full lg:!mx-0 lg:!max-w-none">
       <div className="mb-4 flex flex-wrap gap-x-5 gap-y-2 text-xs">
         <LegendItem swatch={<span className="font-bold text-emerald-500">✓</span>} label="Built-in" />
         <LegendItem swatch={<span className="text-gray-300 dark:text-gray-600">✗</span>} label="Not supported" />
@@ -305,18 +305,21 @@ export function ComparisonMatrix() {
         <LegendItem swatch={<span className="text-xs font-semibold text-rose-600 dark:text-rose-400">Paid</span>} label="Paid / enterprise tier" />
         <LegendItem swatch={<span className="text-xs font-semibold text-blue-600 dark:text-blue-400">Roadmap</span>} label="Planned, not shipped" />
       </div>
+      <p className="mb-2 text-right text-xs text-gray-400 dark:text-gray-500 xl:hidden">
+        6 products compared — scroll the table sideways to see Sanity &amp; Contentful →
+      </p>
       <div className="overflow-x-auto rounded-xl border border-gray-200 dark:border-gray-800">
-        <table className="w-full min-w-[1040px] border-collapse text-left">
+        <table className="w-full min-w-[920px] border-collapse text-left">
           <thead>
             <tr className="bg-gradient-to-r from-blue-50 to-purple-50 dark:from-blue-900/30 dark:to-purple-900/30">
-              <th className="sticky left-0 z-10 bg-gradient-to-r from-blue-50 to-purple-50 p-3 text-sm font-bold text-gray-900 dark:from-blue-900/30 dark:to-purple-900/30 dark:text-white">
+              <th className="sticky left-0 z-10 bg-gradient-to-r from-blue-50 to-purple-50 px-2.5 py-2.5 text-sm font-bold text-gray-900 dark:from-blue-900/30 dark:to-purple-900/30 dark:text-white">
                 Capability
               </th>
               {PRODUCTS.map((p, i) => (
                 <th
                   key={p}
                   className={clsx(
-                    'p-3 text-center text-sm font-bold',
+                    'px-2.5 py-2.5 text-center text-sm font-bold',
                     i === 0
                       ? 'bg-blue-100/60 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
                       : 'text-gray-600 dark:text-gray-400',
@@ -343,13 +346,13 @@ export function ComparisonMatrix() {
                     key={section.title + row.label}
                     className="border-t border-gray-100 hover:bg-gray-50/70 dark:border-gray-800 dark:hover:bg-gray-800/40"
                   >
-                    <td className="sticky left-0 z-10 bg-white p-3 text-xs font-medium text-gray-900 dark:bg-gray-950 dark:text-white">
+                    <td className="sticky left-0 z-10 bg-white px-2.5 py-2.5 text-xs font-medium text-gray-900 dark:bg-gray-950 dark:text-white">
                       {row.label}
                     </td>
                     {row.cells.map((cell, i) => (
                       <td
                         key={i}
-                        className={clsx('p-3 text-center align-middle', i === 0 && 'bg-blue-50/40 dark:bg-blue-900/10')}
+                        className={clsx('px-2.5 py-2.5 text-center align-middle', i === 0 && 'bg-blue-50/40 dark:bg-blue-900/10')}
                       >
                         <CellContent cell={cell} highlight={i === 0} />
                       </td>

--- a/www/src/components/ComparisonMatrix.tsx
+++ b/www/src/components/ComparisonMatrix.tsx
@@ -1,0 +1,375 @@
+import { Fragment } from 'react'
+import clsx from 'clsx'
+
+/**
+ * Detailed feature-comparison matrix between SonicJS and other headless CMSs.
+ *
+ * Cell values are either a plain string (rendered as text) or one of the
+ * sentinel marks below:
+ *   yes            → built into core, no extra cost
+ *   no             → not supported
+ *   partial(note)  → limited / requires custom code / not first-class
+ *   plugin(note)   → available via an official/bundled plugin or adapter
+ *   paid(note)     → only in a paid / enterprise / cloud tier
+ *   soon(note)     → on the SonicJS roadmap, not yet shipped
+ *
+ * This is intended as an honest, exhaustive inventory for evaluating gaps —
+ * not a marketing piece. SonicJS is rated from its source/docs; competitors
+ * from their official docs, GitHub, and pricing pages. Sanity and Contentful
+ * are SaaS content platforms, so "self-hostable" rows are honestly No and many
+ * features are plan-gated.
+ *
+ * Data last verified June 2026. Update LAST_VERIFIED when refreshed.
+ */
+
+const LAST_VERIFIED = 'June 2026'
+
+type Mark = {
+  kind: 'yes' | 'no' | 'partial' | 'plugin' | 'paid' | 'soon'
+  note?: string
+}
+type Cell = string | Mark
+
+const yes: Mark = { kind: 'yes' }
+const no: Mark = { kind: 'no' }
+const partial = (note?: string): Mark => ({ kind: 'partial', note })
+const plugin = (note?: string): Mark => ({ kind: 'plugin', note })
+const paid = (note?: string): Mark => ({ kind: 'paid', note })
+const soon = (note?: string): Mark => ({ kind: 'soon', note })
+
+// Column order — SonicJS first and visually highlighted.
+const PRODUCTS = ['SonicJS', 'Payload', 'Strapi', 'Directus', 'Sanity', 'Contentful'] as const
+
+interface Row {
+  label: string
+  // [SonicJS, Payload, Strapi, Directus, Sanity, Contentful]
+  cells: [Cell, Cell, Cell, Cell, Cell, Cell]
+}
+
+interface Section {
+  title: string
+  rows: Row[]
+}
+
+const SECTIONS: Section[] = [
+  {
+    title: 'Architecture & Runtime',
+    rows: [
+      { label: 'Runtime', cells: ['Cloudflare Workers', 'Node.js', 'Node.js', 'Node.js', 'Hosted SaaS', 'Hosted SaaS'] },
+      { label: 'Deployment model', cells: ['Global edge', 'Single-region', 'Single-region', 'Single-region', 'Managed SaaS', 'Managed SaaS'] },
+      { label: 'Edge / serverless runtime', cells: [yes, partial('Vercel'), no, no, partial('CDN'), partial('CDN')] },
+      { label: 'Database', cells: ['D1 (SQLite)', 'Postgres · Mongo', 'Postgres · MySQL', 'Postgres · +5', 'Content Lake', 'Proprietary'] },
+      { label: 'Data layer / ORM', cells: ['Drizzle', 'Drizzle · Mongoose', 'Knex', 'Knex', 'GROQ', '—'] },
+      { label: 'Typical cold start', cells: ['0–5 ms', '100–300 ms', '500–2000 ms', '300–1000 ms', 'n/a', 'n/a'] },
+      { label: 'Global edge distribution', cells: [yes, no, no, no, yes, yes] },
+      { label: 'Built-in caching', cells: ['3-tier', partial('Manual'), partial('Plugin'), partial('Cache'), 'API CDN', 'API CDN'] },
+      { label: 'Auto-scaling', cells: [yes, partial('Infra'), partial('Infra'), partial('Infra'), yes, yes] },
+      { label: 'Self-hostable anywhere', cells: [partial('CF only'), yes, yes, yes, no, no] },
+      { label: 'Docker support', cells: [no, yes, yes, yes, no, no] },
+      { label: 'Official managed cloud', cells: [no, paid('Paused'), paid(), paid(), yes, yes] },
+    ],
+  },
+  {
+    title: 'Pricing & Licensing',
+    rows: [
+      { label: 'License', cells: ['MIT', 'MIT', 'MIT (+ EE)', 'MSCL', 'MIT / SaaS', 'Proprietary'] },
+      { label: 'Free to self-host', cells: [yes, yes, yes, partial('<$5M rev'), no, no] },
+      { label: 'Free cloud tier', cells: [partial('CF free tier'), no, no, no, yes, yes] },
+      { label: 'Paid cloud entry price', cells: ['Free / ~$5', '$35+/mo', '$15+/mo', '$25+/mo', '$15/seat', '~$300/mo'] },
+      { label: 'Features behind paywall', cells: [no, no, paid('Several'), partial('Some'), paid('Several'), paid('Many')] },
+    ],
+  },
+  {
+    title: 'Content Modeling',
+    rows: [
+      { label: 'Collections / content types', cells: [yes, yes, yes, yes, yes, yes] },
+      { label: 'Single types / globals', cells: [partial(), yes, yes, partial(), yes, partial()] },
+      { label: 'Repeatable / array fields', cells: [yes, yes, yes, yes, yes, yes] },
+      { label: 'Reusable component / group fields', cells: [yes, yes, yes, partial(), yes, partial()] },
+      { label: 'Blocks / dynamic zones', cells: [yes, yes, yes, partial(), yes, yes] },
+      { label: 'One-to-one relationships', cells: [partial(), yes, yes, yes, yes, yes] },
+      { label: 'One-to-many relationships', cells: [yes, yes, yes, yes, yes, yes] },
+      { label: 'Many-to-many relationships', cells: [partial(), yes, yes, yes, yes, yes] },
+      { label: 'Polymorphic relationships', cells: [partial(), yes, partial(), yes, yes, yes] },
+      { label: 'Conditional field logic', cells: [no, yes, yes, yes, yes, no] },
+      { label: 'Field-level validation', cells: [yes, yes, yes, yes, yes, yes] },
+      { label: 'Computed / virtual fields', cells: [no, partial(), partial(), partial(), partial(), no] },
+      { label: 'Rich text editor', cells: ['TinyMCE', 'Lexical', 'CKEditor', 'TinyMCE', 'Portable Text', 'Rich Text'] },
+      { label: 'Markdown field', cells: [yes, partial(), yes, yes, plugin(), yes] },
+      { label: 'JSON field', cells: [yes, yes, yes, yes, partial(), yes] },
+      { label: 'Custom field types', cells: [partial(), yes, yes, plugin(), yes, plugin()] },
+      { label: 'UI / presentational fields', cells: [no, yes, partial(), yes, partial(), partial()] },
+      { label: 'Field-level localization', cells: [soon(), yes, yes, yes, plugin(), yes] },
+      { label: 'Built-in field types (approx.)', cells: ['~21', '~22', '~15', '~25', '~13', '~12'] },
+    ],
+  },
+  {
+    title: 'Content Management & Editorial',
+    rows: [
+      { label: 'Draft & publish', cells: [yes, yes, yes, yes, yes, yes] },
+      { label: 'Version history / revisions', cells: [yes, yes, paid(), yes, partial('3-day free'), yes] },
+      { label: 'Autosave', cells: [yes, yes, no, no, yes, yes] },
+      { label: 'Scheduled publishing', cells: [yes, yes, paid(), partial('Flows'), paid(), paid()] },
+      { label: 'Live preview', cells: [yes, yes, paid(), yes, yes, partial()] },
+      { label: 'Editorial workflow / review stages', cells: [yes, partial(), paid(), partial(), partial(), paid()] },
+      { label: 'Bulk edit / delete', cells: [yes, yes, yes, yes, partial(), yes] },
+      { label: 'Document duplication', cells: [yes, yes, yes, yes, yes, yes] },
+      { label: 'Soft delete / trash', cells: [no, yes, no, partial(), partial(), partial()] },
+      { label: 'Concurrent edit locking', cells: [no, yes, partial(), partial(), yes, partial()] },
+      { label: 'Editorial comments', cells: [no, no, no, yes, paid(), paid()] },
+      { label: 'Real-time collaboration', cells: [no, no, no, no, yes, partial()] },
+    ],
+  },
+  {
+    title: 'APIs & Integration',
+    rows: [
+      { label: 'REST API', cells: [yes, yes, yes, yes, yes, yes] },
+      { label: 'GraphQL API', cells: [soon(), yes, plugin(), yes, yes, yes] },
+      { label: 'GraphQL subscriptions', cells: [no, no, no, yes, no, no] },
+      { label: 'Realtime / WebSockets', cells: [soon(), no, no, yes, yes, no] },
+      { label: 'Local / server-side API', cells: [yes, yes, yes, yes, no, no] },
+      { label: 'Webhooks', cells: [yes, partial('Hooks'), yes, yes, yes, yes] },
+      { label: 'Filtering / sorting / pagination', cells: [yes, yes, yes, yes, yes, yes] },
+      { label: 'Deep relationship population', cells: [partial(), yes, yes, yes, yes, yes] },
+      { label: 'Aggregation queries', cells: [no, partial(), no, yes, yes, no] },
+      { label: 'Field selection / sparse fieldsets', cells: [yes, yes, yes, yes, yes, yes] },
+      { label: 'Custom endpoints', cells: [yes, yes, yes, plugin(), partial(), plugin()] },
+      { label: 'OpenAPI / Swagger spec', cells: [yes, plugin(), yes, yes, no, partial()] },
+    ],
+  },
+  {
+    title: 'Authentication & Authorization',
+    rows: [
+      { label: 'End-user / app auth', cells: [yes, yes, yes, yes, no, no] },
+      { label: 'JWT / token auth', cells: [yes, yes, yes, yes, yes, yes] },
+      { label: 'API keys / tokens', cells: [yes, yes, yes, yes, yes, yes] },
+      { label: 'OAuth / social login', cells: [plugin(), partial(), yes, yes, yes, partial()] },
+      { label: 'SSO / SAML', cells: [soon(), paid(), paid(), yes, paid(), paid()] },
+      { label: 'Magic link', cells: [plugin(), no, no, no, yes, no] },
+      { label: 'OTP / 2FA / MFA', cells: [plugin('OTP'), plugin(), no, yes, partial(), yes] },
+      { label: 'Role-based access control', cells: [yes, yes, partial('Adv = EE'), yes, partial('2 free'), paid()] },
+      { label: 'Collection-level permissions', cells: [yes, yes, yes, yes, paid(), paid()] },
+      { label: 'Field-level permissions', cells: [yes, yes, paid(), yes, paid(), paid()] },
+      { label: 'Document / row-level access', cells: [partial(), yes, partial(), yes, paid(), paid()] },
+      { label: 'Custom access-control functions', cells: [no, yes, yes, partial(), paid(), no] },
+      { label: 'Password reset', cells: [yes, yes, yes, yes, yes, yes] },
+    ],
+  },
+  {
+    title: 'Media & Assets',
+    rows: [
+      { label: 'Media library', cells: [yes, yes, yes, yes, yes, yes] },
+      { label: 'Image resizing / transforms', cells: [yes, yes, yes, yes, yes, yes] },
+      { label: 'Focal point', cells: [no, yes, yes, yes, yes, yes] },
+      { label: 'Cloud storage adapters', cells: ['R2', yes, plugin(), yes, no, no] },
+      { label: 'File metadata', cells: [yes, yes, yes, yes, yes, yes] },
+      { label: 'Alt text / captions', cells: [yes, yes, yes, yes, partial(), partial()] },
+      { label: 'Folders / organization', cells: [yes, yes, yes, yes, partial(), partial()] },
+      { label: 'Image optimization', cells: [yes, partial(), yes, yes, yes, yes] },
+      { label: 'CDN integration', cells: [yes, partial(), partial(), partial(), yes, yes] },
+    ],
+  },
+  {
+    title: 'Internationalization',
+    rows: [
+      { label: 'Content localization (i18n)', cells: [soon(), yes, yes, yes, plugin(), yes] },
+      { label: 'Locale fallbacks', cells: [soon(), yes, no, partial(), plugin(), yes] },
+      { label: 'Admin UI translations', cells: [no, yes, yes, yes, yes, partial()] },
+      { label: 'RTL support', cells: [no, yes, partial(), yes, partial(), yes] },
+    ],
+  },
+  {
+    title: 'Admin Panel & UI',
+    rows: [
+      { label: 'Built-in admin UI', cells: ['HTMX', 'React / Next', 'React', 'Vue', 'React (Studio)', 'Web app'] },
+      { label: 'Custom components / fields', cells: [partial(), yes, yes, plugin(), yes, plugin()] },
+      { label: 'Customizable dashboard', cells: [yes, yes, partial(), yes, yes, plugin()] },
+      { label: 'Custom admin views / routes', cells: [yes, yes, yes, plugin(), yes, plugin()] },
+      { label: 'Theming / white-label', cells: [partial(), yes, partial(), partial(), partial(), paid()] },
+      { label: 'Dark mode', cells: [yes, yes, yes, yes, yes, no] },
+      { label: 'List view configuration', cells: [yes, yes, yes, yes, yes, yes] },
+      { label: 'Conditional field display', cells: [no, yes, yes, yes, yes, no] },
+    ],
+  },
+  {
+    title: 'Extensibility & Automation',
+    rows: [
+      { label: 'Plugin / extension system', cells: [yes, yes, yes, yes, yes, yes] },
+      { label: 'Lifecycle hooks', cells: [yes, yes, yes, yes, partial(), partial()] },
+      { label: 'Middleware', cells: [yes, partial(), yes, partial(), partial(), no] },
+      { label: 'Custom endpoints', cells: [yes, yes, yes, yes, partial(), plugin()] },
+      { label: 'Cron / scheduled jobs', cells: [partial(), yes, yes, yes, partial(), partial()] },
+      { label: 'Background jobs / queues', cells: [no, yes, no, partial(), no, no] },
+      { label: 'Email sending', cells: [yes, yes, plugin(), yes, no, no] },
+      { label: 'Visual automation builder', cells: [no, no, no, yes, no, paid()] },
+      { label: 'Custom CLI', cells: [no, partial(), partial(), partial(), yes, yes] },
+    ],
+  },
+  {
+    title: 'Developer Experience',
+    rows: [
+      { label: 'TypeScript support', cells: [yes, yes, yes, yes, yes, yes] },
+      { label: 'Schema as code', cells: [yes, yes, yes, yes, yes, yes] },
+      { label: 'Type generation from schema', cells: [partial(), yes, yes, partial(), yes, plugin()] },
+      { label: 'DB / content migrations', cells: [yes, yes, partial(), yes, yes, yes] },
+      { label: 'Data seeding', cells: [yes, partial(), partial(), partial(), partial(), partial()] },
+      { label: 'CLI scaffolding', cells: [yes, yes, yes, yes, yes, partial()] },
+      { label: 'Official JS / TS SDK', cells: [no, yes, yes, yes, yes, yes] },
+      { label: 'API playground / docs UI', cells: [yes, partial(), yes, partial(), yes, yes] },
+    ],
+  },
+  {
+    title: 'Security & Operations',
+    rows: [
+      { label: 'Rate limiting', cells: [yes, partial(), partial(), yes, yes, yes] },
+      { label: 'CSRF protection', cells: [yes, yes, partial(), partial(), yes, partial()] },
+      { label: 'CORS config', cells: [yes, yes, yes, yes, yes, yes] },
+      { label: 'Audit logs', cells: [yes, partial(), paid(), yes, paid(), paid()] },
+      { label: 'Field encryption', cells: [no, partial(), no, no, no, no] },
+      { label: 'GDPR / data-export tools', cells: [partial(), partial(), partial(), yes, partial(), yes] },
+      { label: 'Bot protection (CAPTCHA)', cells: [plugin('Turnstile'), no, no, no, partial(), partial()] },
+      { label: 'Database transactions', cells: [yes, yes, yes, yes, yes, no] },
+      { label: 'Multi-tenancy', cells: [partial(), plugin(), no, partial(), partial(), yes] },
+    ],
+  },
+  {
+    title: 'Ecosystem & Maturity',
+    rows: [
+      { label: 'First released', cells: ['2018', '2021', '2015', '2012', '2017', '2013'] },
+      { label: 'GitHub stars (approx.)', cells: ['~1.6k', '~43k', '~72k', '~36k', '~6.2k', 'Closed'] },
+      { label: 'Official plugins / marketplace', cells: ['~25 bundled', '~10 official', 'Marketplace', 'Marketplace', 'Marketplace', 'Marketplace'] },
+      { label: 'Visual page builder', cells: [no, partial(), no, partial(), partial(), paid()] },
+      { label: 'Built-in AI features', cells: [yes, no, paid(), no, partial(), paid()] },
+    ],
+  },
+]
+
+const MARK_STYLES: Record<Mark['kind'], { label: string; className: string } | null> = {
+  yes: null,
+  no: null,
+  partial: { label: 'Partial', className: 'text-amber-600 dark:text-amber-400' },
+  plugin: { label: 'Plugin', className: 'text-violet-600 dark:text-violet-400' },
+  paid: { label: 'Paid', className: 'text-rose-600 dark:text-rose-400' },
+  soon: { label: 'Roadmap', className: 'text-blue-600 dark:text-blue-400' },
+}
+
+function MarkCell({ mark }: { mark: Mark }) {
+  if (mark.kind === 'yes') {
+    return <span className="text-lg font-bold text-emerald-500 dark:text-emerald-400">✓</span>
+  }
+  if (mark.kind === 'no') {
+    return <span className="text-lg text-gray-300 dark:text-gray-600">✗</span>
+  }
+  const style = MARK_STYLES[mark.kind]!
+  return (
+    <span className="inline-flex flex-col items-center leading-tight">
+      <span className={clsx('text-xs font-semibold', style.className)}>{style.label}</span>
+      {mark.note && <span className="text-[10px] text-gray-400 dark:text-gray-500">{mark.note}</span>}
+    </span>
+  )
+}
+
+function CellContent({ cell, highlight }: { cell: Cell; highlight: boolean }) {
+  if (typeof cell === 'string') {
+    return (
+      <span
+        className={clsx(
+          'text-xs',
+          highlight ? 'font-semibold text-blue-700 dark:text-blue-300' : 'text-gray-600 dark:text-gray-300',
+        )}
+      >
+        {cell}
+      </span>
+    )
+  }
+  return <MarkCell mark={cell} />
+}
+
+function LegendItem({ swatch, label }: { swatch: React.ReactNode; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      {swatch}
+      <span className="text-gray-600 dark:text-gray-400">{label}</span>
+    </span>
+  )
+}
+
+export function ComparisonMatrix() {
+  return (
+    <div className="not-prose my-10">
+      <div className="mb-4 flex flex-wrap gap-x-5 gap-y-2 text-xs">
+        <LegendItem swatch={<span className="font-bold text-emerald-500">✓</span>} label="Built-in" />
+        <LegendItem swatch={<span className="text-gray-300 dark:text-gray-600">✗</span>} label="Not supported" />
+        <LegendItem swatch={<span className="text-xs font-semibold text-amber-600 dark:text-amber-400">Partial</span>} label="Limited / custom code" />
+        <LegendItem swatch={<span className="text-xs font-semibold text-violet-600 dark:text-violet-400">Plugin</span>} label="Via official plugin" />
+        <LegendItem swatch={<span className="text-xs font-semibold text-rose-600 dark:text-rose-400">Paid</span>} label="Paid / enterprise tier" />
+        <LegendItem swatch={<span className="text-xs font-semibold text-blue-600 dark:text-blue-400">Roadmap</span>} label="Planned, not shipped" />
+      </div>
+      <div className="overflow-x-auto rounded-xl border border-gray-200 dark:border-gray-800">
+        <table className="w-full min-w-[1040px] border-collapse text-left">
+          <thead>
+            <tr className="bg-gradient-to-r from-blue-50 to-purple-50 dark:from-blue-900/30 dark:to-purple-900/30">
+              <th className="sticky left-0 z-10 bg-gradient-to-r from-blue-50 to-purple-50 p-3 text-sm font-bold text-gray-900 dark:from-blue-900/30 dark:to-purple-900/30 dark:text-white">
+                Capability
+              </th>
+              {PRODUCTS.map((p, i) => (
+                <th
+                  key={p}
+                  className={clsx(
+                    'p-3 text-center text-sm font-bold',
+                    i === 0
+                      ? 'bg-blue-100/60 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
+                      : 'text-gray-600 dark:text-gray-400',
+                  )}
+                >
+                  {p}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {SECTIONS.map((section) => (
+              <Fragment key={section.title}>
+                <tr>
+                  <th
+                    colSpan={PRODUCTS.length + 1}
+                    className="bg-gray-50 px-3 py-2 text-left text-xs font-bold uppercase tracking-wider text-gray-500 dark:bg-gray-800/60 dark:text-gray-400"
+                  >
+                    {section.title}
+                  </th>
+                </tr>
+                {section.rows.map((row) => (
+                  <tr
+                    key={section.title + row.label}
+                    className="border-t border-gray-100 hover:bg-gray-50/70 dark:border-gray-800 dark:hover:bg-gray-800/40"
+                  >
+                    <td className="sticky left-0 z-10 bg-white p-3 text-xs font-medium text-gray-900 dark:bg-gray-950 dark:text-white">
+                      {row.label}
+                    </td>
+                    {row.cells.map((cell, i) => (
+                      <td
+                        key={i}
+                        className={clsx('p-3 text-center align-middle', i === 0 && 'bg-blue-50/40 dark:bg-blue-900/10')}
+                      >
+                        <CellContent cell={cell} highlight={i === 0} />
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </Fragment>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="mt-3 text-center text-xs text-gray-500 dark:text-gray-400">
+        Data last verified {LAST_VERIFIED} against each project&rsquo;s official docs, GitHub, and pricing pages.
+        Sanity and Contentful are hosted SaaS platforms, so &ldquo;self-hostable&rdquo; rows are No and several
+        features are plan-gated. Corrections welcome via{' '}
+        <a href="https://github.com/lane711/sonicjs" className="underline hover:text-gray-700 dark:hover:text-gray-300">
+          GitHub
+        </a>
+        .
+      </p>
+    </div>
+  )
+}

--- a/www/src/components/Navigation.tsx
+++ b/www/src/components/Navigation.tsx
@@ -299,6 +299,7 @@ export const navigation: Array<NavGroup> = [
     title: 'Resources',
     links: [
       { title: 'Blog', href: '/blog' },
+      { title: 'Compare', href: '/compare' },
       { title: 'Roadmap', href: '/roadmap' },
       { title: 'Examples', href: '/examples' },
       { title: 'FAQ', href: '/faq' },


### PR DESCRIPTION
## Summary

Adds **`/compare`** — an honest, exhaustive headless-CMS feature matrix comparing **SonicJS, Payload, Strapi, Directus, Sanity, and Contentful** across **125+ capabilities in 13 categories** (architecture, pricing, content modeling, editorial, APIs, auth, media, i18n, admin UI, extensibility, DX, security, ecosystem).

Framed as a neutral gap-analysis reference — it deliberately surfaces where competitors lead (GraphQL, i18n, real-time, SSO, soft-delete, etc.), not just where SonicJS wins. Competitor data was verified against official docs, GitHub, and pricing pages (June 2026); SonicJS rated from source/docs. SaaS nuances (no self-host, plan-gating) are marked honestly.

## What's included
- **`ComparisonMatrix` component** — 6-column responsive table, sticky first column, SonicJS column highlighted, with a status vocabulary + legend: ✓ Built-in · ✗ Not supported · **Partial** · **Plugin** · **Paid** · **Roadmap**.
- **`/compare` page** — intro, matrix, "how to read this", a 3-way "which should you pick?", deep-dive links, and an FAQ.
- **SEO sweep** — page title/description/keywords, **FAQPage + BreadcrumbList JSON-LD**, visible FAQ, canonical, OG/Twitter, sitemap entry (priority 0.8), and a global `metadataBase` (also fixes the OG/canonical build warning).
- **Internal linking** — cross-links `/compare` from **10 CMS comparison blog posts** (and back to them).
- **Nav** — "Compare" added to the Resources group.

## Incidental fixes (pre-existing, surfaced while running the site)
- **`Code.tsx`**: `CodePanel` used `React.Children.only`, which threw and **500'd MDX pages** (e.g. `/contributing`) in dev. Now picks the first valid element child; highlighting + copy button unaffected.
- **`package.json`**: docs dev server now runs standalone — `next dev --webpack` (Turbopack can't serialize the `@next/mdx` loader) and a port-3010 cleanup in `predev`.

## Verification
- `npm run build` (www) → exit 0, `/compare` prerendered static.
- Typecheck clean for new/changed files.
- All site routes return 200 (crawled); FAQ + JSON-LD present in rendered HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)