### PR TITLE
refactor(plugins): move dashboard to opt-in plugin

### DIFF
--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -19,7 +19,6 @@ import {
   adminMediaRoutes,
   adminPluginRoutes,
   adminLogsRoutes,
-  adminDashboardRoutes,
   adminCollectionsRoutes,
   adminSettingsRoutes,
   adminApiReferenceRoutes,
@@ -536,7 +535,6 @@ export function createSonicJSApp(config: SonicJSConfig = {}): SonicJSApp {
   }
 
   app.route('/admin/api', adminApiRoutes)
-  app.route('/admin/dashboard', adminDashboardRoutes)
   app.route('/admin/collections', adminCollectionsRoutes)
   app.route('/admin/settings', adminSettingsRoutes)
   app.route('/admin/api-reference', adminApiReferenceRoutes)

--- a/packages/core/src/plugins/core-plugins/analytics/index.ts
+++ b/packages/core/src/plugins/core-plugins/analytics/index.ts
@@ -25,8 +25,7 @@ export function createAnalyticsPlugin(): Plugin {
       email: 'team@sonicjs.com'
     },
     license: 'MIT',
-    compatibility: '^0.1.0',
-    dependencies: ['core-auth'] // Requires auth for admin access
+    compatibility: '^0.1.0'
   })
 
   // Create analytics API routes

--- a/packages/core/src/plugins/core-plugins/dashboard-plugin/index.ts
+++ b/packages/core/src/plugins/core-plugins/dashboard-plugin/index.ts
@@ -1,0 +1,26 @@
+import { PluginBuilder } from '../../sdk/plugin-builder'
+import type { Plugin } from '@sonicjs-cms/core'
+import { adminDashboardRoutes } from '../../../routes/admin-dashboard'
+
+export function createDashboardPlugin(): Plugin {
+  const builder = PluginBuilder.create({
+    name: 'dashboard',
+    version: '1.0.0',
+    description: 'Admin dashboard with stats, storage usage, and recent activity'
+  })
+
+  builder.addRoute('/admin/dashboard', adminDashboardRoutes as any, {
+    description: 'Admin dashboard',
+    requiresAuth: true,
+    priority: 100
+  })
+
+  builder.addMenuItem('Dashboard', '/admin/dashboard', {
+    icon: 'home',
+    order: 1
+  })
+
+  return builder.build() as Plugin
+}
+
+export const dashboardPlugin = createDashboardPlugin()

--- a/packages/core/src/plugins/core-plugins/index.ts
+++ b/packages/core/src/plugins/core-plugins/index.ts
@@ -40,6 +40,7 @@ export { SecurityAuditService, BruteForceDetector, securityAuditMiddleware } fro
 export { userProfilesPlugin, createUserProfilesPlugin, defineUserProfile, getUserProfileConfig } from './user-profiles'
 export type { ProfileFieldDefinition, UserProfileConfig } from './user-profiles'
 export { stripePlugin, createStripePlugin, SubscriptionService, StripeAPI, requireSubscription } from './stripe-plugin'
+export { dashboardPlugin, createDashboardPlugin } from './dashboard-plugin'
 
 // Core plugins list - now imported from auto-generated registry
 export const CORE_PLUGIN_IDS = [

--- a/packages/core/src/routes/auth.ts
+++ b/packages/core/src/routes/auth.ts
@@ -618,7 +618,7 @@ authRoutes.post('/register/form',
     await setCsrfCookie(c)
 
     // Redirect based on role
-    const redirectUrl = role === 'admin' ? '/admin/dashboard' : '/admin/dashboard'
+    const redirectUrl = '/admin/content'
 
     return c.html(html`
       <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded">
@@ -701,11 +701,11 @@ authRoutes.post('/login/form',
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
             </svg>
             <div class="flex-1">
-              <p class="text-sm font-medium text-green-700 dark:text-lime-300">Login successful! Redirecting to admin dashboard...</p>
+              <p class="text-sm font-medium text-green-700 dark:text-lime-300">Login successful! Redirecting...</p>
             </div>
           </div>
           <script>
-            setTimeout(() => { window.location.href = '/admin'; }, 500);
+            setTimeout(() => { window.location.href = '/admin/content'; }, 500);
           </script>
         </div>
       </div>
@@ -1016,7 +1016,7 @@ authRoutes.post('/accept-invitation', async (c) => {
     // Activity logging is deferred until utils/log-activity is implemented
 
     // Redirect to admin dashboard
-    return c.redirect('/admin/dashboard?welcome=true')
+    return c.redirect('/admin/content')
 
   } catch (error) {
     console.error('Accept invitation error:', error)

--- a/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
+++ b/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
@@ -550,13 +550,6 @@ function renderCatalystSidebar(
 ): string {
   let baseMenuItems = [
     {
-      label: "Dashboard",
-      path: "/admin",
-      icon: `<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
-        <path d="M3 4a1 1 0 011-1h12a1 1 0 011 1v2a1 1 0 01-1 1H4a1 1 0 01-1-1V4zM3 10a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H4a1 1 0 01-1-1v-6zM14 9a1 1 0 00-1 1v6a1 1 0 001 1h2a1 1 0 001-1v-6a1 1 0 00-1-1h-2z"/>
-      </svg>`,
-    },
-    {
       label: "Collections",
       path: "/admin/collections",
       icon: `<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">

--- a/packages/core/src/templates/layouts/admin-layout-v2.template.ts
+++ b/packages/core/src/templates/layouts/admin-layout-v2.template.ts
@@ -510,13 +510,6 @@ function renderSidebar(
 ): string {
   const baseMenuItems = [
     {
-      label: "Dashboard",
-      path: "/admin",
-      icon: `<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-        <path d="M3 4a1 1 0 011-1h12a1 1 0 011 1v2a1 1 0 01-1 1H4a1 1 0 01-1-1V4zM3 10a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H4a1 1 0 01-1-1v-6zM14 9a1 1 0 00-1 1v6a1 1 0 001 1h2a1 1 0 001-1v-6a1 1 0 00-1-1h-2z"/>
-      </svg>`,
-    },
-    {
       label: "Content",
       path: "/admin/content",
       icon: `<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">


### PR DESCRIPTION
## Summary
- Extracts dashboard into `dashboard-plugin` (off by default) — enable by adding to `corePluginsBeforeCatchAll` or `config.plugins.register`
- Login, registration, and invitation accept redirects now land on `/admin/content`
- Removes hardcoded Dashboard nav item from both layouts (plugin injects its own when enabled)
- Fixes analytics plugin declaring invalid `core-auth` dependency (auth is always present, not a plugin)

## Test plan
- [ ] Login redirects to `/admin/content`
- [ ] Dashboard route 404s unless plugin enabled
- [ ] No warning about `core-analytics` dependency on `core-auth`
- [ ] Nav sidebar has no Dashboard item by default