### PR TITLE
fix(admin): hide Media nav item when media plugin is disabled

### DIFF
--- a/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
+++ b/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
@@ -555,13 +555,6 @@ function renderCatalystSidebar(
       </svg>`,
     },
     {
-      label: "Media",
-      path: "/admin/media",
-      icon: `<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
-        <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd"/>
-      </svg>`,
-    },
-    {
       label: "Users",
       path: "/admin/users",
       icon: `<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">


### PR DESCRIPTION
## Summary
- Removes hardcoded `Media` entry from `baseMenuItems` in `renderCatalystSidebar()`
- `core-media` plugin already has `adminMenu` in manifest-registry, so it flows through `pluginMenuMiddleware` like all other plugins
- Media nav item now only appears when `core-media` plugin is active in DB

## Test plan
- [ ] Disable core-media plugin → Media not visible in left nav
- [ ] Enable core-media plugin → Media appears in left nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)