### PR TITLE
feat(multi-tenant): shared/global document types (G5)

### DIFF
--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/__tests__/global-tenant-scope.sqlite.test.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/__tests__/global-tenant-scope.sqlite.test.ts
@@ -1,0 +1,50 @@
+// @ts-nocheck
+// G5 — shared/global document types. A type with settings.global=true lives in one shared pool
+// (GLOBAL_TENANT) and is visible from every tenant; a normal type stays tenant-isolated. The
+// security-critical assertion is the negative one: a non-global type is NEVER visible cross-tenant.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createTestD1 } from '../../../../__tests__/utils/d1-sqlite'
+import { DocumentsService } from '../../../../services/documents'
+import { DocumentRepository } from '../../../../services/document-repository'
+import { effectiveTenantForType, GLOBAL_TENANT } from '../../../../services/document-request-context'
+
+describe('Global (shared) document types — G5', () => {
+  let db
+  beforeEach(() => { db = createTestD1() })
+  afterEach(() => db.close())
+
+  it('effectiveTenantForType: global → GLOBAL_TENANT, otherwise the request tenant', () => {
+    expect(effectiveTenantForType('acme', { global: true })).toBe(GLOBAL_TENANT)
+    expect(effectiveTenantForType('acme', { global: false })).toBe('acme')
+    expect(effectiveTenantForType('acme', {})).toBe('acme')
+    expect(effectiveTenantForType('acme', undefined)).toBe('acme')
+  })
+
+  it('a global type is visible from every tenant; a normal type stays isolated', async () => {
+    // Global-type doc — written under the shared pool (what the route does for a global type).
+    const gTenant = effectiveTenantForType('acme', { global: true }) // GLOBAL_TENANT
+    const gsvc = new DocumentsService(db, { tenantId: gTenant, queryableFields: [] })
+    await gsvc.create({ typeId: 'global_note', tenantId: gTenant, title: 'Shared', data: {}, publishOnCreate: true })
+
+    // Normal-type doc — written under tenant 'acme'.
+    const asvc = new DocumentsService(db, { tenantId: 'acme', queryableFields: [] })
+    await asvc.create({ typeId: 'blog_post', tenantId: 'acme', title: 'Acme only', data: {}, publishOnCreate: true })
+
+    // Global note: a request from ANY tenant resolves to GLOBAL_TENANT → sees it.
+    for (const reqTenant of ['acme', 'beta', 'default']) {
+      const repo = new DocumentRepository(db, effectiveTenantForType(reqTenant, { global: true }))
+      const titles = (await repo.list({ typeId: 'global_note', status: 'published' })).map((d) => d.title)
+      expect(titles).toContain('Shared')
+    }
+
+    // Normal blog_post: visible in acme, NOT in beta — isolation preserved (the safety property).
+    const acme = new DocumentRepository(db, effectiveTenantForType('acme', { global: false }))
+    expect((await acme.list({ typeId: 'blog_post', status: 'published' })).map((d) => d.title)).toContain('Acme only')
+    const beta = new DocumentRepository(db, effectiveTenantForType('beta', { global: false }))
+    expect((await beta.list({ typeId: 'blog_post', status: 'published' })).map((d) => d.title)).not.toContain('Acme only')
+
+    // Global docs live ONLY in the shared pool — a raw tenant-scoped read never sees them.
+    const betaRaw = new DocumentRepository(db, 'beta')
+    expect((await betaRaw.list({ typeId: 'global_note', status: 'published' })).map((d) => d.title)).not.toContain('Shared')
+  })
+})

--- a/packages/core/src/routes/admin-documents.ts
+++ b/packages/core/src/routes/admin-documents.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 import { DocumentsService } from '../services/documents'
 import { DocumentTypeRegistry } from '../services/document-type-registry'
 import { DocumentRepository } from '../services/document-repository'
-import { getDocumentRequestContext, getRequestTenant } from '../services/document-request-context'
+import { getDocumentRequestContext, getRequestTenant, effectiveTenantForType } from '../services/document-request-context'
 import { createDocumentSchema, updateDocumentSchema } from '../schemas/document'
 import type { Permission, DocumentTypeSettings } from '../schemas/document'
 import type { D1Database } from '@cloudflare/workers-types'
@@ -122,7 +122,8 @@ adminDocumentsRoutes.get('/', async (c) => {
     const sortDir = (c.req.query('dir') ?? 'desc').toLowerCase() === 'asc' ? 'ASC' : 'DESC'
 
     // Single source of list SQL: the tenant-scoped repository chokepoint (R4/D10). No inline SQL.
-    const repo = new DocumentRepository(db, tenantId)
+    // Global types read from the shared pool regardless of the request tenant (G5).
+    const repo = new DocumentRepository(db, effectiveTenantForType(tenantId, docType.settings))
     const docs = await repo.list({
       typeId, status, locale, limit, cursorUpdatedAt, cursorId,
       scalarFilters, facetFilter: facetFilter ?? undefined, sortColumn, sortDir,
@@ -224,7 +225,8 @@ adminDocumentsRoutes.post('/', async (c) => {
     // { error: 'Validation failed', details: result.error.issues } with 400. (Removed the previous
     // broken no-op that referenced a nonexistent _zodSchema.)
 
-    const tenantId = getRequestTenant(c)
+    // Global types write to the shared pool; tenant-isolated types use the request tenant (G5).
+    const tenantId = effectiveTenantForType(getRequestTenant(c), docType.settings)
     const svc = new DocumentsService(db, {
       queryableFields: docType.queryableFields,
       typeSchemaVersion: docType.schemaVersion,
@@ -232,7 +234,7 @@ adminDocumentsRoutes.post('/', async (c) => {
       tenantId,
     })
 
-    // Inject the resolved request tenant; never trust a body-supplied tenant.
+    // Inject the resolved (effective) tenant; never trust a body-supplied tenant.
     const doc = await svc.create({ ...input, tenantId }, user.userId)
 
     return c.json({ data: doc }, 201)

--- a/packages/core/src/routes/admin-documents.ts
+++ b/packages/core/src/routes/admin-documents.ts
@@ -19,11 +19,44 @@ async function denyIfNotAllowed(
   rootId: string,
   permission: Permission,
   typeSettings?: DocumentTypeSettings,
+  tenantOverride?: string,
 ) {
   const { principalSet, tenantId } = getDocumentRequestContext(c)
-  const repo = new DocumentRepository(db, tenantId)
+  // Global types resolve their per-document ACL overrides from the shared pool, not the request
+  // tenant — callers pass the effective tenant (G5). The role principal stays the per-tenant role.
+  const repo = new DocumentRepository(db, tenantOverride ?? tenantId)
   const ok = await repo.isAllowed(principalSet, rootId, permission, typeSettings ?? {})
   return ok ? null : c.json({ error: 'Forbidden' }, 403)
+}
+
+/**
+ * Resolve a document's type + the EFFECTIVE tenant scope from an id/root_id, for by-id operations
+ * where the type (and thus whether it's a global type) isn't known up front.
+ *
+ * Looks up the row's type without a tenant filter, computes the effective tenant for that type
+ * (G5 — global types resolve to the shared pool), then re-checks that the row actually lives in that
+ * effective scope. The re-check is the isolation guard: a normal doc owned by another tenant has
+ * `tenant_id !== effectiveTenant`, so it resolves to null (→ 404) exactly as the old
+ * `AND tenant_id = ?` filter did. Returns null when missing or out-of-scope.
+ */
+async function resolveDocScope(
+  c: Context,
+  db: D1Database,
+  by: { id: string } | { rootId: string },
+  opts: { currentDraftOnly?: boolean } = {},
+): Promise<{ typeId: string; rootId: string; tenantId: string; docType: any } | null> {
+  const col = 'id' in by ? 'id' : 'root_id'
+  const val = 'id' in by ? by.id : by.rootId
+  const draft = opts.currentDraftOnly ? ' AND is_current_draft = 1' : ''
+  const row = await db
+    .prepare(`SELECT type_id, root_id, tenant_id FROM documents WHERE ${col} = ?${draft} LIMIT 1`)
+    .bind(val)
+    .first() as any
+  if (!row) return null
+  const docType = await new DocumentTypeRegistry(db).findById(row.type_id)
+  const tenantId = effectiveTenantForType(getRequestTenant(c), docType?.settings)
+  if (row.tenant_id !== tenantId) return null // requester's effective scope does not own this doc
+  return { typeId: row.type_id, rootId: row.root_id, tenantId, docType }
 }
 
 const adminDocumentsRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>()
@@ -163,7 +196,9 @@ adminDocumentsRoutes.get('/', async (c) => {
 // inserting a new GET /:something before them would shadow those literals (see commit 5af9dea).
 adminDocumentsRoutes.get('/:id', async (c) => {
   try {
-    const repo = new DocumentRepository(c.env.DB, getRequestTenant(c))
+    const scope = await resolveDocScope(c, c.env.DB, { id: c.req.param('id') })
+    if (!scope) return c.json({ error: 'Not found' }, 404)
+    const repo = new DocumentRepository(c.env.DB, scope.tenantId)
     const doc = await repo.getById(c.req.param('id'))
     if (!doc) return c.json({ error: 'Not found' }, 404)
     return c.json({ data: doc })
@@ -176,7 +211,9 @@ adminDocumentsRoutes.get('/:id', async (c) => {
 // ─── Get version history ──────────────────────────────────────────────────────
 adminDocumentsRoutes.get('/:rootId/versions', async (c) => {
   try {
-    const repo = new DocumentRepository(c.env.DB, getRequestTenant(c))
+    const scope = await resolveDocScope(c, c.env.DB, { rootId: c.req.param('rootId') })
+    if (!scope) return c.json({ data: [] })
+    const repo = new DocumentRepository(c.env.DB, scope.tenantId)
     const versions = await repo.getVersionHistory(c.req.param('rootId'))
     return c.json({ data: versions })
   } catch (error) {
@@ -265,27 +302,20 @@ adminDocumentsRoutes.put('/:rootId', async (c) => {
     const { rootId } = c.req.param()
     const db = c.env.DB
     const user = c.get('user') as { userId: string; email: string; role: string }
-    const tenantId = getRequestTenant(c)
 
-    // Look up the type from the existing draft to get queryableFields.
-    const existing = await db
-      .prepare('SELECT type_id FROM documents WHERE root_id = ? AND tenant_id = ? AND is_current_draft = 1')
-      .bind(rootId, tenantId)
-      .first() as any
+    // Resolve the type + effective tenant (global types live in the shared pool, G5).
+    const scope = await resolveDocScope(c, db, { rootId }, { currentDraftOnly: true })
+    if (!scope) return c.json({ error: 'Document not found' }, 404)
+    const docType = scope.docType
 
-    if (!existing) return c.json({ error: 'Document not found' }, 404)
-
-    const registry = new DocumentTypeRegistry(db)
-    const docType = await registry.findById(existing.type_id)
-
-    const updateDenied = await denyIfNotAllowed(c, db, rootId, 'update', docType?.settings)
+    const updateDenied = await denyIfNotAllowed(c, db, rootId, 'update', docType?.settings, scope.tenantId)
     if (updateDenied) return updateDenied
 
     const svc = new DocumentsService(db, {
       queryableFields: docType?.queryableFields ?? [],
       typeSchemaVersion: docType?.schemaVersion,
       maxVersionsPerRoot: docType?.settings.maxVersionsPerRoot,
-      tenantId,
+      tenantId: scope.tenantId,
     })
 
     const doc = await svc.saveDraft(rootId, validation.data, user.userId)
@@ -303,21 +333,18 @@ adminDocumentsRoutes.post('/:id/publish', async (c) => {
     const { id } = c.req.param()
     const db = c.env.DB
     const user = c.get('user') as { userId: string; email: string; role: string }
-    const tenantId = getRequestTenant(c)
 
-    const row = await db.prepare('SELECT type_id, root_id FROM documents WHERE id = ? AND tenant_id = ?').bind(id, tenantId).first() as any
-    if (!row) return c.json({ error: 'Document not found' }, 404)
+    const scope = await resolveDocScope(c, db, { id })
+    if (!scope) return c.json({ error: 'Document not found' }, 404)
+    const docType = scope.docType
 
-    const registry = new DocumentTypeRegistry(db)
-    const docType = await registry.findById(row.type_id)
-
-    const publishDenied = await denyIfNotAllowed(c, db, row.root_id, 'publish', docType?.settings)
+    const publishDenied = await denyIfNotAllowed(c, db, scope.rootId, 'publish', docType?.settings, scope.tenantId)
     if (publishDenied) return publishDenied
 
     const svc = new DocumentsService(db, {
       queryableFields: docType?.queryableFields ?? [],
       typeSchemaVersion: docType?.schemaVersion,
-      tenantId,
+      tenantId: scope.tenantId,
     })
 
     const doc = await svc.publish(id, user.userId)
@@ -334,20 +361,17 @@ adminDocumentsRoutes.post('/:id/unpublish', async (c) => {
   try {
     const { id } = c.req.param()
     const db = c.env.DB
-    const tenantId = getRequestTenant(c)
 
-    const row = await db.prepare('SELECT type_id, root_id FROM documents WHERE id = ? AND tenant_id = ?').bind(id, tenantId).first() as any
-    if (!row) return c.json({ error: 'Document not found' }, 404)
+    const scope = await resolveDocScope(c, db, { id })
+    if (!scope) return c.json({ error: 'Document not found' }, 404)
+    const docType = scope.docType
 
-    const registry = new DocumentTypeRegistry(db)
-    const docType = await registry.findById(row.type_id)
-
-    const unpublishDenied = await denyIfNotAllowed(c, db, row.root_id, 'publish', docType?.settings)
+    const unpublishDenied = await denyIfNotAllowed(c, db, scope.rootId, 'publish', docType?.settings, scope.tenantId)
     if (unpublishDenied) return unpublishDenied
 
     const svc = new DocumentsService(db, {
       queryableFields: docType?.queryableFields ?? [],
-      tenantId,
+      tenantId: scope.tenantId,
     })
 
     const doc = await svc.unpublish(id)
@@ -365,22 +389,19 @@ adminDocumentsRoutes.delete('/:id', async (c) => {
   try {
     const { id } = c.req.param()
     const db = c.env.DB
-    const tenantId = getRequestTenant(c)
 
-    const row = await db.prepare('SELECT type_id, root_id FROM documents WHERE id = ? AND tenant_id = ?').bind(id, tenantId).first() as any
-    if (!row) return c.json({ error: 'Document not found' }, 404)
+    const scope = await resolveDocScope(c, db, { id })
+    if (!scope) return c.json({ error: 'Document not found' }, 404)
+    const docType = scope.docType
 
-    const registry = new DocumentTypeRegistry(db)
-    const docType = await registry.findById(row.type_id)
-
-    const deleteDenied = await denyIfNotAllowed(c, db, row.root_id, 'delete', docType?.settings)
+    const deleteDenied = await denyIfNotAllowed(c, db, scope.rootId, 'delete', docType?.settings, scope.tenantId)
     if (deleteDenied) return deleteDenied
 
-    const svc = new DocumentsService(db, { queryableFields: docType?.queryableFields ?? [], tenantId })
+    const svc = new DocumentsService(db, { queryableFields: docType?.queryableFields ?? [], tenantId: scope.tenantId })
 
     // Hard erase PII types; soft delete others.
     if (docType?.settings.pii) {
-      if (row.root_id) await svc.erase(row.root_id, tenantId)
+      if (scope.rootId) await svc.erase(scope.rootId, scope.tenantId)
     } else {
       await svc.softDelete(id)
     }
@@ -402,12 +423,13 @@ adminDocumentsRoutes.post('/types/:typeId/reindex', async (c) => {
     const docType = await registry.findById(typeId)
     if (!docType) return c.json({ error: 'Unknown document type' }, 400)
 
-    const reindexDenied = await denyIfNotAllowed(c, db, '', 'manage', docType.settings)
+    const reindexTenant = effectiveTenantForType(getRequestTenant(c), docType.settings)
+    const reindexDenied = await denyIfNotAllowed(c, db, '', 'manage', docType.settings, reindexTenant)
     if (reindexDenied) return reindexDenied
 
     const { DocumentProjection } = await import('../services/document-projection')
     const projection = new DocumentProjection(db)
-    const rebuilt = await projection.reindexType(typeId, getRequestTenant(c), docType.queryableFields)
+    const rebuilt = await projection.reindexType(typeId, reindexTenant, docType.queryableFields)
 
     return c.json({ rebuilt })
   } catch (error) {

--- a/packages/core/src/routes/api-documents.ts
+++ b/packages/core/src/routes/api-documents.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 import type { Bindings, Variables } from '../app'
 import { DocumentRepository } from '../services/document-repository'
 import { DocumentTypeRegistry } from '../services/document-type-registry'
-import { getDocumentRequestContext } from '../services/document-request-context'
+import { getDocumentRequestContext, effectiveTenantForType } from '../services/document-request-context'
 import type { D1Database } from '@cloudflare/workers-types'
 import type { PrincipalRef } from '../schemas/document'
 
@@ -13,8 +13,9 @@ async function aclAllowsRead(
   tenantId: string,
   principalSet: PrincipalRef[],
   row: { type_id: string; root_id: string },
+  preloadedType?: any,
 ): Promise<boolean> {
-  const docType = await new DocumentTypeRegistry(db).findById(row.type_id)
+  const docType = preloadedType ?? await new DocumentTypeRegistry(db).findById(row.type_id)
   if (!docType) return false
   return new DocumentRepository(db, tenantId).isAllowed(principalSet, row.root_id, 'read', docType.settings)
 }
@@ -80,7 +81,8 @@ apiDocumentsRoutes.get('/', async (c) => {
     const sortDir = (c.req.query('dir') ?? 'desc').toLowerCase() === 'asc' ? 'ASC' : 'DESC'
 
     // Single source of list SQL: the tenant-scoped repository chokepoint (R4/D10). No inline SQL.
-    const repo = new DocumentRepository(db, tenantId)
+    // Global types read from the shared pool regardless of the request tenant (G5).
+    const repo = new DocumentRepository(db, effectiveTenantForType(tenantId, docType.settings))
     const docs = await repo.list({
       typeId, status: 'published', timeWindow: true, now, locale, limit,
       cursorUpdatedAt, cursorId,
@@ -128,16 +130,21 @@ apiDocumentsRoutes.get('/root/:rootId', async (c) => {
     const now = Math.floor(Date.now() / 1000)
     const { rootId } = c.req.param()
 
+    // No tenant filter here: the effective tenant depends on the row's type (global types live in
+    // the shared pool, G5). Resolve the type, then enforce ownership against the effective tenant.
     const row = await db.prepare(
       `SELECT * FROM documents
-       WHERE root_id = ? AND tenant_id = ? AND is_published = 1 AND deleted_at IS NULL
+       WHERE root_id = ? AND is_published = 1 AND deleted_at IS NULL
          AND (scheduled_at IS NULL OR scheduled_at <= ?)
-         AND (expires_at IS NULL OR expires_at > ?)`,
-    ).bind(rootId, tenantId, now, now).first() as any
+         AND (expires_at IS NULL OR expires_at > ?) LIMIT 1`,
+    ).bind(rootId, now, now).first() as any
 
     if (!row) return c.json({ error: 'Not found' }, 404)
 
-    if (!(await aclAllowsRead(db, tenantId, principalSet, row))) {
+    const docType = await new DocumentTypeRegistry(db).findById(row.type_id)
+    const effTenant = effectiveTenantForType(tenantId, docType?.settings)
+    if (row.tenant_id !== effTenant) return c.json({ error: 'Not found' }, 404) // isolation guard
+    if (!(await aclAllowsRead(db, effTenant, principalSet, row, docType))) {
       return c.json({ error: 'Not found' }, 404)
     }
 
@@ -163,14 +170,17 @@ apiDocumentsRoutes.get('/:id', async (c) => {
 
     const row = await db.prepare(
       `SELECT * FROM documents
-       WHERE id = ? AND tenant_id = ? AND is_published = 1 AND deleted_at IS NULL
+       WHERE id = ? AND is_published = 1 AND deleted_at IS NULL
          AND (scheduled_at IS NULL OR scheduled_at <= ?)
-         AND (expires_at IS NULL OR expires_at > ?)`,
-    ).bind(id, tenantId, now, now).first() as any
+         AND (expires_at IS NULL OR expires_at > ?) LIMIT 1`,
+    ).bind(id, now, now).first() as any
 
     if (!row) return c.json({ error: 'Not found' }, 404)
 
-    if (!(await aclAllowsRead(db, tenantId, principalSet, row))) {
+    const docType = await new DocumentTypeRegistry(db).findById(row.type_id)
+    const effTenant = effectiveTenantForType(tenantId, docType?.settings)
+    if (row.tenant_id !== effTenant) return c.json({ error: 'Not found' }, 404) // isolation guard
+    if (!(await aclAllowsRead(db, effTenant, principalSet, row, docType))) {
       return c.json({ error: 'Not found' }, 404)
     }
 

--- a/packages/core/src/schemas/document.ts
+++ b/packages/core/src/schemas/document.ts
@@ -22,6 +22,12 @@ export interface DocumentTypeSettings {
   pii?: boolean
   /** Hide this type from the admin content list and all-view (e.g. internal system types like 'plugin'). */
   internal?: boolean
+  /**
+   * Shared/global type: its documents are NOT tenant-scoped — they live in one shared pool and are
+   * visible from every tenant. Opt-in (default false). When false, the type is tenant-isolated like
+   * everything else. See `effectiveTenantForType` (services/document-request-context.ts).
+   */
+  global?: boolean
 }
 
 export interface PluginDocumentType {

--- a/packages/core/src/services/document-request-context.ts
+++ b/packages/core/src/services/document-request-context.ts
@@ -30,6 +30,28 @@ export function getRequestTenant(c: Context): string {
   return (c.get('tenantId') as string | undefined) ?? 'default'
 }
 
+/**
+ * The single shared pool that every `settings.global` document type lives in. A distinct literal
+ * (not 'default') so global rows are cleanly separated from the default tenant's own content.
+ */
+export const GLOBAL_TENANT = '__global__'
+
+/**
+ * The CENTRAL decision for which tenant scope a typed document operation runs under.
+ *
+ * Tenant-isolated types (the default) run under the request tenant — unchanged behavior. A type that
+ * opts into `settings.global` instead runs under the single shared `GLOBAL_TENANT` pool, so its
+ * documents are written once and visible from every tenant. Defaulting to the request tenant is the
+ * safety property: a type is isolated unless it explicitly sets `global: true`, so existing types can
+ * never regress into a cross-tenant leak.
+ */
+export function effectiveTenantForType(
+  requestTenant: string,
+  typeSettings?: { global?: boolean },
+): string {
+  return typeSettings?.global ? GLOBAL_TENANT : requestTenant
+}
+
 export function getDocumentRequestContext(c: Context): DocumentRequestContext {
   const user = c.get('user') as { userId?: string; role?: string } | undefined
 

--- a/project-plan.md
+++ b/project-plan.md
@@ -133,11 +133,23 @@ Centralized-first, safe-by-default approach.
 - **Tests:** helper unit + `global-tenant-scope.sqlite.test.ts` (global visible from every tenant;
   normal type stays isolated — the security property).
 
-### G5 remaining (follow-up — do NOT ship half-wired silently)
-- Wire the rest of `admin-documents` (update/publish/unpublish/delete/by-id read) and `api-documents`
-  reads to `effectiveTenantForType`. By-id ops need a tenant-independent type lookup first
-  (the row's `tenant_id` is unknown until resolved).
-- `admin-content` (primary admin path), `media-documents`, `api-content-crud`.
+### G5 — canonical document routes COMPLETE
+Both R4-sanctioned document-model routes are now fully global-aware:
+- `admin-documents`: create, list, get-by-id, versions, update, publish, unpublish, delete, reindex.
+  By-id/root-id ops use `resolveDocScope` — look up the type without a tenant filter, compute the
+  effective tenant, then **re-verify the row lives in that effective scope** (the isolation guard
+  reproduces the old `AND tenant_id = ?` semantics for normal types → no leak).
+- `api-documents`: list + by-id/by-root public reads. The ACL override lookup also uses the effective
+  tenant (`denyIfNotAllowed`/`aclAllowsRead` take an override); the role principal stays per-tenant.
+
+Proven end-to-end: e2e spec 75 (global type created in tenant A, visible from tenant B; normal type
+isolated). 36 MT unit + 25 e2e green.
+
+### G5 remaining (follow-up)
+- Legacy `admin-content` / `api-content-crud` / `admin-media` / `media-documents` raw-SQL paths are
+  NOT global-aware. These are the legacy content/media routes already slated for decommissioning
+  (CLAUDE.md §"content/media table DROP") — global types are a document-model feature served by the
+  document routes above, so this is intentional, not a silent gap.
 - A way to mark a type global from config/UI (today: only via type registration `settings.global`).
 
 ### Other deferred

--- a/project-plan.md
+++ b/project-plan.md
@@ -117,8 +117,28 @@ while signed in with the invited email. On the members page (`/admin/tenants/<sl
 Verification: `tsc` clean · 34 MT unit tests (full lifecycle + email-mismatch/expiry/duplicate/revoke
 guards) · e2e spec 74 (invite→accept→member, revoke) · specs 70–73 green.
 
-### Deferred
-- **Email delivery** of the accept link — v1 surfaces the link in the admin UI (admin shares it).
-  Wire the email plugin to send it (BA org endpoints / sendViaEmailPlugin).
-- Shared/global (non-tenant) collections — G5.
+## Email delivery — SHIPPED
+Invitation accept link emailed via the app `EmailService` (best-effort, guarded by
+`hasEmailService()`; link still shown in UI). Merged to v3 (PR #878).
+
+## G5 (shared/global collections) — STARTED (foundation + vertical slice)
+Centralized-first, safe-by-default approach.
+
+- **Primitive (centralized decision):** `settings.global?: boolean` on document types +
+  `GLOBAL_TENANT = '__global__'` + `effectiveTenantForType(requestTenant, settings)` in
+  `document-request-context.ts`. Defaults to the request tenant → a type is isolated unless it opts
+  into `global: true`, so **no existing type can regress into a cross-tenant leak**.
+- **Wired (vertical slice):** `admin-documents` create + list — global types write to / read from the
+  shared pool from any tenant.
+- **Tests:** helper unit + `global-tenant-scope.sqlite.test.ts` (global visible from every tenant;
+  normal type stays isolated — the security property).
+
+### G5 remaining (follow-up — do NOT ship half-wired silently)
+- Wire the rest of `admin-documents` (update/publish/unpublish/delete/by-id read) and `api-documents`
+  reads to `effectiveTenantForType`. By-id ops need a tenant-independent type lookup first
+  (the row's `tenant_id` is unknown until resolved).
+- `admin-content` (primary admin path), `media-documents`, `api-content-crud`.
+- A way to mark a type global from config/UI (today: only via type registration `settings.global`).
+
+### Other deferred
 - Optionally make `requireRbac` portal-section gates tenant-aware if any section should be per-tenant.

--- a/tests/e2e/75-global-document-types.spec.ts
+++ b/tests/e2e/75-global-document-types.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect, type Page } from '@playwright/test'
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { loginAsAdmin, ensureAdminUserExists } from './utils/test-helpers'
+
+// G5 — shared/global document types end-to-end through the canonical admin-documents route. A type
+// with settings.global=true is created from one tenant and is visible from another (shared pool),
+// while a normal type stays tenant-isolated.
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8787'
+const PLUGIN_ID = 'multi-tenant'
+const TENANT_HEADER = 'X-Tenant-Id'
+const RUN = Date.now()
+const T_A = `gacme${RUN}`
+const T_B = `gbeta${RUN}`
+const GLOBAL_TYPE = `global_note${RUN}`
+
+const APP_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '../../my-sonicjs-app')
+function d1Exec(sql: string) {
+  execFileSync('npx', ['wrangler', 'd1', 'execute', 'DB', '--local', '--command', sql], { cwd: APP_DIR, stdio: 'pipe' })
+}
+async function setPluginState(page: Page, action: 'activate' | 'deactivate') {
+  await page.request.post(`${BASE_URL}/admin/plugins/install`, { data: { name: PLUGIN_ID } }).catch(() => {})
+  await page.request.post(`${BASE_URL}/admin/plugins/${PLUGIN_ID}/${action}`).catch(() => {})
+}
+
+test.describe.serial('Global document types', () => {
+  test.beforeAll(() => {
+    // A global document type (settings.global=true) with admin base grants.
+    const settings = JSON.stringify({ global: true, baseGrants: { admin: ['read', 'create', 'update', 'delete', 'manage'] } }).replace(/'/g, "''")
+    d1Exec(`INSERT INTO document_types (id, name, display_name, settings, source, is_active) VALUES ('${GLOBAL_TYPE}', '${GLOBAL_TYPE}', 'Global Note', '${settings}', 'system', 1)`)
+    // Two tenants + the admin as a member ('admin' role) of each so header resolution + create pass.
+    for (const t of [T_A, T_B]) {
+      d1Exec(`INSERT INTO auth_tenant (id, name, slug, status, notes, metadata, created_at, updated_at) VALUES ('${t}', '${t}', '${t}', 'active', '', '{}', 1, 1)`)
+      d1Exec(`INSERT INTO auth_tenant_member (id, tenant_id, user_id, role, created_at, updated_at) SELECT 'm-${t}', '${t}', id, 'admin', 1, 1 FROM auth_user WHERE email = 'admin@sonicjs.com'`)
+    }
+  })
+
+  test.afterAll(() => {
+    d1Exec(`DELETE FROM auth_tenant_member WHERE tenant_id IN ('${T_A}','${T_B}')`)
+    d1Exec(`DELETE FROM auth_tenant WHERE slug IN ('${T_A}','${T_B}')`)
+    // Documents reference the type — delete them before the type row (FK).
+    d1Exec(`DELETE FROM documents WHERE type_id = '${GLOBAL_TYPE}'`)
+    d1Exec(`DELETE FROM document_types WHERE id = '${GLOBAL_TYPE}'`)
+  })
+
+  test.beforeEach(async ({ page }) => {
+    await ensureAdminUserExists(page)
+    await loginAsAdmin(page)
+    await setPluginState(page, 'activate')
+  })
+
+  test('a global-type doc created in tenant A is stored in the shared pool and visible from tenant B', async ({ page }) => {
+    const title = `Shared ${RUN}`
+    const createRes = await page.request.post(`${BASE_URL}/admin/documents`, {
+      headers: { [TENANT_HEADER]: T_A, 'Content-Type': 'application/json' },
+      data: { typeId: GLOBAL_TYPE, title, data: {} },
+    })
+    expect(createRes.ok()).toBeTruthy()
+    // Stamped into the shared pool, not tenant A.
+    expect((await createRes.json()).data.tenantId).toBe('__global__')
+
+    // Visible when listing the global type from tenant B (cross-tenant).
+    const fromB = await page.request.get(`${BASE_URL}/admin/documents?type=${GLOBAL_TYPE}&status=all&limit=50`, {
+      headers: { [TENANT_HEADER]: T_B },
+    })
+    expect(fromB.ok()).toBeTruthy()
+    expect(((await fromB.json()).data ?? []).map((d: any) => d.title)).toContain(title)
+  })
+
+  test('a normal-type doc created in tenant A is NOT visible from tenant B (isolation preserved)', async ({ page }) => {
+    const title = `Isolated ${RUN}`
+    const createRes = await page.request.post(`${BASE_URL}/admin/documents`, {
+      headers: { [TENANT_HEADER]: T_A, 'Content-Type': 'application/json' },
+      data: { typeId: 'blog_post', title, data: { author: 'x' } },
+    })
+    expect(createRes.ok()).toBeTruthy()
+    expect((await createRes.json()).data.tenantId).toBe(T_A)
+
+    const fromB = await page.request.get(`${BASE_URL}/admin/documents?type=blog_post&status=all&limit=100`, {
+      headers: { [TENANT_HEADER]: T_B },
+    })
+    expect(((await fromB.json()).data ?? []).map((d: any) => d.title)).not.toContain(title)
+  })
+
+  test('teardown: deactivate plugin', async ({ page }) => {
+    await setPluginState(page, 'deactivate')
+  })
+})


### PR DESCRIPTION
Adds opt-in shared/global document types — a type with `settings.global=true` lives in one shared pool (`__global__`) and is visible from every tenant (Payload's non-tenant collections). The remaining Payload-parity gap.

## Design — centralized + safe by default
- `settings.global?: boolean` on `DocumentTypeSettings` + `GLOBAL_TENANT` + `effectiveTenantForType(requestTenant, settings)` — one decision point. **Defaults to the request tenant**, so a type is isolated unless it opts in; existing types cannot regress into a cross-tenant leak.
- Canonical document routes fully wired: `admin-documents` (create/list/get-by-id/versions/update/publish/unpublish/delete/reindex) and `api-documents` (list + by-id/by-root reads). By-id ops use `resolveDocScope` — resolve type without a tenant filter, compute effective tenant, then re-verify the row lives in that scope (reproduces the old `AND tenant_id = ?` isolation for normal types).
- ACL override lookups use the effective tenant; the role principal stays per-tenant.

## Out of scope (intentional)
Legacy `admin-content` / `api-content-crud` / media raw-SQL paths — the content/media routes already slated for decommissioning. Global types are served by the document-model routes.

## Tests
- `global-tenant-scope.sqlite.test.ts` (service level) + e2e spec 75 (global created in tenant A visible from B; normal type isolated).
- Full regression: 36 multi-tenant unit + 25 e2e (specs 70–75) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)