### PR TITLE
feat(multi-tenant): user- and role-centric tenant membership UI

### DIFF
--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/__tests__/tenant-service.sqlite.test.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/__tests__/tenant-service.sqlite.test.ts
@@ -151,6 +151,29 @@ describe('TenantService — real SQLite', () => {
     expect((await svc.listMembers('acme')).map((m) => m.email)).toEqual(['ed@example.com'])
   })
 
+  it('user-centric: listUserMemberships + listAssignmentsByRole', async () => {
+    await svc.createTenant({ name: 'Acme', slug: 'acme' })
+    await svc.createTenant({ name: 'Beta', slug: 'beta' })
+    db.raw.prepare(`INSERT INTO auth_user (id, email, first_name, last_name, created_at, updated_at) VALUES ('u1','u1@x.com','U','One',1,1)`).run()
+    db.raw.prepare(`INSERT INTO auth_user (id, email, first_name, last_name, created_at, updated_at) VALUES ('u2','u2@x.com','U','Two',1,1)`).run()
+
+    await svc.addMember('acme', 'u1', 'admin', 'u1@x.com')
+    await svc.addMember('beta', 'u1', 'viewer', 'u1@x.com')
+    await svc.addMember('acme', 'u2', 'viewer', 'u2@x.com')
+
+    // User-centric: u1 belongs to acme(admin) + beta(viewer).
+    const u1 = await svc.listUserMemberships('u1')
+    expect(u1.map((m) => `${m.slug}:${m.role}`).sort()).toEqual(['acme:admin', 'beta:viewer'])
+    expect(u1.find((m) => m.slug === 'acme')?.name).toBe('Acme')
+    expect(await svc.listUserMemberships('u2')).toEqual([{ slug: 'acme', name: 'Acme', role: 'viewer' }])
+
+    // Role-centric: 'viewer' assigned to u1@beta and u2@acme.
+    const viewers = await svc.listAssignmentsByRole('viewer')
+    expect(viewers.map((a) => `${a.email}@${a.slug}`).sort()).toEqual(['u1@x.com@beta', 'u2@x.com@acme'])
+    expect((await svc.listAssignmentsByRole('admin')).map((a) => a.email)).toEqual(['u1@x.com'])
+    expect(await svc.listAssignmentsByRole('author')).toEqual([])
+  })
+
   it('invitations: create → accept (email must match) → membership; revoke + duplicate + expiry guards', async () => {
     await svc.createTenant({ name: 'Acme', slug: 'acme' })
     db.raw.prepare(

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/routes/admin.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/routes/admin.ts
@@ -11,10 +11,12 @@ import type { D1Database, KVNamespace } from '@cloudflare/workers-types'
 import { requireAuth } from '../../../../middleware/auth'
 import { TENANT_COOKIE, MULTI_TENANT_PLUGIN_ID } from '../../../../middleware/tenant'
 import { PluginService } from '../../../../services/plugin-service'
-import { TenantService } from '../services/tenant-service'
+import { TenantService, isValidMemberRole } from '../services/tenant-service'
 import { renderTenantsList, renderTenantsInactive } from '../templates/tenants-list.template'
 import { renderTenantForm } from '../templates/tenant-form.template'
 import { renderTenantMembers } from '../templates/tenant-members.template'
+import { renderUserMemberships } from '../templates/user-memberships.template'
+import { renderRoleUsage } from '../templates/role-usage.template'
 import { getEmailService, hasEmailService } from '../../../../services/email/email-service-singleton'
 import { escapeHtml } from '../../../../utils/sanitize'
 
@@ -130,6 +132,95 @@ export function createTenantAdminRoutes(): Hono<{ Bindings: Bindings; Variables:
       const message = error instanceof Error ? error.message : 'Failed to accept invitation'
       return c.redirect(`/admin/tenants?message=${encodeURIComponent(message)}&type=error`)
     }
+  })
+
+  // ─── User-centric memberships (registered before /:slug; 'users' is reserved) ──
+  routes.get('/users/:userId', async (c) => {
+    const db = c.env.DB
+    const cur = c.get('user')
+    const version = c.get('appVersion')
+    if (!(await isMultiTenantActive(db))) {
+      return c.html(renderTenantsInactive({ user: userShape(cur), version }))
+    }
+    const userId = c.req.param('userId')
+    const target = await db.prepare('SELECT id, email FROM auth_user WHERE id = ?').bind(userId).first() as { id?: string; email?: string } | null
+    if (!target?.id) return c.redirect('/admin/users?message=User not found&type=error')
+
+    const svc = new TenantService(db)
+    const [memberships, allTenants] = await Promise.all([svc.listUserMemberships(userId), svc.listTenants()])
+    const memberSlugs = new Set(memberships.map((m) => m.slug))
+    const availableTenants = allTenants
+      .filter((t) => t.status === 'active' && !memberSlugs.has(t.slug))
+      .map((t) => ({ slug: t.slug, name: t.name }))
+    const messageType = c.req.query('type') === 'error' ? 'error' as const : 'success' as const
+    return c.html(renderUserMemberships({
+      userId, userEmail: target.email ?? userId, memberships, availableTenants,
+      user: userShape(cur), version, message: c.req.query('message'), messageType,
+    }))
+  })
+
+  routes.post('/users/:userId/memberships', async (c) => {
+    const db = c.env.DB
+    const userId = c.req.param('userId')
+    if (!(await isMultiTenantActive(db))) return c.json({ error: 'Multi-tenant plugin is not active' }, 403)
+    try {
+      const form = await c.req.formData()
+      const slug = String(form.get('slug') ?? '').trim().toLowerCase()
+      const role = String(form.get('role') ?? 'viewer')
+      if (!isValidMemberRole(role)) throw new Error(`Invalid role '${role}'`)
+      const target = await db.prepare('SELECT email FROM auth_user WHERE id = ?').bind(userId).first() as { email?: string } | null
+      if (!target) throw new Error('User not found')
+      const svc = new TenantService(db)
+      if (!(await svc.getTenantBySlug(slug))) throw new Error('Tenant not found')
+      if (await svc.isMember(userId, slug)) throw new Error(`Already a member of '${slug}'`)
+      await svc.addMember(slug, userId, role, target.email ?? null)
+      return c.redirect(`/admin/tenants/users/${userId}?message=Added to ${encodeURIComponent(slug)}`)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to add membership'
+      return c.redirect(`/admin/tenants/users/${userId}?message=${encodeURIComponent(message)}&type=error`)
+    }
+  })
+
+  routes.post('/users/:userId/memberships/:slug/role', async (c) => {
+    const db = c.env.DB
+    const userId = c.req.param('userId')
+    const slug = c.req.param('slug')
+    if (!(await isMultiTenantActive(db))) return c.json({ error: 'Multi-tenant plugin is not active' }, 403)
+    try {
+      const role = String((await c.req.formData()).get('role') ?? '')
+      await new TenantService(db).setMemberRole(slug, userId, role)
+      return c.redirect(`/admin/tenants/users/${userId}?message=Role updated`)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to update role'
+      return c.redirect(`/admin/tenants/users/${userId}?message=${encodeURIComponent(message)}&type=error`)
+    }
+  })
+
+  routes.post('/users/:userId/memberships/:slug/delete', async (c) => {
+    const db = c.env.DB
+    const userId = c.req.param('userId')
+    const slug = c.req.param('slug')
+    if (!(await isMultiTenantActive(db))) return c.json({ error: 'Multi-tenant plugin is not active' }, 403)
+    try {
+      await new TenantService(db).removeMember(slug, userId)
+      return c.redirect(`/admin/tenants/users/${userId}?message=Removed from ${encodeURIComponent(slug)}`)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to remove membership'
+      return c.redirect(`/admin/tenants/users/${userId}?message=${encodeURIComponent(message)}&type=error`)
+    }
+  })
+
+  // ─── Role usage (read-only): where a role is assigned across tenants ──────────
+  routes.get('/roles/:roleName', async (c) => {
+    const db = c.env.DB
+    const cur = c.get('user')
+    const version = c.get('appVersion')
+    if (!(await isMultiTenantActive(db))) {
+      return c.html(renderTenantsInactive({ user: userShape(cur), version }))
+    }
+    const roleName = c.req.param('roleName')
+    const assignments = await new TenantService(db).listAssignmentsByRole(roleName)
+    return c.html(renderRoleUsage({ roleName, assignments, user: userShape(cur), version }))
   })
 
   // ─── List ───────────────────────────────────────────────────────────────────

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/services/tenant-service.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/services/tenant-service.ts
@@ -23,7 +23,7 @@ export interface TenantData {
 export const DEFAULT_TENANT_SLUG = 'default'
 
 /** Slugs that would collide with routing or platform conventions. */
-export const RESERVED_TENANT_SLUGS = ['www', 'admin', 'api', 'auth', 'assets', 'static', 'invitations']
+export const RESERVED_TENANT_SLUGS = ['www', 'admin', 'api', 'auth', 'assets', 'static', 'invitations', 'users', 'roles']
 
 const SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/
 
@@ -181,6 +181,31 @@ export class TenantService {
       WHERE m.user_id = ?
     `).bind(userId).all()
     return new Map((results || []).map((r: any) => [r.slug as string, (r.role as string) || 'viewer']))
+  }
+
+  /** A user's tenant memberships joined with tenant details (user-centric view). */
+  async listUserMemberships(userId: string): Promise<Array<{ slug: string; name: string; role: string }>> {
+    const { results } = await this.db.prepare(`
+      SELECT t.slug, t.name AS tenant_name, m.role
+      FROM auth_tenant_member m
+      JOIN auth_tenant t ON t.id = m.tenant_id
+      WHERE m.user_id = ?
+      ORDER BY CASE WHEN t.slug = 'default' THEN 0 ELSE 1 END, t.name ASC
+    `).bind(userId).all()
+    return (results || []).map((r: any) => ({ slug: r.slug, name: r.tenant_name || r.slug, role: r.role || 'viewer' }))
+  }
+
+  /** All (tenant, user) assignments holding a given role — powers the roles "where used" view. */
+  async listAssignmentsByRole(role: string): Promise<Array<{ slug: string; tenantName: string; userId: string; email: string }>> {
+    const { results } = await this.db.prepare(`
+      SELECT t.slug, t.name AS tenant_name, u.id AS user_id, u.email
+      FROM auth_tenant_member m
+      JOIN auth_tenant t ON t.id = m.tenant_id
+      JOIN auth_user u ON u.id = m.user_id
+      WHERE m.role = ?
+      ORDER BY t.name ASC, u.email ASC
+    `).bind(role).all()
+    return (results || []).map((r: any) => ({ slug: r.slug, tenantName: r.tenant_name || r.slug, userId: r.user_id, email: r.email }))
   }
 
   /** The user's role in a tenant, or null if not a member. */

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/role-usage.template.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/role-usage.template.ts
@@ -1,0 +1,57 @@
+import { renderAdminLayoutCatalyst } from '../../../../templates/layouts/admin-layout-catalyst.template'
+import { escapeHtml } from '../../../../utils/sanitize'
+
+export interface RoleUsagePageData {
+  roleName: string
+  assignments: Array<{ slug: string; tenantName: string; userId: string; email: string }>
+  user?: { name: string; email: string; role: string }
+  version?: string
+}
+
+export function renderRoleUsage(data: RoleUsagePageData): string {
+  const role = escapeHtml(data.roleName)
+  const rows = data.assignments.length
+    ? data.assignments.map((a) => `
+        <tr class="border-b border-zinc-950/5 dark:border-white/5" data-role-assignment="${escapeHtml(a.email)}@${escapeHtml(a.slug)}">
+          <td class="px-4 py-3">
+            <div class="font-medium text-zinc-950 dark:text-white">${escapeHtml(a.tenantName)}</div>
+            <div class="font-mono text-xs text-zinc-500 dark:text-zinc-400">${escapeHtml(a.slug)}</div>
+          </td>
+          <td class="px-4 py-3 text-sm text-zinc-700 dark:text-zinc-300">${escapeHtml(a.email)}</td>
+          <td class="px-4 py-3 text-right">
+            <a href="/admin/tenants/users/${escapeHtml(a.userId)}" class="text-sm text-cyan-600 hover:underline dark:text-cyan-400">manage</a>
+          </td>
+        </tr>`).join('')
+    : `<tr><td colspan="3" class="px-4 py-3 text-sm text-zinc-500 dark:text-zinc-400">This role is not assigned in any tenant.</td></tr>`
+
+  const content = `
+    <div class="p-6 lg:p-8">
+      <div class="mb-2"><a href="/admin/tenants" class="text-sm text-zinc-500 hover:text-zinc-700 dark:text-zinc-400">← Tenants</a></div>
+      <div class="mb-8">
+        <h1 class="text-2xl font-semibold text-zinc-950 dark:text-white">Role usage — <span class="font-mono">${role}</span></h1>
+        <p class="mt-1 text-sm text-zinc-600 dark:text-zinc-400">Per-tenant assignments of the <span class="font-mono">${role}</span> role. Roles are one shared catalog; this shows who holds it, and in which tenant. Assign or change roles on a user's memberships page or a tenant's members page.</p>
+      </div>
+
+      <div class="overflow-hidden rounded-xl border border-zinc-950/5 bg-white shadow-sm dark:border-white/10 dark:bg-zinc-900">
+        <table class="w-full text-left">
+          <thead>
+            <tr class="border-b border-zinc-950/5 text-xs font-medium uppercase tracking-wide text-zinc-500 dark:border-white/5 dark:text-zinc-400">
+              <th class="px-4 py-3">Tenant</th>
+              <th class="px-4 py-3">User</th>
+              <th class="px-4 py-3 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>
+    </div>`
+
+  return renderAdminLayoutCatalyst({
+    title: `Role usage - ${data.roleName} - SonicJS`,
+    pageTitle: 'Role usage',
+    currentPath: '/admin/tenants',
+    user: data.user,
+    version: data.version,
+    content,
+  })
+}

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/tenant-members.template.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/tenant-members.template.ts
@@ -37,6 +37,7 @@ function renderRow(slug: string, m: TenantMember): string {
         </form>
       </td>
       <td class="px-4 py-3 text-right">
+        <a href="/admin/tenants/users/${uid}" data-member-memberships="${escapeHtml(m.email)}" class="mr-1 rounded-lg px-2.5 py-1.5 text-sm font-medium text-zinc-600 hover:bg-zinc-950/5 dark:text-zinc-400 dark:hover:bg-white/5">All tenants</a>
         <form method="POST" action="/admin/tenants/${escapeHtml(slug)}/members/${uid}/delete" class="inline"
           onsubmit="return confirm('Remove ${escapeHtml(m.email)} from this tenant?')">
           <button type="submit" data-remove-member="${escapeHtml(m.email)}" class="rounded-lg px-2.5 py-1.5 text-sm font-medium text-red-600 hover:bg-red-500/10 dark:text-red-400">Remove</button>

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/user-memberships.template.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/user-memberships.template.ts
@@ -1,0 +1,114 @@
+import { renderAdminLayoutCatalyst } from '../../../../templates/layouts/admin-layout-catalyst.template'
+import { escapeHtml } from '../../../../utils/sanitize'
+import { VALID_MEMBER_ROLES } from '../services/tenant-service'
+
+export interface UserMembershipsPageData {
+  userId: string
+  userEmail: string
+  memberships: Array<{ slug: string; name: string; role: string }>
+  /** Tenants the user is NOT yet a member of (for the add picker). */
+  availableTenants: Array<{ slug: string; name: string }>
+  user?: { name: string; email: string; role: string }
+  version?: string
+  message?: string
+  messageType?: 'success' | 'error'
+}
+
+function roleOptions(selected: string): string {
+  return VALID_MEMBER_ROLES.map(
+    (r) => `<option value="${r}" ${r === selected ? 'selected' : ''}>${r}</option>`,
+  ).join('')
+}
+
+export function renderUserMemberships(data: UserMembershipsPageData): string {
+  const uid = escapeHtml(data.userId)
+  const alert = data.message
+    ? `<div data-memberships-alert class="mb-6 rounded-lg border px-4 py-3 text-sm ${
+        data.messageType === 'error'
+          ? 'border-red-500/20 bg-red-500/10 text-red-700 dark:text-red-400'
+          : 'border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400'
+      }">${escapeHtml(data.message)}</div>`
+    : ''
+
+  const rows = data.memberships.length
+    ? data.memberships.map((m) => {
+        const slug = escapeHtml(m.slug)
+        return `
+        <tr data-membership-row="${slug}" class="border-b border-zinc-950/5 dark:border-white/5">
+          <td class="px-4 py-3">
+            <div class="font-medium text-zinc-950 dark:text-white">${escapeHtml(m.name)}</div>
+            <div class="font-mono text-xs text-zinc-500 dark:text-zinc-400">${slug}</div>
+          </td>
+          <td class="px-4 py-3">
+            <form method="POST" action="/admin/tenants/users/${uid}/memberships/${slug}/role" class="flex items-center gap-2">
+              <select name="role" data-membership-role onchange="this.form.requestSubmit ? this.form.requestSubmit() : this.form.submit()"
+                class="rounded-lg border border-zinc-950/10 bg-white px-2 py-1.5 text-sm text-zinc-950 dark:border-white/10 dark:bg-zinc-800 dark:text-white">
+                ${roleOptions(m.role)}
+              </select>
+            </form>
+          </td>
+          <td class="px-4 py-3 text-right">
+            <form method="POST" action="/admin/tenants/users/${uid}/memberships/${slug}/delete" class="inline"
+              onsubmit="return confirm('Remove this user from ${slug}?')">
+              <button type="submit" data-remove-membership="${slug}" class="rounded-lg px-2.5 py-1.5 text-sm font-medium text-red-600 hover:bg-red-500/10 dark:text-red-400">Remove</button>
+            </form>
+          </td>
+        </tr>`
+      }).join('')
+    : `<tr><td colspan="3" class="px-4 py-3 text-sm text-zinc-500 dark:text-zinc-400">Not a member of any tenant.</td></tr>`
+
+  const addForm = data.availableTenants.length
+    ? `<form method="POST" action="/admin/tenants/users/${uid}/memberships" class="flex flex-wrap items-end gap-3" data-add-membership-form>
+        <div class="flex-1 min-w-[14rem]">
+          <label for="membership-tenant" class="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">Tenant</label>
+          <select id="membership-tenant" name="slug" class="w-full rounded-lg border border-zinc-950/10 bg-white px-2 py-2 text-sm text-zinc-950 dark:border-white/10 dark:bg-zinc-800 dark:text-white">
+            ${data.availableTenants.map((t) => `<option value="${escapeHtml(t.slug)}">${escapeHtml(t.name)}</option>`).join('')}
+          </select>
+        </div>
+        <div>
+          <label for="membership-role" class="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">Role</label>
+          <select id="membership-role" name="role" class="rounded-lg border border-zinc-950/10 bg-white px-2 py-2 text-sm text-zinc-950 dark:border-white/10 dark:bg-zinc-800 dark:text-white">
+            ${roleOptions('viewer')}
+          </select>
+        </div>
+        <button type="submit" data-add-membership class="rounded-lg bg-zinc-950 px-3.5 py-2 text-sm font-semibold text-white hover:bg-zinc-800 dark:bg-white dark:text-zinc-950 dark:hover:bg-zinc-200">Add to tenant</button>
+      </form>`
+    : `<p class="text-sm text-zinc-500 dark:text-zinc-400">This user is already a member of every tenant.</p>`
+
+  const content = `
+    <div class="p-6 lg:p-8">
+      <div class="mb-2"><a href="/admin/users/${uid}/edit" class="text-sm text-zinc-500 hover:text-zinc-700 dark:text-zinc-400">← Back to user</a></div>
+      <div class="mb-8">
+        <h1 class="text-2xl font-semibold text-zinc-950 dark:text-white">Tenant memberships</h1>
+        <p class="mt-1 text-sm text-zinc-600 dark:text-zinc-400">Tenants <span class="font-medium">${escapeHtml(data.userEmail)}</span> belongs to, and their role within each. Role is per-tenant — a user can be admin in one tenant and viewer in another.</p>
+      </div>
+
+      ${alert}
+
+      <div class="mb-6 rounded-xl border border-zinc-950/5 bg-white p-4 shadow-sm dark:border-white/10 dark:bg-zinc-900">
+        ${addForm}
+      </div>
+
+      <div class="overflow-hidden rounded-xl border border-zinc-950/5 bg-white shadow-sm dark:border-white/10 dark:bg-zinc-900">
+        <table class="w-full text-left">
+          <thead>
+            <tr class="border-b border-zinc-950/5 text-xs font-medium uppercase tracking-wide text-zinc-500 dark:border-white/5 dark:text-zinc-400">
+              <th class="px-4 py-3">Tenant</th>
+              <th class="px-4 py-3">Role</th>
+              <th class="px-4 py-3 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>
+    </div>`
+
+  return renderAdminLayoutCatalyst({
+    title: `Tenant memberships - ${data.userEmail} - SonicJS`,
+    pageTitle: 'Tenant memberships',
+    currentPath: '/admin/users',
+    user: data.user,
+    version: data.version,
+    content,
+  })
+}

--- a/packages/core/src/routes/admin-rbac.ts
+++ b/packages/core/src/routes/admin-rbac.ts
@@ -237,6 +237,7 @@ adminRbacRoutes.get('/', async (c) => {
             } class="h-3.5 w-3.5 rounded border-zinc-400 text-cyan-600 focus:ring-cyan-500">
             Access portal
           </label>
+          <a href="/admin/tenants/roles/${esc(r.name)}" data-role-tenants="${esc(r.name)}" class="text-xs text-cyan-600 dark:text-cyan-400 hover:underline" title="Per-tenant assignments of this role">tenants</a>
           ${
             r.is_system
               ? ''

--- a/packages/core/src/routes/admin-users.ts
+++ b/packages/core/src/routes/admin-users.ts
@@ -869,10 +869,18 @@ userRoutes.get('/users/:id/edit', async (c) => {
       profile
     }
 
+    // Multi-tenant plugin active? (same source of truth as middleware/tenant.ts). When active, the
+    // edit page links to the user's per-tenant membership management. Single-tenant installs: no link.
+    const mtRow = await db.prepare(
+      `SELECT 1 FROM documents WHERE type_id = 'plugin' AND slug = 'multi-tenant'
+         AND q_plugin_status = 'active' AND is_current_draft = 1 AND deleted_at IS NULL`
+    ).first().catch(() => null)
+
     const pageData: UserEditPageData = {
       userToEdit: editData,
       roles: ROLES,
       customProfileFieldsHtml,
+      tenantMembershipsHref: mtRow ? `/admin/tenants/users/${userId}` : undefined,
       user: {
         name: user!.email.split('@')[0] || user!.email,
         email: user!.email,

--- a/packages/core/src/templates/pages/admin-user-edit.template.ts
+++ b/packages/core/src/templates/pages/admin-user-edit.template.ts
@@ -29,6 +29,8 @@ export interface UserEditPageData {
   error?: string
   success?: string
   customProfileFieldsHtml?: string
+  /** When the multi-tenant plugin is active: link to this user's per-tenant membership management. */
+  tenantMembershipsHref?: string
   user?: {
     name: string
     email: string
@@ -167,6 +169,17 @@ export function renderUserEditPage(data: UserEditPageData): string {
               </div>
 
               ${data.customProfileFieldsHtml || ''}
+
+              ${data.tenantMembershipsHref ? `
+              <!-- Tenant Memberships (multi-tenant plugin) -->
+              <div class="mb-8">
+                <h3 class="text-base font-semibold text-zinc-950 dark:text-white mb-2">Tenant memberships</h3>
+                <p class="text-sm text-zinc-600 dark:text-zinc-400 mb-3">Assign this user to one or more tenants and set their role within each.</p>
+                <a href="${data.tenantMembershipsHref}" data-tenant-memberships-link class="inline-flex items-center gap-2 rounded-lg bg-zinc-950 px-3.5 py-2 text-sm font-semibold text-white hover:bg-zinc-800 dark:bg-white dark:text-zinc-950 dark:hover:bg-zinc-200">
+                  Manage tenant memberships
+                  <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                </a>
+              </div>` : ''}
 
               <!-- Set Password -->
               <div class="mb-8">

--- a/project-plan.md
+++ b/project-plan.md
@@ -152,5 +152,21 @@ isolated). 36 MT unit + 25 e2e green.
   document routes above, so this is intentional, not a silent gap.
 - A way to mark a type global from config/UI (today: only via type registration `settings.global`).
 
+## User- & role-centric membership UI — SHIPPED
+Payload's model: one shared role catalog; global-vs-tenant is the *assignment location*
+(global = `rbac_user_roles`/`is_super_admin`, per-tenant = `auth_tenant_member`). No schema change.
+
+- **User-centric** (`/admin/tenants/users/:userId`): list a user's tenants + per-tenant role, add the
+  user to a tenant (picker + role), change role, remove. Linked from the user edit page (`/admin/users/:id/edit`)
+  when the plugin is active, and from each tenant member row ("All tenants").
+- **Role-centric** (`/admin/tenants/roles/:roleName`, read-only): per-tenant assignments of a role.
+  Linked per-role from the RBAC roles tab.
+- `TenantService.listUserMemberships` / `listAssignmentsByRole`; reserved slugs `users`/`roles`.
+
+Verification: 37 MT unit (incl. the two new queries) + e2e spec 76 (user edit link → add/change/remove +
+role-usage page). Full suite 70–76 = 29 e2e green.
+
 ### Other deferred
 - Optionally make `requireRbac` portal-section gates tenant-aware if any section should be per-tenant.
+- The per-role "tenants" link on the RBAC roles tab is authored but not e2e-covered (hidden-tab DOM
+  assertion was flaky); the role-usage page is reached directly + from user pages.

--- a/tests/e2e/76-user-tenant-memberships.spec.ts
+++ b/tests/e2e/76-user-tenant-memberships.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect, type Page } from '@playwright/test'
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { loginAsAdmin, ensureAdminUserExists } from './utils/test-helpers'
+
+// User-centric tenant membership management: from a user's edit page, open their memberships,
+// add the user to a tenant with a role, change the role, and remove them. Roles are per-tenant.
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8787'
+const PLUGIN_ID = 'multi-tenant'
+const RUN = Date.now()
+const T_A = `umta${RUN}`
+const T_B = `umtb${RUN}`
+const UID = `umbr${RUN}`
+const UEMAIL = `member${RUN}@example.com`
+
+const APP_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '../../my-sonicjs-app')
+function d1Exec(sql: string) {
+  execFileSync('npx', ['wrangler', 'd1', 'execute', 'DB', '--local', '--command', sql], { cwd: APP_DIR, stdio: 'pipe' })
+}
+async function setPluginState(page: Page, action: 'activate' | 'deactivate') {
+  await page.request.post(`${BASE_URL}/admin/plugins/install`, { data: { name: PLUGIN_ID } }).catch(() => {})
+  await page.request.post(`${BASE_URL}/admin/plugins/${PLUGIN_ID}/${action}`).catch(() => {})
+}
+
+test.describe.serial('User-centric tenant memberships', () => {
+  test.beforeAll(() => {
+    d1Exec(`INSERT INTO auth_user (id, email, first_name, last_name, created_at, updated_at) VALUES ('${UID}', '${UEMAIL}', 'Mem', 'Ber', 1, 1)`)
+    for (const t of [T_A, T_B]) {
+      d1Exec(`INSERT INTO auth_tenant (id, name, slug, status, notes, metadata, created_at, updated_at) VALUES ('${t}', '${t}', '${t}', 'active', '', '{}', 1, 1)`)
+    }
+  })
+
+  test.afterAll(() => {
+    d1Exec(`DELETE FROM auth_tenant_member WHERE user_id = '${UID}'`)
+    d1Exec(`DELETE FROM auth_tenant WHERE slug IN ('${T_A}','${T_B}')`)
+    d1Exec(`DELETE FROM auth_user WHERE id = '${UID}'`)
+  })
+
+  test.beforeEach(async ({ page }) => {
+    await ensureAdminUserExists(page)
+    await loginAsAdmin(page)
+    await setPluginState(page, 'activate')
+  })
+
+  test('user edit page links to membership management when the plugin is active', async ({ page }) => {
+    await page.goto(`${BASE_URL}/admin/users/${UID}/edit`)
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator('[data-tenant-memberships-link]')).toBeVisible()
+  })
+
+  test('add user to a tenant, change role, remove', async ({ page }) => {
+    await page.goto(`${BASE_URL}/admin/tenants/users/${UID}`)
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator('#membership-tenant')).toBeVisible()
+
+    // Add to tenant A as viewer.
+    await page.selectOption('#membership-tenant', T_A)
+    await page.selectOption('#membership-role', 'viewer')
+    await Promise.all([page.waitForURL(/\/tenants\/users\//), page.click('[data-add-membership]')])
+    const row = page.locator(`[data-membership-row="${T_A}"]`)
+    await expect(row).toBeVisible()
+    await expect(row.locator('[data-membership-role]')).toHaveValue('viewer')
+
+    // Change role to editor (select auto-submits).
+    await Promise.all([
+      page.waitForURL(/\/tenants\/users\//),
+      row.locator('[data-membership-role]').selectOption('editor'),
+    ])
+    await expect(page.locator(`[data-membership-row="${T_A}"] [data-membership-role]`)).toHaveValue('editor')
+
+    // Remove.
+    page.on('dialog', (d) => d.accept())
+    await Promise.all([
+      page.waitForURL(/\/tenants\/users\//),
+      page.locator(`[data-remove-membership="${T_A}"]`).click(),
+    ])
+    await expect(page.locator(`[data-membership-row="${T_A}"]`)).toHaveCount(0)
+  })
+
+  test('the per-tenant role-usage page renders and lists assignments', async ({ page }) => {
+    // Seed an assignment so the usage page has a row to show.
+    d1Exec(`INSERT INTO auth_tenant_member (id, tenant_id, user_id, role, created_at, updated_at) SELECT 'ru-${RUN}', '${T_B}', id, 'viewer', 1, 1 FROM auth_user WHERE id = '${UID}'`)
+    await page.goto(`${BASE_URL}/admin/tenants/roles/viewer`)
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText(/Role usage/i)).toBeVisible()
+    await expect(page.locator(`[data-role-assignment="${UEMAIL}@${T_B}"]`)).toBeVisible()
+  })
+
+  test('teardown: deactivate plugin', async ({ page }) => {
+    await setPluginState(page, 'deactivate')
+  })
+})


### PR DESCRIPTION
Assign users to tenants (with a per-tenant role) from the **user's** page, not just from a tenant's members page. Implements Payload's model: one shared role catalog where global-vs-tenant is the *assignment location* — **no schema change**.

## What's added
- **User-centric** `/admin/tenants/users/:userId` — list a user's tenants + per-tenant role; add to a tenant (picker + role), change role, remove. Linked from the user edit page (`/admin/users/:id/edit`, gated on plugin-active) and from each tenant member row.
- **Role-centric** `/admin/tenants/roles/:roleName` (read-only) — per-tenant assignments of a role; linked per-role from the RBAC roles tab.
- `TenantService.listUserMemberships` / `listAssignmentsByRole`; `users`/`roles` reserved slugs.

## Design answer (recorded for reference)
Payload has **one set of role names**; "global" vs "tenant-specific" is *where* the role is assigned (`user.roles` vs `user.tenants[].roles`), not a flag on the role. Our schema already matched this (`rbac_user_roles` + `is_super_admin` = global; `auth_tenant_member` = per-tenant). Chosen model: **per-user assignment only** (Payload-exact) — no role→tenant link, no tenant-scoped role catalog.

## Tests
- Unit for both new queries; e2e spec 76 (user edit link → add/change/remove + role-usage page).
- Full suite 70–76: 37 multi-tenant unit + 29 e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)