### PR TITLE
docs: document optional BETTER_AUTH_URL in .dev.vars.example

### DIFF
--- a/my-sonicjs-app/.dev.vars.example
+++ b/my-sonicjs-app/.dev.vars.example
@@ -9,3 +9,6 @@
 # Or:
 #   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 BETTER_AUTH_SECRET="replace-me-with-32-bytes-of-hex"
+# Optional: set if Better Auth can't detect the base URL (avoids redirect/callback warnings).
+# Use whatever port wrangler dev actually binds to (default 8787, may differ if port is taken).
+# BETTER_AUTH_URL="http://localhost:8787"


### PR DESCRIPTION
## Summary
- Adds commented-out `BETTER_AUTH_URL` entry to `.dev.vars.example`
- Notes that the port may differ from 8787 if already in use
- Suppresses the Better Auth base URL warning in local dev without hard-coding the port

## Changes
- `my-sonicjs-app/.dev.vars.example` — optional env var with inline comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)