### PR TITLE
fix(plugins): PluginBuilder hooks silently dropped by capability gate

### DIFF
--- a/packages/core/src/__tests__/plugins/email-reconciliation.test.ts
+++ b/packages/core/src/__tests__/plugins/email-reconciliation.test.ts
@@ -88,9 +88,9 @@ describe('PluginBuilder.build() v3 compat fields', () => {
     expect((plugin as any).id).toBe('my-plugin')
   })
 
-  it('build() adds empty capabilities array', () => {
+  it('build() leaves capabilities undefined (exempt from capability gate)', () => {
     const plugin = PluginBuilder.create({ name: 'my-plugin', version: '1.0.0' }).build()
-    expect((plugin as any).capabilities).toEqual([])
+    expect((plugin as any).capabilities).toBeUndefined()
   })
 
   it('build() does not override explicitly set capabilities', () => {

--- a/packages/core/src/plugins/sdk/plugin-builder.ts
+++ b/packages/core/src/plugins/sdk/plugin-builder.ts
@@ -314,7 +314,8 @@ export class PluginBuilder {
     // V3 compatibility fields — added without breaking the Plugin type contract.
     const built = this.plugin as Plugin & { id?: string; capabilities?: string[] }
     built.id = built.id ?? this.plugin.name
-    built.capabilities = built.capabilities ?? []
+    // Leave capabilities as undefined so wire.ts treats this as an old-style
+    // PluginBuilder plugin and skips the capability gate (backwards-compatible).
 
     return built as Plugin
   }


### PR DESCRIPTION
## Summary

- `PluginBuilder.build()` was setting `capabilities = []` (empty array), but `wire.ts` only exempts plugins with `capabilities === undefined` from the capability gate
- Any PluginBuilder plugin that registered a hook (e.g. `global-variables` with `content:read`) got silently blocked at runtime with the warning: _"Plugin used capability hooks.content:subscribe without declaring it. Hook content:read will not be registered."_
- Fix: leave `capabilities` as `undefined` in `build()` so old-style PluginBuilder plugins stay exempt as documented

## Changes

- `packages/core/src/plugins/sdk/plugin-builder.ts` — removed the `built.capabilities = built.capabilities ?? []` line; replaced with a clarifying comment
- `packages/core/src/__tests__/plugins/email-reconciliation.test.ts` — updated the one test that was asserting the buggy `[]` behavior to assert `undefined` instead

## Testing
- [x] 23 unit tests pass (`vitest run` on email-reconciliation + dispatch-event suites)
- [x] No TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)