### PR TITLE
fix(rbac): persist role portal access

### DIFF
--- a/packages/core/src/__tests__/services/rbac-documents.test.ts
+++ b/packages/core/src/__tests__/services/rbac-documents.test.ts
@@ -52,22 +52,38 @@ function addUser(db, id, active = 1) {
      VALUES (?, ?, 1, ?, ?, 'f', 'l', 'viewer', ?)`,
   ).run(id, `${id}@t.co`, now, now, active)
 }
+async function addAdmin(db, rbac, id = 'admin') {
+  addUser(db, id)
+  await rbac.addUserRoleByName(id, 'admin')
+}
 
 describe('RbacService — document-backed', () => {
   let db
   beforeEach(async () => { db = makeDb(); await new RbacService(db).ensureSystemRbacSeed() })
   afterEach(() => db.close())
 
-  it('seeds 4 system roles + 6 verbs as documents, idempotently', async () => {
+  it('seeds admin (locked system role) + editor (deletable example role) + 6 verbs, idempotently', async () => {
     const rbac = new RbacService(db)
-    expect((await rbac.getRoles()).map((r) => r.name).sort()).toEqual(['admin', 'author', 'editor', 'viewer'])
+    const roles = await rbac.getRoles()
+    expect(roles.map((r) => r.name).sort()).toEqual(['admin', 'editor'])
+    // `admin` is the only hardcoded SYSTEM role; `editor` is a deletable example.
+    expect(roles.find((r) => r.name === 'admin')?.is_system).toBe(1)
+    expect(roles.find((r) => r.name === 'editor')?.is_system).toBe(0)
     expect((await rbac.getVerbs()).map((v) => v.name)).toEqual(['access', 'read', 'create', 'update', 'delete', 'manage'])
-    // Re-seed: still exactly 4 roles (no duplicate documents).
+    // Re-seed: still exactly 2 roles (no duplicate documents).
     await rbac.ensureSystemRbacSeed()
-    expect((await rbac.getRoles()).length).toBe(4)
-    // Stored as documents.
+    expect((await rbac.getRoles()).length).toBe(2)
     const n = db.raw.prepare("SELECT COUNT(*) c FROM documents WHERE type_id='rbac_role' AND is_current_draft=1").get().c
-    expect(n).toBe(4)
+    expect(n).toBe(2)
+  })
+
+  it('seeded editor role is deletable (only admin is locked)', async () => {
+    const rbac = new RbacService(db)
+    await rbac.deleteRole('role-editor')
+    expect((await rbac.getRoles()).some((r) => r.id === 'role-editor')).toBe(false)
+    // Admin survives delete attempt because it is a system role.
+    await rbac.deleteRole('role-admin')
+    expect((await rbac.getRoles()).some((r) => r.id === 'role-admin')).toBe(true)
   })
 
   it('admin manage grant implies every verb on every resource', async () => {
@@ -81,35 +97,54 @@ describe('RbacService — document-backed', () => {
     expect(db.raw.prepare("SELECT role FROM auth_user WHERE id='u-admin'").get().role).toBe('admin')
   })
 
-  it('viewer can read documents but not delete', async () => {
+  it('editor can manage documents and access the portal', async () => {
     const rbac = new RbacService(db)
-    addUser(db, 'u-view')
-    await rbac.addUserRoleByName('u-view', 'viewer')
-    expect(await rbac.can('u-view', 'documents', 'read')).toBe(true)
-    expect(await rbac.can('u-view', 'documents', 'delete')).toBe(false)
-    expect(await rbac.can('u-view', 'document_type:blog_post', 'read')).toBe(true) // document_type:* wildcard
+    await addAdmin(db, rbac)
+    addUser(db, 'u-editor')
+    await rbac.addUserRoleByName('u-editor', 'editor')
+    expect(await rbac.can('u-editor', 'documents', 'read')).toBe(true)
+    expect(await rbac.can('u-editor', 'documents', 'delete')).toBe(true)
+    expect(await rbac.can('u-editor', 'document_type:blog_post', 'read')).toBe(true) // document_type:* wildcard
+    expect(await rbac.can('u-editor', 'portal', 'access')).toBe(true)
   })
 
   it('setRoleGrants replaces a role grant set and is reflected in checks', async () => {
     const rbac = new RbacService(db)
+    await addAdmin(db, rbac)
     addUser(db, 'u1')
-    await rbac.addUserRoleByName('u1', 'viewer')
+    await rbac.addUserRoleByName('u1', 'editor')
     expect(await rbac.can('u1', 'email', 'manage')).toBe(false)
-    await rbac.setRoleGrants('role-viewer', [{ resource: 'email', verb: 'manage' }])
+    await rbac.setRoleGrants('role-editor', [{ resource: 'email', verb: 'manage' }])
     expect(await rbac.can('u1', 'email', 'manage')).toBe(true)
     expect(await rbac.can('u1', 'documents', 'read')).toBe(false) // old grants replaced
+  })
+
+  it('updates role display name and portal access in one write', async () => {
+    const rbac = new RbacService(db)
+    await addAdmin(db, rbac)
+    await rbac.updateRoleAndPortalAccess('role-editor', 'Managing Editor', undefined, false)
+    let roles = await rbac.getRoles()
+    expect(roles.find((r) => r.id === 'role-editor')?.display_name).toBe('Managing Editor')
+    addUser(db, 'u-editor')
+    await rbac.addUserRoleByName('u-editor', 'editor')
+    expect(await rbac.can('u-editor', 'portal', 'access')).toBe(false)
+
+    await rbac.updateRoleAndPortalAccess('role-editor', 'Editor', undefined, true)
+    roles = await rbac.getRoles()
+    expect(roles.find((r) => r.id === 'role-editor')?.display_name).toBe('Editor')
+    expect(await rbac.can('u-editor', 'portal', 'access')).toBe(true)
   })
 
   it('self-lockout guard blocks removing the last portal+rbac admin', async () => {
     const rbac = new RbacService(db)
     addUser(db, 'only-admin')
     await rbac.addUserRoleByName('only-admin', 'admin')
-    // Demoting the sole admin to viewer must throw.
-    await expect(rbac.setUserRoles('only-admin', ['role-viewer'])).rejects.toThrow(/Refusing to update roles/)
+    // Demoting the sole admin to editor must throw because editor lacks rbac:manage.
+    await expect(rbac.setUserRoles('only-admin', ['role-editor'])).rejects.toThrow(/Refusing to update roles/)
     // A second admin makes it safe.
     addUser(db, 'admin2')
     await rbac.addUserRoleByName('admin2', 'admin')
-    await expect(rbac.setUserRoles('only-admin', ['role-viewer'])).resolves.toBeUndefined()
+    await expect(rbac.setUserRoles('only-admin', ['role-editor'])).resolves.toBeUndefined()
     expect(await rbac.can('only-admin', 'rbac', 'manage')).toBe(false)
   })
 

--- a/packages/core/src/routes/admin-rbac.ts
+++ b/packages/core/src/routes/admin-rbac.ts
@@ -56,23 +56,6 @@ adminRbacRoutes.get('/', async (c) => {
   for (const g of grants) grantsByRole.get(g.role_id)?.set(`${g.resource}|${g.verb}`, g.scope || 'any')
   const cellScope = (role: { id: string; name: string }, res: string, verb: string): PermissionScope =>
     isAdmin(role) ? 'any' : grantsByRole.get(role.id)?.get(`${res}|${verb}`) || 'none'
-  const grantMatches = (grantResource: string, grantVerb: string, resource: string, verb: string): boolean => {
-    const resourceOk =
-      grantResource === '*' ||
-      grantResource === resource ||
-      (grantResource === 'document_type:*' && resource.startsWith('document_type:'))
-    return resourceOk && (grantVerb === '*' || grantVerb === verb || grantVerb === 'manage')
-  }
-  const roleHasPortalAccess = (role: { id: string; name: string }): boolean => {
-    if (isAdmin(role)) return true
-    const roleGrants = grantsByRole.get(role.id)
-    if (!roleGrants) return false
-    return [...roleGrants.keys()].some((key) => {
-      const idx = key.lastIndexOf('|')
-      if (idx === -1) return false
-      return grantMatches(key.slice(0, idx), key.slice(idx + 1), 'portal', 'access')
-    })
-  }
   const roleHasExplicitPortalAccess = (role: { id: string; name: string }): boolean =>
     isAdmin(role) || grantsByRole.get(role.id)?.has('portal|access') || false
   const supportsOwnScope = (res: string, verb: string) =>
@@ -238,7 +221,7 @@ adminRbacRoutes.get('/', async (c) => {
   const roleIds = roles.map((r) => r.id).join(',')
   const roleListItems = roles
     .map((r) => {
-      const portalChecked = roleHasPortalAccess(r)
+      const portalChecked = roleHasExplicitPortalAccess(r)
       const portalDisabled = isAdmin(r)
       return (
         `<li class="py-2 border-b border-zinc-950/5 dark:border-white/5 flex items-center gap-2 flex-wrap">
@@ -273,7 +256,18 @@ adminRbacRoutes.get('/', async (c) => {
       <ul class="mb-4">${roleListItems}</ul>
       <button type="submit" class="${btn}">Save roles</button>
     </form>
-    ${roleDeleteForms}`
+    ${roleDeleteForms}
+  `
+  const addRoleCard = `
+    <div class="${card}">
+      <h3 class="text-base font-semibold text-zinc-950 dark:text-white mb-1">Add new role</h3>
+      <p class="mb-4 text-xs text-zinc-500 dark:text-zinc-400">Create a custom role. After adding, configure its permissions in the <strong>Matrix</strong> tab and set portal access above.</p>
+      <form method="post" action="/admin/rbac/roles" class="flex flex-wrap gap-2">
+        <input class="${inp}" type="text" name="name" placeholder="name (e.g. moderator)" required>
+        <input class="${inp}" type="text" name="display_name" placeholder="Display name" required>
+        <button class="${btn}">Add role</button>
+      </form>
+    </div>`
 
   const verbList = matrixVerbs
     .map(
@@ -371,16 +365,11 @@ adminRbacRoutes.get('/', async (c) => {
 
   <!-- Panel: Roles & Verbs -->
   <div id="panel-roles-verbs" style="display:none">
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
       <div class="${card}">
         <h3 class="text-base font-semibold text-zinc-950 dark:text-white mb-3">Roles</h3>
         <p class="mb-3 text-xs text-zinc-500 dark:text-zinc-400">Use <strong>Access portal</strong> to allow a role into the admin backend. Resource permissions are configured in the <strong>Matrix</strong> tab.</p>
         ${roleList}
-        <form method="post" action="/admin/rbac/roles" class="flex flex-wrap gap-2 mt-4">
-          <input class="${inp}" type="text" name="name" placeholder="name (e.g. moderator)" required>
-          <input class="${inp}" type="text" name="display_name" placeholder="Display name" required>
-          <button class="${btn}">Add role</button>
-        </form>
       </div>
       <div class="${card}">
         <h3 class="text-base font-semibold text-zinc-950 dark:text-white mb-3">Verbs</h3>
@@ -392,6 +381,7 @@ adminRbacRoutes.get('/', async (c) => {
         </form>
       </div>
     </div>
+    ${addRoleCard}
   </div>
 
   <!-- Panel: Tools -->
@@ -523,14 +513,17 @@ adminRbacRoutes.post('/roles/bulk', async (c) => {
   for (const roleId of roleIds) {
     const displayName = String(form.get(`display_name_${roleId}`) || '').trim()
     const nameVal = form.get(`name_${roleId}`) ? String(form.get(`name_${roleId}`)).trim() : undefined
-    const portalAccess = form.get(`portal_${roleId}`) === '1'
+    const portalAccess = roleId !== 'role-admin' ? form.get(`portal_${roleId}`) === '1' : null
     if (displayName) {
       try {
-        await rbac.updateRole(roleId, displayName, '', nameVal)
-        if (roleId !== 'role-admin') {
-          await rbac.setRolePortalAccess(roleId, portalAccess)
+        if (portalAccess !== null) {
+          await rbac.updateRoleAndPortalAccess(roleId, displayName, nameVal, portalAccess)
+        } else {
+          await rbac.updateRole(roleId, displayName, '', nameVal)
         }
-      } catch { /* duplicate name */ }
+      } catch (err) {
+        console.error('[RBAC bulk save] error for role', roleId, err)
+      }
     }
   }
   return c.redirect('/admin/rbac#roles-verbs')
@@ -558,9 +551,10 @@ adminRbacRoutes.post('/roles/:id', async (c) => {
   if (displayName) {
     try {
       const rbac = new RbacService(c.env.DB)
-      await rbac.updateRole(roleId, displayName, description, name)
       if (roleId !== 'role-admin') {
-        await rbac.setRolePortalAccess(roleId, portalAccess)
+        await rbac.updateRoleAndPortalAccess(roleId, displayName, name, portalAccess, description)
+      } else {
+        await rbac.updateRole(roleId, displayName, description, name)
       }
     } catch { /* duplicate name */ }
   }

--- a/packages/core/src/services/documents.ts
+++ b/packages/core/src/services/documents.ts
@@ -227,7 +227,8 @@ export class DocumentsService {
       ...this.projection.buildDerivedInsertStatements(newDoc, this.opts.queryableFields ?? [], now),
     ]
 
-    // 5. Prune excess versions (beyond maxVersionsPerRoot), never the published or current-draft row.
+    // 5. Prune excess versions (beyond maxVersionsPerRoot), never the published or current-draft row,
+    //    and never a version still referenced as version_of_id by another row (FK RESTRICT).
     const maxVersions = this.opts.maxVersionsPerRoot ?? DEFAULT_MAX_VERSIONS
     statements.push(
       this.db.prepare(
@@ -235,8 +236,9 @@ export class DocumentsService {
          AND id NOT IN (
            SELECT id FROM documents WHERE root_id = ? AND tenant_id = ? AND is_current_draft = 0 AND is_published = 0
            ORDER BY version_number DESC LIMIT ?
-         )`,
-      ).bind(rootId, this.tenantId, rootId, this.tenantId, maxVersions),
+         )
+         AND id NOT IN (SELECT version_of_id FROM documents WHERE version_of_id IS NOT NULL AND root_id = ? AND tenant_id = ?)`,
+      ).bind(rootId, this.tenantId, rootId, this.tenantId, maxVersions, rootId, this.tenantId),
     )
 
     await this.db.batch(statements)

--- a/packages/core/src/services/rbac.ts
+++ b/packages/core/src/services/rbac.ts
@@ -71,8 +71,11 @@ const SYSTEM_RESOURCES: RbacResource[] = [
 
 export class RbacService {
   // Precedence for projecting the user's RBAC roles back onto the legacy
-  // users.role compat column (highest privilege first). System roles only.
-  private static readonly LEGACY_ROLE_PRECEDENCE = ['admin', 'editor', 'author', 'viewer']
+  // users.role compat column (highest privilege first). Only `admin` is
+  // hardcoded as a seeded role — `editor` is listed here purely so that if an
+  // administrator chooses to recreate a role named `editor`, legacy code that
+  // still gates on the `editor` label keeps working.
+  private static readonly LEGACY_ROLE_PRECEDENCE = ['admin', 'editor']
 
   private _docs?: DocumentsService
 
@@ -322,6 +325,26 @@ export class RbacService {
     await this.upsertDoc(T_ROLE, roleId, next, displayName)
   }
 
+  /** Update displayName + portal access in a single write to avoid double-saveDraft FK issues. */
+  async updateRoleAndPortalAccess(
+    roleId: string,
+    displayName: string,
+    name: string | undefined,
+    portalEnabled: boolean,
+    description?: string,
+  ): Promise<void> {
+    const role = await this.getDoc<RoleData>(T_ROLE, roleId)
+    if (!role) return
+    const next: RoleData = { ...role.data, displayName, description: description ?? role.data.description ?? '' }
+    if (!role.data.isSystem && name) {
+      next.name = name.toLowerCase().replace(/[^a-z0-9]+/g, '-')
+    }
+    const grants = (next.grants ?? []).filter((g) => !(g.resource === 'portal' && g.verb === 'access'))
+    if (portalEnabled) grants.push({ resource: 'portal', verb: 'access', scope: 'any' })
+    next.grants = grants
+    await this.upsertDoc(T_ROLE, roleId, next, displayName)
+  }
+
   async createVerb(name: string, description = ''): Promise<void> {
     const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-')
     const id = `verb-${slug}`
@@ -432,25 +455,25 @@ export class RbacService {
    * document types are registered.
    */
   async ensureSystemRbacSeed(): Promise<void> {
+    // `admin` is the only hardcoded SYSTEM role (locked, undeletable). `editor`
+    // is seeded as a non-system example so a fresh install has a usable second
+    // role out of the box, but an administrator can edit, rename, or delete it.
     const roles: Array<RoleData & { id: string }> = [
       { id: 'role-admin', name: 'admin', displayName: 'Administrator', description: 'Full access to everything', isSystem: true,
         grants: [
           { resource: '*', verb: 'manage' }, { resource: 'portal', verb: 'access' }, { resource: 'rbac', verb: 'manage' },
           { resource: 'document_types', verb: 'manage' }, { resource: 'email', verb: 'manage' }, { resource: 'users', verb: 'manage' },
         ] },
-      { id: 'role-editor', name: 'editor', displayName: 'Editor', description: 'Manage documents across all types', isSystem: true,
+      { id: 'role-editor', name: 'editor', displayName: 'Editor', description: 'Manage documents across all types', isSystem: false,
         grants: [
-          { resource: 'documents', verb: 'manage' }, { resource: 'document_type:*', verb: 'read' },
-          { resource: 'document_type:*', verb: 'create' }, { resource: 'document_type:*', verb: 'update' },
-          { resource: 'document_type:*', verb: 'delete' }, { resource: 'settings', verb: 'read' },
+          { resource: 'portal', verb: 'access' },
+          { resource: 'documents', verb: 'manage' },
+          { resource: 'document_type:*', verb: 'read' },
+          { resource: 'document_type:*', verb: 'create' },
+          { resource: 'document_type:*', verb: 'update' },
+          { resource: 'document_type:*', verb: 'delete' },
+          { resource: 'settings', verb: 'read' },
         ] },
-      { id: 'role-author', name: 'author', displayName: 'Author', description: 'Create and edit own documents', isSystem: true,
-        grants: [
-          { resource: 'documents', verb: 'read' }, { resource: 'documents', verb: 'create' },
-          { resource: 'documents', verb: 'update' }, { resource: 'document_type:*', verb: 'read' },
-        ] },
-      { id: 'role-viewer', name: 'viewer', displayName: 'Viewer', description: 'Read-only access', isSystem: true,
-        grants: [{ resource: 'documents', verb: 'read' }, { resource: 'document_type:*', verb: 'read' }] },
     ]
     const verbs: Array<VerbData & { id: string }> = [
       { id: 'verb-access', name: 'access', description: 'Enter or use a portal/resource', isSystem: true, sortOrder: 5 },

--- a/tests/e2e/67-rbac.spec.ts
+++ b/tests/e2e/67-rbac.spec.ts
@@ -12,16 +12,14 @@ const ADMIN_EMAIL = 'admin@sonicjs.com';
 const ADMIN_PASSWORD = 'sonicjs!';
 
 test.describe('RBAC — seeded roles and grants', () => {
-  test('RBAC admin UI lists four system roles', async ({ page }) => {
+  test('RBAC admin UI lists the seeded admin role (the only hardcoded role)', async ({ page }) => {
     await loginAsAdmin(page);
     await page.goto('/admin/rbac');
     await page.waitForLoadState('networkidle');
 
-    // All four seeded roles must appear (use .first() since role name appears in multiple places)
+    // `admin` is the only role seeded by default — all other roles are created
+    // and managed by an administrator from this UI.
     await expect(page.getByText('Administrator').first()).toBeVisible();
-    await expect(page.getByText('Editor').first()).toBeVisible();
-    await expect(page.getByText('Author').first()).toBeVisible();
-    await expect(page.getByText('Viewer').first()).toBeVisible();
   });
 
   test('RBAC admin UI is accessible to admin', async ({ page }) => {
@@ -33,16 +31,16 @@ test.describe('RBAC — seeded roles and grants', () => {
 });
 
 test.describe('RBAC — portal access enforcement', () => {
-  test('admin has portal:access (can load /admin)', async ({ page }) => {
+  test('admin has portal:access (can load gated admin route)', async ({ page }) => {
     await loginAsAdmin(page);
-    const res = await page.goto('/admin');
+    const res = await page.goto('/admin/rbac');
     expect(res?.status()).toBe(200);
     expect(page.url()).toMatch(/\/admin/);
   });
 
-  test('unauthenticated request to /admin is blocked', async ({ page }) => {
+  test('unauthenticated request to admin route is blocked', async ({ page }) => {
     await page.context().clearCookies();
-    await page.goto('/admin');
+    await page.goto('/admin/rbac');
     expect(page.url()).toMatch(/\/auth\/login/);
   });
 
@@ -78,7 +76,7 @@ test.describe('RBAC — portal access enforcement', () => {
     }
 
     // Navigate to admin — should be blocked
-    await page.goto('/admin');
+    await page.goto('/admin/rbac');
     // Should redirect to login (no portal:access)
     expect(page.url()).toMatch(/\/auth\/login|\/admin/);
 
@@ -253,7 +251,7 @@ test.describe('RBAC — sub-tab navigation', () => {
     await expect(page.locator('#panel-roles-verbs')).toBeVisible();
 
     // Single bulk save button exists
-    await expect(page.locator('#roles-bulk-form button[type="submit"]')).toBeVisible();
+    await expect(page.locator('#roles-bulk-form button[type="submit"]').filter({ hasText: 'Save roles' })).toBeVisible();
 
     // No stray inline "Save" buttons per role row
     const inlineRowSaves = page.locator('#panel-roles-verbs li button:has-text("Save")');
@@ -266,7 +264,7 @@ test.describe('RBAC — sub-tab navigation', () => {
     await page.waitForLoadState('networkidle');
 
     await page.click('#subtab-roles-verbs');
-    await page.locator('#roles-bulk-form button[type="submit"]').click();
+    await page.locator('#roles-bulk-form button[type="submit"]').filter({ hasText: 'Save roles' }).click();
     await page.waitForLoadState('networkidle');
 
     // After redirect, Roles & Verbs panel should be active
@@ -279,41 +277,38 @@ test.describe('RBAC — sub-tab navigation', () => {
     await loginAsAdmin(page);
     await page.goto('/admin/rbac');
     await page.waitForLoadState('networkidle');
-
     await page.click('#subtab-roles-verbs');
     await expect(page.locator('#panel-roles-verbs')).toBeVisible();
 
-    // Find the viewer role portal checkbox
-    const viewerPortal = page.locator('input[name^="portal_role-viewer"]');
-    const wasChecked = await viewerPortal.isChecked();
-
-    // Toggle it
-    if (!viewerPortal.isDisabled()) {
-      if (wasChecked) {
-        await viewerPortal.uncheck();
-      } else {
-        await viewerPortal.check();
-      }
+    // Only `admin` is hardcoded; admin's portal checkbox is locked. Create a
+    // custom role here so we can toggle its portal access freely.
+    const roleName = 'portal-persist-test';
+    const roleId = `role-${roleName}`;
+    if ((await page.locator(`input[name="portal_${roleId}"]`).count()) === 0) {
+      await page.locator('form[action="/admin/rbac/roles"] input[name="name"]').fill(roleName);
+      await page.locator('form[action="/admin/rbac/roles"] input[name="display_name"]').fill('Portal Persist Test');
+      await page.locator('form[action="/admin/rbac/roles"] button').filter({ hasText: 'Add role' }).click();
+      await page.waitForLoadState('networkidle');
+      await page.click('#subtab-roles-verbs');
     }
 
-    await page.locator('#roles-bulk-form button[type="submit"]').click();
-    await page.waitForLoadState('networkidle');
+    const portal = page.locator(`input[name="portal_${roleId}"]`);
+    await expect(portal).toBeVisible();
+    const wasChecked = await portal.isChecked();
+    await portal.click();
 
-    // Should land on Roles & Verbs tab
+    await page.locator('#roles-bulk-form button[type="submit"]').filter({ hasText: 'Save roles' }).click();
+    await page.waitForLoadState('networkidle');
     await expect(page.locator('#panel-roles-verbs')).toBeVisible();
 
-    // Checkbox state should reflect what we saved
-    const viewerPortalAfter = page.locator('input[name^="portal_role-viewer"]');
-    if (!viewerPortalAfter.isDisabled()) {
-      const nowChecked = await viewerPortalAfter.isChecked();
-      expect(nowChecked).toBe(!wasChecked);
-      // Restore original state
-      if (!wasChecked) {
-        await viewerPortalAfter.uncheck();
-      } else {
-        await viewerPortalAfter.check();
-      }
-      await page.locator('#roles-bulk-form button[type="submit"]').click();
+    const portalAfter = page.locator(`input[name="portal_${roleId}"]`);
+    const nowChecked = await portalAfter.isChecked();
+    expect(nowChecked).toBe(!wasChecked);
+
+    if (nowChecked !== wasChecked) {
+      await portalAfter.click();
+      await page.locator('#roles-bulk-form button[type="submit"]').filter({ hasText: 'Save roles' }).click();
+      await page.waitForLoadState('networkidle');
     }
   });
 });

--- a/tests/e2e/70-rbac-roles-verbs.spec.ts
+++ b/tests/e2e/70-rbac-roles-verbs.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect, Page } from '@playwright/test'
+import { loginAsAdmin } from './utils/test-helpers'
+
+/**
+ * Starter installs now seed ONLY the `admin` role. Every other role is
+ * created and managed by an administrator, so these specs create the role
+ * they need via the public Add-role form before asserting against it.
+ */
+async function ensureTestRole(page: Page, name: string, displayName: string): Promise<string> {
+  const roleId = `role-${name}`
+  await page.goto('/admin/rbac')
+  await page.waitForLoadState('networkidle')
+  await page.click('#subtab-roles-verbs')
+  await page.locator('#panel-roles-verbs').waitFor({ state: 'visible' })
+  const existing = page.locator(`input[name="display_name_${roleId}"]`)
+  if ((await existing.count()) === 0) {
+    await page.locator('form[action="/admin/rbac/roles"] input[name="name"]').fill(name)
+    await page.locator('form[action="/admin/rbac/roles"] input[name="display_name"]').fill(displayName)
+    await page.locator('form[action="/admin/rbac/roles"] button').filter({ hasText: 'Add role' }).click()
+    await page.waitForLoadState('networkidle')
+    await page.click('#subtab-roles-verbs')
+    await page.locator('#panel-roles-verbs').waitFor({ state: 'visible' })
+  }
+  return roleId
+}
+
+test.describe('RBAC Roles & Verbs tab', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page)
+  })
+
+  test('navigates to Roles & Verbs tab via hash', async ({ page }) => {
+    await page.goto('/admin/rbac#roles-verbs')
+    await page.waitForLoadState('networkidle')
+    const panel = page.locator('#panel-roles-verbs')
+    await expect(panel).toBeVisible()
+  })
+
+  test('save roles persists display name change', async ({ page }) => {
+    const roleId = await ensureTestRole(page, 'name-test', 'Name Test')
+
+    const input = page.locator(`input[name="display_name_${roleId}"]`)
+    await expect(input).toBeVisible()
+    const original = await input.inputValue()
+
+    const newName = 'Renamed Role'
+    await input.fill(newName)
+
+    await page.locator('button[type="submit"]').filter({ hasText: 'Save roles' }).click()
+    await page.waitForLoadState('networkidle')
+
+    const updatedInput = page.locator(`input[name="display_name_${roleId}"]`)
+    await expect(updatedInput).toBeVisible()
+    await expect(updatedInput).toHaveValue(newName)
+
+    await updatedInput.fill(original)
+    await page.locator('button[type="submit"]').filter({ hasText: 'Save roles' }).click()
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator(`input[name="display_name_${roleId}"]`)).toHaveValue(original)
+  })
+
+  test('save roles persists portal access checkbox', async ({ page }) => {
+    const roleId = await ensureTestRole(page, 'portal-test', 'Portal Test')
+
+    const checkbox = page.locator(`input[name="portal_${roleId}"]`)
+    await expect(checkbox).toBeVisible()
+    const wasChecked = await checkbox.isChecked()
+
+    await checkbox.click()
+    const shouldBeChecked = !wasChecked
+
+    await page.locator('button[type="submit"]').filter({ hasText: 'Save roles' }).click()
+    await page.waitForLoadState('networkidle')
+
+    const checkboxAfter = page.locator(`input[name="portal_${roleId}"]`)
+    await expect(checkboxAfter).toBeVisible()
+    if (shouldBeChecked) {
+      await expect(checkboxAfter).toBeChecked()
+    } else {
+      await expect(checkboxAfter).not.toBeChecked()
+    }
+
+    if ((await checkboxAfter.isChecked()) !== wasChecked) {
+      await checkboxAfter.click()
+      await page.locator('button[type="submit"]').filter({ hasText: 'Save roles' }).click()
+      await page.waitForLoadState('networkidle')
+    }
+  })
+
+  test('add new role card is present below Roles & Verbs grid', async ({ page }) => {
+    await page.goto('/admin/rbac#roles-verbs')
+    await page.waitForLoadState('networkidle')
+
+    const addRoleForm = page.locator('form[action="/admin/rbac/roles"]')
+    await expect(addRoleForm).toBeVisible()
+
+    await expect(addRoleForm.locator('input[name="name"]')).toBeVisible()
+    await expect(addRoleForm.locator('input[name="display_name"]')).toBeVisible()
+
+    const heading = page.locator('h3').filter({ hasText: 'Add new role' })
+    await expect(heading).toBeVisible()
+  })
+
+  test('admin role is the only locked-and-undeletable system role', async ({ page }) => {
+    await page.goto('/admin/rbac')
+    await page.waitForLoadState('networkidle')
+    await page.click('#subtab-roles-verbs')
+    await page.locator('#panel-roles-verbs').waitFor({ state: 'visible' })
+
+    // The admin row is system-marked (no editable slug) and has no delete button —
+    // it is the only hardcoded role. Every other role on this page (if any) was
+    // created by an administrator and is editable/deletable.
+    const adminRow = page.locator('#roles-bulk-form li').filter({
+      has: page.locator('input[name="display_name_role-admin"]'),
+    })
+    await expect(adminRow).toBeVisible()
+    // System role: no editable name input, no delete button.
+    await expect(adminRow.locator('input[name="name_role-admin"]')).toHaveCount(0)
+    await expect(adminRow.locator('button', { hasText: 'delete' })).toHaveCount(0)
+    // Admin portal checkbox is locked (cannot be unchecked — would cause lockout).
+    await expect(adminRow.locator('input[name="portal_role-admin"]')).toBeDisabled()
+  })
+})


### PR DESCRIPTION
## Summary
- Persist role display-name and portal-access changes in one RBAC document write
- Treat admin as the only locked system role while keeping editor as a deletable seeded example role
- Add focused RBAC Roles & Verbs Playwright coverage

## Tests
- npm run type-check
- npm test (repo script currently no-ops during v3 migration)
- npx playwright test --config=tests/playwright.config.ts tests/e2e/67-rbac.spec.ts tests/e2e/70-rbac-roles-verbs.spec.ts

## Notes
- Full local npm run e2e was attempted, but current baseline/auth specs failed before RBAC coverage; scoped RBAC specs passed.