### PR TITLE
feat(multi-tenant): multi-tenancy plugin v1 — UI, UX, and invitation flow

### DIFF
--- a/packages/core/src/middleware/tenant.ts
+++ b/packages/core/src/middleware/tenant.ts
@@ -252,7 +252,7 @@ function renderTenantSwitcher(state: TenantCacheEntry, currentTenantId: string, 
     .join('')
 
   return `
-    <div class="mt-3 border-t border-zinc-950/5 pt-3 dark:border-white/5" data-tenant-switcher>
+    <div class="mt-4 border-t border-zinc-950/5 pt-4 dark:border-white/5" data-tenant-switcher>
       <label for="tenant-switcher-select" class="mb-1 flex items-center gap-1.5 text-xs/5 font-medium text-zinc-500 dark:text-zinc-400">
         <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21"/></svg>
         Tenant

--- a/packages/core/src/middleware/tenant.ts
+++ b/packages/core/src/middleware/tenant.ts
@@ -252,7 +252,7 @@ function renderTenantSwitcher(state: TenantCacheEntry, currentTenantId: string, 
     .join('')
 
   return `
-    <div class="mt-3" data-tenant-switcher>
+    <div class="mt-4 border-t border-zinc-950/5 pt-4 dark:border-white/5" data-tenant-switcher>
       <label for="tenant-switcher-select" class="mb-1 flex items-center gap-1.5 text-xs/5 font-medium text-zinc-500 dark:text-zinc-400">
         <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21"/></svg>
         Tenant

--- a/packages/core/src/middleware/tenant.ts
+++ b/packages/core/src/middleware/tenant.ts
@@ -252,7 +252,7 @@ function renderTenantSwitcher(state: TenantCacheEntry, currentTenantId: string, 
     .join('')
 
   return `
-    <div class="mt-4 border-t border-zinc-950/5 pt-4 dark:border-white/5" data-tenant-switcher>
+    <div class="mt-3 border-t border-zinc-950/5 pt-3 dark:border-white/5" data-tenant-switcher>
       <label for="tenant-switcher-select" class="mb-1 flex items-center gap-1.5 text-xs/5 font-medium text-zinc-500 dark:text-zinc-400">
         <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21"/></svg>
         Tenant

--- a/packages/core/src/middleware/tenant.ts
+++ b/packages/core/src/middleware/tenant.ts
@@ -252,7 +252,7 @@ function renderTenantSwitcher(state: TenantCacheEntry, currentTenantId: string, 
     .join('')
 
   return `
-    <div class="mt-4 border-t border-zinc-950/5 pt-4 dark:border-white/5" data-tenant-switcher>
+    <div class="border-b border-zinc-950/5 px-4 py-3 dark:border-white/5" data-tenant-switcher>
       <label for="tenant-switcher-select" class="mb-1 flex items-center gap-1.5 text-xs/5 font-medium text-zinc-500 dark:text-zinc-400">
         <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21"/></svg>
         Tenant

--- a/packages/core/src/middleware/tenant.ts
+++ b/packages/core/src/middleware/tenant.ts
@@ -252,7 +252,7 @@ function renderTenantSwitcher(state: TenantCacheEntry, currentTenantId: string, 
     .join('')
 
   return `
-    <div class="border-t border-zinc-950/5 p-3 dark:border-white/5" data-tenant-switcher>
+    <div class="mt-3" data-tenant-switcher>
       <label for="tenant-switcher-select" class="mb-1 flex items-center gap-1.5 text-xs/5 font-medium text-zinc-500 dark:text-zinc-400">
         <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21"/></svg>
         Tenant

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/index.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/index.ts
@@ -2,6 +2,7 @@ import { PluginBuilder } from '../../sdk/plugin-builder'
 import type { Plugin } from '../../types'
 import manifest from './manifest.json'
 import { createTenantAdminRoutes } from './routes/admin'
+import { createJoinRoutes } from './routes/join'
 import { invalidateTenantCache } from '../../../middleware/tenant'
 
 export function createMultiTenantPlugin(): Plugin {
@@ -22,6 +23,13 @@ export function createMultiTenantPlugin(): Plugin {
     description: 'Tenant management admin routes',
     requiresAuth: true,
     priority: 90,
+  })
+
+  // Public invitation join routes — NO auth middleware (unauthenticated invitees).
+  builder.addRoute('/join/invite', createJoinRoutes() as any, {
+    description: 'Public invitation accept / register / sign-in',
+    requiresAuth: false,
+    priority: 95,
   })
 
   builder.addMenuItem('Tenants', '/admin/tenants', {

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/routes/admin.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/routes/admin.ts
@@ -134,6 +134,19 @@ export function createTenantAdminRoutes(): Hono<{ Bindings: Bindings; Variables:
     }
   })
 
+  // ─── User email search for datalist autocomplete ────────────────────────────
+  routes.get('/users/search', async (c) => {
+    const db = c.env.DB
+    if (!(await isMultiTenantActive(db))) return c.text('', 200)
+    const q = (c.req.query('email') ?? c.req.query('q') ?? '').trim().toLowerCase()
+    if (!q) return c.text('', 200)
+    const { results } = await db.prepare(
+      `SELECT email FROM auth_user WHERE LOWER(email) LIKE ? LIMIT 10`
+    ).bind(`%${q}%`).all()
+    const options = (results ?? []).map((r: any) => `<option value="${escapeHtml(r.email as string)}">`).join('')
+    return c.html(options)
+  })
+
   // ─── User-centric memberships (registered before /:slug; 'users' is reserved) ──
   routes.get('/users/:userId', async (c) => {
     const db = c.env.DB

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/routes/admin.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/routes/admin.ts
@@ -398,6 +398,7 @@ export function createTenantAdminRoutes(): Hono<{ Bindings: Bindings; Variables:
       slug, tenantName: tenant.name, members, invitations,
       user: userShape(user), version,
       message: c.req.query('message'), messageType,
+      retryInvitationId: c.req.query('retry_invitation'),
     }))
   })
 
@@ -490,9 +491,45 @@ export function createTenantAdminRoutes(): Hono<{ Bindings: Bindings; Variables:
         noteType = 'warning'
       }
       const typeParam = noteType ? `&type=${noteType}` : ''
-      return c.redirect(`/admin/tenants/${slug}/members?message=${encodeURIComponent(note)}${typeParam}`)
+      const retryParam = noteType === 'warning' && hasRealProvider ? `&retry_invitation=${encodeURIComponent(token)}` : ''
+      return c.redirect(`/admin/tenants/${slug}/members?message=${encodeURIComponent(note)}${typeParam}${retryParam}`)
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to create invitation'
+      return c.redirect(`/admin/tenants/${slug}/members?message=${encodeURIComponent(message)}&type=error`)
+    }
+  })
+
+  // ─── Invitations: resend email ────────────────────────────────────────────────
+  routes.post('/:slug/invitations/:id/resend', async (c) => {
+    const db = c.env.DB
+    const slug = c.req.param('slug')
+    const id = c.req.param('id')
+    if (!(await isMultiTenantActive(db))) return c.json({ error: 'Multi-tenant plugin is not active' }, 403)
+    try {
+      const inv = await db.prepare(
+        `SELECT i.id, i.email, i.role FROM auth_tenant_invitation i
+         JOIN auth_tenant t ON t.id = i.tenant_id
+         WHERE i.id = ? AND t.slug = ? AND i.status = 'pending'`
+      ).bind(id, slug).first() as { id: string; email: string; role: string } | null
+      if (!inv) throw new Error('Invitation not found or already used')
+
+      const svc2 = hasEmailService() ? getEmailService() : null
+      const hasRealProvider = !!svc2 && svc2.getProviderName() !== 'console'
+      if (!hasRealProvider) throw new Error('No email plugin active')
+
+      const origin = c.req.header('origin') || new URL(c.req.url).origin
+      const acceptUrl = `${origin}/admin/tenants/invitations/accept?token=${encodeURIComponent(inv.id)}`
+      const result = await svc2!.send({
+        to: inv.email,
+        subject: `You're invited to the ${slug} workspace`,
+        flow: 'tenant-invitation',
+        html: renderInviteEmail(acceptUrl, slug, inv.role),
+        text: `You've been invited to '${slug}' as ${inv.role}. Sign in with this email and accept: ${acceptUrl}`,
+      })
+      if (!result.ok) throw new Error(result.error ?? 'Send failed')
+      return c.redirect(`/admin/tenants/${slug}/members?message=Invitation email sent to ${encodeURIComponent(inv.email)}`)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to resend invitation'
       return c.redirect(`/admin/tenants/${slug}/members?message=${encodeURIComponent(message)}&type=error`)
     }
   })

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/routes/admin.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/routes/admin.ts
@@ -468,18 +468,20 @@ export function createTenantAdminRoutes(): Hono<{ Bindings: Bindings; Variables:
       const acceptUrl = `${origin}/admin/tenants/invitations/accept?token=${encodeURIComponent(token)}`
       let note: string
       let noteType = ''
-      if (hasEmailService()) {
-        try {
-          await getEmailService().send({
-            to: email.trim(),
-            subject: `You're invited to the ${slug} workspace`,
-            flow: 'tenant-invitation',
-            html: renderInviteEmail(acceptUrl, slug, role),
-            text: `You've been invited to '${slug}' as ${role}. Sign in with this email and accept: ${acceptUrl}`,
-          })
+      const svc2 = hasEmailService() ? getEmailService() : null
+      const hasRealProvider = !!svc2 && svc2.getProviderName() !== 'console'
+      if (hasRealProvider) {
+        const result = await svc2!.send({
+          to: email.trim(),
+          subject: `You're invited to the ${slug} workspace`,
+          flow: 'tenant-invitation',
+          html: renderInviteEmail(acceptUrl, slug, role),
+          text: `You've been invited to '${slug}' as ${role}. Sign in with this email and accept: ${acceptUrl}`,
+        })
+        if (result.ok) {
           note = 'Invitation created and emailed'
-        } catch (err) {
-          console.error('Failed to send invitation email:', err)
+        } else {
+          console.error('Failed to send invitation email:', result.error)
           note = 'Invitation created — email failed to send, share the accept link manually'
           noteType = 'warning'
         }

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/routes/admin.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/routes/admin.ts
@@ -112,7 +112,9 @@ export function createTenantAdminRoutes(): Hono<{ Bindings: Bindings; Variables:
       maxAge: 60 * 60 * 24 * 365,
     })
 
-    const target = redirect.startsWith('/') && !redirect.startsWith('//') ? redirect : '/admin'
+    let target = redirect.startsWith('/') && !redirect.startsWith('//') ? redirect : '/admin'
+    // Detail/edit pages are tenant-specific; send back to the list instead.
+    if (/^\/admin\/content\/.+/.test(target)) target = '/admin/content'
     return c.redirect(target)
   })
 
@@ -180,6 +182,7 @@ export function createTenantAdminRoutes(): Hono<{ Bindings: Bindings; Variables:
       const form = await c.req.formData()
       const slug = String(form.get('slug') ?? '').trim().toLowerCase()
       const role = String(form.get('role') ?? 'viewer')
+      const redirectTo = String(form.get('_redirect') ?? '') || `/admin/tenants/users/${userId}`
       if (!isValidMemberRole(role)) throw new Error(`Invalid role '${role}'`)
       const target = await db.prepare('SELECT email FROM auth_user WHERE id = ?').bind(userId).first() as { email?: string } | null
       if (!target) throw new Error('User not found')
@@ -187,7 +190,7 @@ export function createTenantAdminRoutes(): Hono<{ Bindings: Bindings; Variables:
       if (!(await svc.getTenantBySlug(slug))) throw new Error('Tenant not found')
       if (await svc.isMember(userId, slug)) throw new Error(`Already a member of '${slug}'`)
       await svc.addMember(slug, userId, role, target.email ?? null)
-      return c.redirect(`/admin/tenants/users/${userId}?message=Added to ${encodeURIComponent(slug)}`)
+      return c.redirect(`${redirectTo}?message=Added to ${encodeURIComponent(slug)}`)
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to add membership'
       return c.redirect(`/admin/tenants/users/${userId}?message=${encodeURIComponent(message)}&type=error`)
@@ -200,9 +203,11 @@ export function createTenantAdminRoutes(): Hono<{ Bindings: Bindings; Variables:
     const slug = c.req.param('slug')
     if (!(await isMultiTenantActive(db))) return c.json({ error: 'Multi-tenant plugin is not active' }, 403)
     try {
-      const role = String((await c.req.formData()).get('role') ?? '')
+      const form = await c.req.formData()
+      const role = String(form.get('role') ?? '')
+      const redirectTo = String(form.get('_redirect') ?? '') || `/admin/tenants/users/${userId}`
       await new TenantService(db).setMemberRole(slug, userId, role)
-      return c.redirect(`/admin/tenants/users/${userId}?message=Role updated`)
+      return c.redirect(`${redirectTo}?message=Role updated`)
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to update role'
       return c.redirect(`/admin/tenants/users/${userId}?message=${encodeURIComponent(message)}&type=error`)
@@ -215,8 +220,10 @@ export function createTenantAdminRoutes(): Hono<{ Bindings: Bindings; Variables:
     const slug = c.req.param('slug')
     if (!(await isMultiTenantActive(db))) return c.json({ error: 'Multi-tenant plugin is not active' }, 403)
     try {
+      const form = await c.req.formData()
+      const redirectTo = String(form.get('_redirect') ?? '') || `/admin/tenants/users/${userId}`
       await new TenantService(db).removeMember(slug, userId)
-      return c.redirect(`/admin/tenants/users/${userId}?message=Removed from ${encodeURIComponent(slug)}`)
+      return c.redirect(`${redirectTo}?message=Removed from ${encodeURIComponent(slug)}`)
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to remove membership'
       return c.redirect(`/admin/tenants/users/${userId}?message=${encodeURIComponent(message)}&type=error`)

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/routes/admin.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/routes/admin.ts
@@ -392,7 +392,8 @@ export function createTenantAdminRoutes(): Hono<{ Bindings: Bindings; Variables:
     if (!tenant) return c.redirect('/admin/tenants?message=Tenant not found&type=error')
 
     const [members, invitations] = await Promise.all([svc.listMembers(slug), svc.listInvitations(slug)])
-    const messageType = c.req.query('type') === 'error' ? 'error' as const : 'success' as const
+    const qt = c.req.query('type')
+    const messageType = qt === 'error' ? 'error' as const : qt === 'warning' ? 'warning' as const : 'success' as const
     return c.html(renderTenantMembers({
       slug, tenantName: tenant.name, members, invitations,
       user: userShape(user), version,
@@ -465,7 +466,8 @@ export function createTenantAdminRoutes(): Hono<{ Bindings: Bindings; Variables:
       // missing/failed mailer never blocks the invite (mirrors the password-reset flow).
       const origin = c.req.header('origin') || new URL(c.req.url).origin
       const acceptUrl = `${origin}/admin/tenants/invitations/accept?token=${encodeURIComponent(token)}`
-      let note = 'Invitation created'
+      let note: string
+      let noteType = ''
       if (hasEmailService()) {
         try {
           await getEmailService().send({
@@ -478,9 +480,15 @@ export function createTenantAdminRoutes(): Hono<{ Bindings: Bindings; Variables:
           note = 'Invitation created and emailed'
         } catch (err) {
           console.error('Failed to send invitation email:', err)
+          note = 'Invitation created — email failed to send, share the accept link manually'
+          noteType = 'warning'
         }
+      } else {
+        note = 'Invitation created — no email plugin active, share the accept link manually'
+        noteType = 'warning'
       }
-      return c.redirect(`/admin/tenants/${slug}/members?message=${encodeURIComponent(note)}`)
+      const typeParam = noteType ? `&type=${noteType}` : ''
+      return c.redirect(`/admin/tenants/${slug}/members?message=${encodeURIComponent(note)}${typeParam}`)
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to create invitation'
       return c.redirect(`/admin/tenants/${slug}/members?message=${encodeURIComponent(message)}&type=error`)

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/routes/admin.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/routes/admin.ts
@@ -236,14 +236,16 @@ export function createTenantAdminRoutes(): Hono<{ Bindings: Bindings; Variables:
     await svc.ensureDefaultTenant()
     const tenants = await svc.listTenants()
 
-    const { results } = await db.prepare(
-      'SELECT tenant_id, COUNT(*) as count FROM documents WHERE deleted_at IS NULL GROUP BY tenant_id'
-    ).all()
-    const counts = new Map((results ?? []).map((r: any) => [r.tenant_id, r.count as number]))
+    const [docRes, memberRes] = await db.batch([
+      db.prepare('SELECT tenant_id, COUNT(*) as count FROM documents WHERE deleted_at IS NULL GROUP BY tenant_id'),
+      db.prepare('SELECT t.slug, COUNT(m.id) as count FROM auth_tenant t LEFT JOIN auth_tenant_member m ON m.tenant_id = t.id GROUP BY t.id'),
+    ])
+    const counts = new Map((docRes?.results ?? []).map((r: any) => [r.tenant_id, r.count as number]))
+    const memberCounts = new Map((memberRes?.results ?? []).map((r: any) => [r.slug, r.count as number]))
 
     const messageType = c.req.query('type') === 'error' ? 'error' as const : 'success' as const
     return c.html(renderTenantsList({
-      tenants: tenants.map(t => ({ ...t, documentCount: counts.get(t.slug) ?? 0 })),
+      tenants: tenants.map(t => ({ ...t, documentCount: counts.get(t.slug) ?? 0, memberCount: memberCounts.get(t.slug) ?? 0 })),
       currentTenantId: c.get('tenantId') ?? 'default',
       user: userShape(user),
       version,

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/routes/admin.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/routes/admin.ts
@@ -466,7 +466,7 @@ export function createTenantAdminRoutes(): Hono<{ Bindings: Bindings; Variables:
       // Best-effort email delivery of the accept link. The link is also shown in the UI, so a
       // missing/failed mailer never blocks the invite (mirrors the password-reset flow).
       const origin = c.req.header('origin') || new URL(c.req.url).origin
-      const acceptUrl = `${origin}/admin/tenants/invitations/accept?token=${encodeURIComponent(token)}`
+      const acceptUrl = `${origin}/join/invite?token=${encodeURIComponent(token)}`
       let note: string
       let noteType = ''
       const svc2 = hasEmailService() ? getEmailService() : null
@@ -518,7 +518,7 @@ export function createTenantAdminRoutes(): Hono<{ Bindings: Bindings; Variables:
       if (!hasRealProvider) throw new Error('No email plugin active')
 
       const origin = c.req.header('origin') || new URL(c.req.url).origin
-      const acceptUrl = `${origin}/admin/tenants/invitations/accept?token=${encodeURIComponent(inv.id)}`
+      const acceptUrl = `${origin}/join/invite?token=${encodeURIComponent(inv.id)}`
       const result = await svc2!.send({
         to: inv.email,
         subject: `You're invited to the ${slug} workspace`,

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/routes/join.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/routes/join.ts
@@ -1,0 +1,264 @@
+/**
+ * Public invitation join routes — mounted at /join/invite (NO auth middleware).
+ *
+ * Handles the full invitation acceptance flow for unauthenticated users:
+ *   GET  /join/invite?token=X          → route to register or sign-in page
+ *   GET  /join/invite/register?token=X → registration form
+ *   POST /join/invite/register          → create user + accept invitation
+ *   POST /join/invite/sign-in           → sign in + accept invitation
+ *
+ * The accept URL in invitation emails points here instead of /admin/tenants/invitations/accept
+ * because /admin/* requires authentication at the app level.
+ *
+ * Already-authenticated users who click the accept link are handled by the admin route
+ * at GET /admin/tenants/invitations/accept (existing behaviour, unchanged).
+ */
+import { Hono } from 'hono'
+import type { D1Database, KVNamespace } from '@cloudflare/workers-types'
+import { TenantService } from '../services/tenant-service'
+import { AuthManager } from '../../../../middleware/auth'
+import { renderInvitationJoinPage, renderInvitationErrorPage } from '../templates/invitation-join.template'
+import { createAuth } from '../../../../auth/config'
+
+type Bindings = { DB: D1Database; KV: KVNamespace; JWT_SECRET?: string }
+type Variables = {
+  user?: { userId: string; email: string; role: string }
+  appVersion?: string
+}
+
+/** Look up a pending invitation row; returns null + error string if invalid/expired. */
+async function lookupPendingInvitation(
+  db: D1Database,
+  token: string,
+): Promise<{ inv: { id: string; email: string; role: string; tenantName: string; tenantSlug: string } } | { error: string }> {
+  if (!token) return { error: 'No invitation token provided.' }
+  try {
+    const row = await db.prepare(`
+      SELECT i.id, i.email, i.role, i.status, i.expires_at, t.name as tenant_name, t.slug as tenant_slug
+      FROM auth_tenant_invitation i
+      JOIN auth_tenant t ON t.id = i.tenant_id
+      WHERE i.id = ?
+    `).bind(token).first() as {
+      id?: string; email?: string; role?: string; status?: string
+      expires_at?: number; tenant_name?: string; tenant_slug?: string
+    } | null
+
+    if (!row?.id) return { error: 'Invitation not found.' }
+    if (row.status !== 'pending') return { error: 'This invitation has already been used or revoked.' }
+    if (Number(row.expires_at) < Date.now()) return { error: 'This invitation has expired.' }
+
+    return {
+      inv: {
+        id: row.id,
+        email: row.email!,
+        role: row.role || 'viewer',
+        tenantName: row.tenant_name || row.tenant_slug || 'Unknown',
+        tenantSlug: row.tenant_slug!,
+      },
+    }
+  } catch {
+    return { error: 'Failed to look up invitation.' }
+  }
+}
+
+/** Set Better Auth session cookie(s) from a successful sign-in response. */
+function copyBaCookies(baRes: Response, responseHeaders: Headers): void {
+  const raw = baRes.headers.get('set-cookie')
+  if (raw) {
+    responseHeaders.append('Set-Cookie', raw)
+    return
+  }
+  if ((baRes.headers as any).getSetCookie) {
+    for (const sc of (baRes.headers as any).getSetCookie()) {
+      responseHeaders.append('Set-Cookie', sc)
+    }
+  }
+}
+
+export function createJoinRoutes(): Hono<{ Bindings: Bindings; Variables: Variables }> {
+  const routes = new Hono<{ Bindings: Bindings; Variables: Variables }>()
+
+  // ─── GET /join/invite — route to register or sign-in page ────────────────────
+  routes.get('/', async (c) => {
+    const db = c.env.DB
+    const token = c.req.query('token') ?? ''
+    const version = c.get('appVersion')
+
+    // If already signed in, hand off to the admin accept route.
+    const user = c.get('user')
+    if (user) {
+      return c.redirect(`/admin/tenants/invitations/accept?token=${encodeURIComponent(token)}`)
+    }
+
+    const result = await lookupPendingInvitation(db, token)
+    if ('error' in result) return c.html(renderInvitationErrorPage(result.error, version), 400)
+
+    const { inv } = result
+    const existingUser = await db.prepare('SELECT id FROM auth_user WHERE LOWER(email) = ?')
+      .bind(inv.email.toLowerCase()).first()
+
+    return c.redirect(
+      existingUser
+        ? `/join/invite/sign-in?token=${encodeURIComponent(token)}`
+        : `/join/invite/register?token=${encodeURIComponent(token)}`,
+    )
+  })
+
+  // ─── GET /join/invite/register — registration form ───────────────────────────
+  routes.get('/register', async (c) => {
+    const db = c.env.DB
+    const token = c.req.query('token') ?? ''
+    const version = c.get('appVersion')
+
+    const user = c.get('user')
+    if (user) return c.redirect(`/admin/tenants/invitations/accept?token=${encodeURIComponent(token)}`)
+
+    const result = await lookupPendingInvitation(db, token)
+    if ('error' in result) return c.html(renderInvitationErrorPage(result.error, version), 400)
+
+    const { inv } = result
+    return c.html(renderInvitationJoinPage({
+      tenantName: inv.tenantName, tenantSlug: inv.tenantSlug, role: inv.role,
+      email: inv.email, token, mode: 'register', version,
+    }))
+  })
+
+  // ─── POST /join/invite/register — create user + accept ───────────────────────
+  routes.post('/register', async (c) => {
+    const db = c.env.DB
+    const version = c.get('appVersion')
+    const form = await c.req.formData()
+    const token = String(form.get('token') ?? '')
+    const firstName = String(form.get('firstName') ?? '').trim()
+    const lastName = String(form.get('lastName') ?? '').trim()
+    const password = String(form.get('password') ?? '')
+
+    const result = await lookupPendingInvitation(db, token)
+    if ('error' in result) return c.html(renderInvitationErrorPage(result.error, version), 400)
+
+    const { inv } = result
+
+    const rerender = (error: string) =>
+      c.html(renderInvitationJoinPage({
+        tenantName: inv.tenantName, tenantSlug: inv.tenantSlug, role: inv.role,
+        email: inv.email, token, mode: 'register', error, version,
+      }), 400)
+
+    if (!firstName) return rerender('First name is required.')
+    if (!lastName) return rerender('Last name is required.')
+    if (password.length < 8) return rerender('Password must be at least 8 characters.')
+
+    // Ensure no existing account for this email.
+    const existing = await db.prepare('SELECT id FROM auth_user WHERE LOWER(email) = ?')
+      .bind(inv.email.toLowerCase()).first()
+    if (existing) return rerender('An account with this email already exists. Please sign in instead.')
+
+    try {
+      // 1. Create user + credential row (mirrors register/form logic).
+      const userId = crypto.randomUUID()
+      const passwordHash = await AuthManager.hashPassword(password)
+      const now = Date.now()
+      const nowSec = Math.floor(now / 1000)
+
+      await db.batch([
+        db.prepare(
+          `INSERT INTO auth_user (id, email, first_name, last_name, password_hash, role, is_active, email_verified, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, 'viewer', 1, 1, ?, ?)`
+        ).bind(userId, inv.email.toLowerCase(), firstName, lastName, passwordHash, now, now),
+        db.prepare(
+          `INSERT OR IGNORE INTO auth_account (id, user_id, account_id, provider_id, password, created_at, updated_at)
+           VALUES (?, ?, ?, 'credential', ?, ?, ?)`
+        ).bind(`cred-${userId}`, userId, userId, passwordHash, nowSec, nowSec),
+      ])
+
+      // 2. Accept the invitation (adds tenant member row).
+      await new TenantService(db).acceptInvitation(token, userId, inv.email)
+
+      // 3. Sign in via Better Auth to get a proper session cookie.
+      const auth = createAuth(c.env as any)
+      const origin = new URL(c.req.url).origin
+      const baReq = new Request(`${origin}/auth/sign-in/email`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Origin': origin },
+        body: JSON.stringify({ email: inv.email.toLowerCase(), password }),
+      })
+      const baRes = await auth.handler(baReq)
+
+      const headers = new Headers({ Location: '/admin?message=Welcome! You have joined ' + encodeURIComponent(inv.tenantName) })
+      if (baRes.ok) copyBaCookies(baRes, headers)
+      return new Response(null, { status: 302, headers })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Registration failed'
+      return rerender(msg)
+    }
+  })
+
+  // ─── GET /join/invite/sign-in — sign-in form for existing users ───────────────
+  routes.get('/sign-in', async (c) => {
+    const db = c.env.DB
+    const token = c.req.query('token') ?? ''
+    const version = c.get('appVersion')
+
+    const user = c.get('user')
+    if (user) return c.redirect(`/admin/tenants/invitations/accept?token=${encodeURIComponent(token)}`)
+
+    const result = await lookupPendingInvitation(db, token)
+    if ('error' in result) return c.html(renderInvitationErrorPage(result.error, version), 400)
+
+    const { inv } = result
+    return c.html(renderInvitationJoinPage({
+      tenantName: inv.tenantName, tenantSlug: inv.tenantSlug, role: inv.role,
+      email: inv.email, token, mode: 'sign-in', version,
+    }))
+  })
+
+  // ─── POST /join/invite/sign-in — sign in existing user + accept ───────────────
+  routes.post('/sign-in', async (c) => {
+    const db = c.env.DB
+    const version = c.get('appVersion')
+    const form = await c.req.formData()
+    const token = String(form.get('token') ?? '')
+    const password = String(form.get('password') ?? '')
+
+    const result = await lookupPendingInvitation(db, token)
+    if ('error' in result) return c.html(renderInvitationErrorPage(result.error, version), 400)
+
+    const { inv } = result
+
+    const rerender = (error: string) =>
+      c.html(renderInvitationJoinPage({
+        tenantName: inv.tenantName, tenantSlug: inv.tenantSlug, role: inv.role,
+        email: inv.email, token, mode: 'sign-in', error, version,
+      }), 400)
+
+    try {
+      // Sign in via Better Auth.
+      const auth = createAuth(c.env as any)
+      const origin = new URL(c.req.url).origin
+      const baReq = new Request(`${origin}/auth/sign-in/email`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Origin': origin },
+        body: JSON.stringify({ email: inv.email.toLowerCase(), password }),
+      })
+      const baRes = await auth.handler(baReq)
+
+      if (!baRes.ok) return rerender('Incorrect password. Please try again.')
+
+      // Get the user ID from the BA session to accept the invitation.
+      const baBody = await baRes.json() as { user?: { id?: string } }
+      const userId = baBody?.user?.id
+      if (!userId) return rerender('Sign-in succeeded but could not read user ID.')
+
+      await new TenantService(db).acceptInvitation(token, userId, inv.email)
+
+      const headers = new Headers({ Location: '/admin?message=Welcome! You have joined ' + encodeURIComponent(inv.tenantName) })
+      copyBaCookies(baRes, headers)
+      return new Response(null, { status: 302, headers })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Sign-in failed'
+      return rerender(msg)
+    }
+  })
+
+  return routes
+}

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/services/tenant-service.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/services/tenant-service.ts
@@ -272,7 +272,11 @@ export class TenantService {
     const user = await this.db.prepare('SELECT id, email FROM auth_user WHERE lower(email) = ?')
       .bind(normalized).first() as { id?: string; email?: string } | null
     if (!user?.id) throw new Error(`No user found with email '${email}'`)
-    if (await this.isMember(user.id, slug)) throw new Error(`${email} is already a member of '${slug}'`)
+    const existing = await this.db.prepare(`
+      SELECT 1 FROM auth_tenant_member m JOIN auth_tenant t ON t.id = m.tenant_id
+      WHERE m.user_id = ? AND t.slug = ? LIMIT 1
+    `).bind(user.id, slug).first()
+    if (existing) throw new Error(`${email} is already a member of '${slug}'`)
 
     await this.addMember(slug, user.id, role, user.email ?? normalized)
   }
@@ -330,8 +334,12 @@ export class TenantService {
 
     const existingUser = await this.db.prepare('SELECT id FROM auth_user WHERE lower(email) = ?')
       .bind(normalized).first() as { id?: string } | null
-    if (existingUser?.id && await this.isMember(existingUser.id, slug)) {
-      throw new Error(`${email} is already a member of '${slug}'`)
+    if (existingUser?.id) {
+      const alreadyMember = await this.db.prepare(`
+        SELECT 1 FROM auth_tenant_member m JOIN auth_tenant t ON t.id = m.tenant_id
+        WHERE m.user_id = ? AND t.slug = ? LIMIT 1
+      `).bind(existingUser.id, slug).first()
+      if (alreadyMember) throw new Error(`${email} is already a member of '${slug}'`)
     }
     const pending = await this.db.prepare(`
       SELECT i.id FROM auth_tenant_invitation i

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/invitation-join.template.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/invitation-join.template.ts
@@ -1,0 +1,134 @@
+import { escapeHtml } from '../../../../utils/sanitize'
+
+export interface InvitationJoinPageData {
+  tenantName: string
+  tenantSlug: string
+  role: string
+  email: string
+  token: string
+  mode: 'register' | 'sign-in'
+  error?: string
+  version?: string
+}
+
+export function renderInvitationJoinPage(data: InvitationJoinPageData): string {
+  const e = escapeHtml
+  const isRegister = data.mode === 'register'
+  const title = isRegister ? 'Create account to accept invitation' : 'Sign in to accept invitation'
+  const action = isRegister ? '/join/invite/register' : '/join/invite/sign-in'
+
+  const fields = isRegister ? `
+    <div class="grid grid-cols-2 gap-4">
+      <div>
+        <label class="block text-sm font-medium text-zinc-200 mb-1">First name</label>
+        <input type="text" name="firstName" required autocomplete="given-name"
+          class="w-full rounded-lg bg-white/10 border border-white/20 px-3 py-2 text-sm text-white placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-white/30">
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-zinc-200 mb-1">Last name</label>
+        <input type="text" name="lastName" required autocomplete="family-name"
+          class="w-full rounded-lg bg-white/10 border border-white/20 px-3 py-2 text-sm text-white placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-white/30">
+      </div>
+    </div>
+    <div>
+      <label class="block text-sm font-medium text-zinc-200 mb-1">Password</label>
+      <input type="password" name="password" required minlength="8" autocomplete="new-password"
+        placeholder="Minimum 8 characters"
+        class="w-full rounded-lg bg-white/10 border border-white/20 px-3 py-2 text-sm text-white placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-white/30">
+    </div>` : `
+    <div>
+      <label class="block text-sm font-medium text-zinc-200 mb-1">Password</label>
+      <input type="password" name="password" required autocomplete="current-password"
+        class="w-full rounded-lg bg-white/10 border border-white/20 px-3 py-2 text-sm text-white placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-white/30">
+    </div>`
+
+  const errorHtml = data.error
+    ? `<div class="rounded-lg bg-red-500/20 border border-red-500/30 px-4 py-3 text-sm text-red-300">${e(data.error)}</div>`
+    : ''
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${e(title)} - SonicJS</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen bg-zinc-950 flex items-center justify-center p-4">
+  <div class="w-full max-w-md">
+    <!-- Logo -->
+    <div class="text-center mb-8">
+      <a href="/" class="inline-flex items-center gap-2 text-white font-bold text-xl">
+        <svg class="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+        </svg>
+        SonicJS
+      </a>
+    </div>
+
+    <!-- Invitation context -->
+    <div class="rounded-xl bg-white/5 border border-white/10 px-6 py-4 mb-6 text-center">
+      <p class="text-sm text-zinc-400 mb-1">You've been invited to join</p>
+      <p class="text-lg font-semibold text-white">${e(data.tenantName)}</p>
+      <p class="text-sm text-zinc-400 mt-1">as <span class="text-white font-medium">${e(data.role)}</span></p>
+    </div>
+
+    <!-- Form card -->
+    <div class="rounded-xl bg-white/5 border border-white/10 px-6 py-8">
+      <h1 class="text-lg font-semibold text-white mb-6">${e(title)}</h1>
+
+      ${errorHtml}
+
+      <form method="POST" action="${e(action)}" class="space-y-4 ${data.error ? 'mt-4' : ''}">
+        <input type="hidden" name="token" value="${e(data.token)}">
+
+        <!-- Email (pre-filled, readonly) -->
+        <div>
+          <label class="block text-sm font-medium text-zinc-200 mb-1">Email</label>
+          <input type="email" name="email" value="${e(data.email)}" readonly
+            class="w-full rounded-lg bg-white/5 border border-white/10 px-3 py-2 text-sm text-zinc-400 cursor-not-allowed">
+        </div>
+
+        ${fields}
+
+        <button type="submit"
+          class="w-full rounded-lg bg-white px-4 py-2.5 text-sm font-semibold text-zinc-950 hover:bg-zinc-100 transition-colors mt-2">
+          ${isRegister ? 'Create account &amp; accept invitation' : 'Sign in &amp; accept invitation'}
+        </button>
+      </form>
+    </div>
+
+    ${data.version ? `<p class="text-center text-xs text-zinc-600 mt-6">SonicJS ${e(data.version)}</p>` : ''}
+  </div>
+</body>
+</html>`
+}
+
+export function renderInvitationErrorPage(message: string, version?: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Invalid Invitation - SonicJS</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen bg-zinc-950 flex items-center justify-center p-4">
+  <div class="w-full max-w-md text-center">
+    <div class="rounded-xl bg-white/5 border border-white/10 px-6 py-10">
+      <svg class="h-12 w-12 text-red-400 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+      </svg>
+      <h1 class="text-xl font-semibold text-white mb-2">Invitation invalid</h1>
+      <p class="text-sm text-zinc-400 mb-6">${escapeHtml(message)}</p>
+      <a href="/auth/login" class="inline-flex items-center rounded-lg bg-white px-4 py-2 text-sm font-semibold text-zinc-950 hover:bg-zinc-100">
+        Go to sign in
+      </a>
+    </div>
+    ${version ? `<p class="text-xs text-zinc-600 mt-6">SonicJS ${escapeHtml(version)}</p>` : ''}
+  </div>
+</body>
+</html>`
+}

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/tenant-members.template.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/tenant-members.template.ts
@@ -75,6 +75,7 @@ function renderInvitations(slug: string, invitations: TenantInvitation[]): strin
           <div class="flex-1 min-w-[16rem]">
             <label for="invite-email" class="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">Invite email</label>
             <input id="invite-email" name="email" type="email" required placeholder="invitee@example.com"
+              autocomplete="off"
               class="w-full rounded-lg border border-zinc-950/10 bg-white px-3 py-2 text-sm text-zinc-950 dark:border-white/10 dark:bg-zinc-800 dark:text-white">
           </div>
           <div>
@@ -130,6 +131,7 @@ export function renderTenantMembers(data: TenantMembersPageData): string {
             <input id="member-email" name="email" type="email" required placeholder="user@example.com"
               list="member-email-suggestions"
               hx-get="/admin/tenants/users/search" hx-trigger="keyup changed delay:300ms" hx-target="#member-email-suggestions" hx-swap="innerHTML" hx-include="this"
+              autocomplete="off"
               class="w-full rounded-lg border border-zinc-950/10 bg-white px-3 py-2 text-sm text-zinc-950 dark:border-white/10 dark:bg-zinc-800 dark:text-white">
           <datalist id="member-email-suggestions"></datalist>
           </div>

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/tenant-members.template.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/tenant-members.template.ts
@@ -11,6 +11,8 @@ export interface TenantMembersPageData {
   version?: string
   message?: string
   messageType?: 'success' | 'error' | 'warning'
+  /** When set alongside a warning: renders a "Try again" button to resend the invitation email. */
+  retryInvitationId?: string
 }
 
 function roleOptions(selected: string): string {
@@ -106,13 +108,22 @@ function renderInvitations(slug: string, invitations: TenantInvitation[]): strin
 
 export function renderTenantMembers(data: TenantMembersPageData): string {
   const alert = data.message
-    ? `<div data-members-alert class="mb-6 rounded-lg border px-4 py-3 text-sm ${
-        data.messageType === 'error'
+    ? (() => {
+        const colorClass = data.messageType === 'error'
           ? 'border-red-500/20 bg-red-500/10 text-red-700 dark:text-red-400'
           : data.messageType === 'warning'
           ? 'border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-400'
           : 'border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400'
-      }">${escapeHtml(data.message)}</div>`
+        const retryBtn = data.messageType === 'warning' && data.retryInvitationId
+          ? `<form method="POST" action="/admin/tenants/${escapeHtml(data.slug)}/invitations/${escapeHtml(data.retryInvitationId)}/resend" class="shrink-0">
+              <button type="submit" class="rounded-lg bg-amber-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-700 dark:bg-amber-500 dark:hover:bg-amber-400">Try again</button>
+            </form>`
+          : ''
+        return `<div data-members-alert class="mb-6 flex items-center justify-between gap-4 rounded-lg border px-4 py-3 text-sm ${colorClass}">
+          <span>${escapeHtml(data.message)}</span>
+          ${retryBtn}
+        </div>`
+      })()
     : ''
 
   const slug = escapeHtml(data.slug)

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/tenant-members.template.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/tenant-members.template.ts
@@ -52,7 +52,7 @@ function renderInvitations(slug: string, invitations: TenantInvitation[]): strin
   const s = escapeHtml(slug)
   const rows = invitations.length
     ? invitations.map((inv) => {
-        const acceptUrl = `/admin/tenants/invitations/accept?token=${encodeURIComponent(inv.id)}`
+        const acceptUrl = `/join/invite?token=${encodeURIComponent(inv.id)}`
         return `
         <tr data-invite-row="${escapeHtml(inv.email)}" class="border-b border-zinc-950/5 dark:border-white/5">
           <td class="px-4 py-3 text-sm text-zinc-950 dark:text-white">${escapeHtml(inv.email)}</td>

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/tenant-members.template.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/tenant-members.template.ts
@@ -128,7 +128,10 @@ export function renderTenantMembers(data: TenantMembersPageData): string {
           <div class="flex-1 min-w-[16rem]">
             <label for="member-email" class="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">User email</label>
             <input id="member-email" name="email" type="email" required placeholder="user@example.com"
+              list="member-email-suggestions"
+              hx-get="/admin/tenants/users/search" hx-trigger="keyup changed delay:300ms" hx-target="#member-email-suggestions" hx-swap="innerHTML" hx-include="this"
               class="w-full rounded-lg border border-zinc-950/10 bg-white px-3 py-2 text-sm text-zinc-950 dark:border-white/10 dark:bg-zinc-800 dark:text-white">
+          <datalist id="member-email-suggestions"></datalist>
           </div>
           <div>
             <label for="member-role" class="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">Role</label>

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/tenant-members.template.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/tenant-members.template.ts
@@ -10,7 +10,7 @@ export interface TenantMembersPageData {
   user?: { name: string; email: string; role: string }
   version?: string
   message?: string
-  messageType?: 'success' | 'error'
+  messageType?: 'success' | 'error' | 'warning'
 }
 
 function roleOptions(selected: string): string {
@@ -109,6 +109,8 @@ export function renderTenantMembers(data: TenantMembersPageData): string {
     ? `<div data-members-alert class="mb-6 rounded-lg border px-4 py-3 text-sm ${
         data.messageType === 'error'
           ? 'border-red-500/20 bg-red-500/10 text-red-700 dark:text-red-400'
+          : data.messageType === 'warning'
+          ? 'border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-400'
           : 'border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400'
       }">${escapeHtml(data.message)}</div>`
     : ''

--- a/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/tenants-list.template.ts
+++ b/packages/core/src/plugins/core-plugins/multi-tenant-plugin/templates/tenants-list.template.ts
@@ -3,7 +3,7 @@ import { escapeHtml } from '../../../../utils/sanitize'
 import type { TenantData } from '../services/tenant-service'
 
 export interface TenantsListPageData {
-  tenants: Array<TenantData & { documentCount: number }>
+  tenants: Array<TenantData & { documentCount: number; memberCount: number }>
   currentTenantId: string
   user?: { name: string; email: string; role: string }
   version?: string
@@ -17,7 +17,7 @@ function statusBadge(status: string): string {
     : '<span class="inline-flex items-center rounded-md bg-zinc-500/10 px-2 py-1 text-xs font-medium text-zinc-600 dark:text-zinc-400">Inactive</span>'
 }
 
-function renderRow(tenant: TenantData & { documentCount: number }, currentTenantId: string): string {
+function renderRow(tenant: TenantData & { documentCount: number; memberCount: number }, currentTenantId: string): string {
   const slug = escapeHtml(tenant.slug)
   const isCurrent = tenant.slug === currentTenantId
   const isDefault = tenant.slug === 'default'
@@ -33,6 +33,7 @@ function renderRow(tenant: TenantData & { documentCount: number }, currentTenant
       <td class="px-4 py-3 text-sm text-zinc-600 dark:text-zinc-400">${tenant.domain ? escapeHtml(tenant.domain) : '—'}</td>
       <td class="px-4 py-3">${statusBadge(tenant.status)}</td>
       <td class="px-4 py-3 text-sm text-zinc-600 dark:text-zinc-400" data-tenant-doc-count>${tenant.documentCount}</td>
+      <td class="px-4 py-3 text-sm text-zinc-600 dark:text-zinc-400" data-tenant-member-count>${tenant.memberCount}</td>
       <td class="px-4 py-3">
         <div class="flex items-center justify-end gap-2">
           ${
@@ -91,6 +92,7 @@ export function renderTenantsList(data: TenantsListPageData): string {
               <th class="px-4 py-3">Domain</th>
               <th class="px-4 py-3">Status</th>
               <th class="px-4 py-3">Documents</th>
+              <th class="px-4 py-3">Members</th>
               <th class="px-4 py-3 text-right">Actions</th>
             </tr>
           </thead>

--- a/packages/core/src/routes/admin-users.ts
+++ b/packages/core/src/routes/admin-users.ts
@@ -9,6 +9,7 @@ import { renderUserNewPage, type UserNewPageData } from '../templates/pages/admi
 import { renderUsersListPage, type UsersListPageData, type User } from '../templates/pages/admin-users-list.template'
 import type { Bindings, Variables } from '../app'
 import { getUserProfileConfig, renderCustomProfileSection, getCustomData, saveCustomData, extractCustomFieldsFromForm, sanitizeCustomData, validateCustomData, readProfileData, writeProfileData } from '../plugins/core-plugins/user-profiles'
+import { TenantService, VALID_MEMBER_ROLES } from '../plugins/core-plugins/multi-tenant-plugin/services/tenant-service'
 
 const userRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>()
 
@@ -869,18 +870,39 @@ userRoutes.get('/users/:id/edit', async (c) => {
       profile
     }
 
-    // Multi-tenant plugin active? (same source of truth as middleware/tenant.ts). When active, the
-    // edit page links to the user's per-tenant membership management. Single-tenant installs: no link.
+    // Multi-tenant plugin active? Fetch memberships inline for the matrix section.
     const mtRow = await db.prepare(
       `SELECT 1 FROM documents WHERE type_id = 'plugin' AND slug = 'multi-tenant'
          AND q_plugin_status = 'active' AND is_current_draft = 1 AND deleted_at IS NULL`
     ).first().catch(() => null)
 
+    let tenantMemberships: UserEditPageData['tenantMemberships']
+    if (mtRow) {
+      const svc = new TenantService(db)
+      const [memberships, allTenants] = await Promise.all([
+        svc.listUserMemberships(userId),
+        svc.listTenants(),
+      ])
+      const memberSlugs = new Set(memberships.map((m) => m.slug))
+      tenantMemberships = {
+        memberships,
+        availableTenants: allTenants
+          .filter((t) => t.status === 'active' && !memberSlugs.has(t.slug))
+          .map((t) => ({ slug: t.slug, name: t.name })),
+        memberRoles: [...VALID_MEMBER_ROLES],
+      }
+    }
+
+    const queryMessage = c.req.query('message')
+    const queryType = c.req.query('type') === 'error' ? 'error' : 'success'
+
     const pageData: UserEditPageData = {
       userToEdit: editData,
       roles: ROLES,
       customProfileFieldsHtml,
-      tenantMembershipsHref: mtRow ? `/admin/tenants/users/${userId}` : undefined,
+      tenantMemberships,
+      ...(queryMessage && queryType === 'error' ? { error: queryMessage } : {}),
+      ...(queryMessage && queryType === 'success' ? { success: queryMessage } : {}),
       user: {
         name: user!.email.split('@')[0] || user!.email,
         email: user!.email,

--- a/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
+++ b/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
@@ -662,9 +662,10 @@ function renderCatalystSidebar(
       <!-- Sidebar Header -->
       <div class="flex w-full flex-col border-b border-zinc-950/5 p-4 dark:border-white/5">
         ${renderLogo({ size: "md", showText: true, variant: "white", version, href: "/admin/content" })}
-        <!-- Tenant switcher (injected by tenantMiddleware when the multi-tenant plugin is active) -->
-        <!-- TENANT_SWITCHER -->
       </div>
+
+      <!-- Tenant switcher (injected by tenantMiddleware when the multi-tenant plugin is active) -->
+      <!-- TENANT_SWITCHER -->
 
       <!-- Sidebar Body -->
       <div class="flex flex-1 flex-col overflow-y-auto p-4">

--- a/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
+++ b/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
@@ -728,12 +728,12 @@ function renderCatalystSidebar(
                 class="flex items-center justify-center rounded-lg p-2 text-zinc-500 hover:bg-zinc-950/5 dark:text-zinc-400 dark:hover:bg-white/5 flex-shrink-0"
                 aria-label="Toggle plugins submenu"
               >
-                <svg data-plugins-chevron class="h-4 w-4 transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg data-plugins-chevron class="h-4 w-4 rotate-180 transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
                 </svg>
               </button>
             </div>
-            <div data-plugins-submenu class="pl-6 mt-0.5 flex flex-col gap-0.5 hidden">
+            <div data-plugins-submenu class="pl-6 mt-0.5 flex flex-col gap-0.5">
               ${pluginsSubItems}
             </div>
           </div>

--- a/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
+++ b/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
@@ -660,7 +660,7 @@ function renderCatalystSidebar(
       ${closeButton}
 
       <!-- Sidebar Header -->
-      <div class="flex flex-col border-b border-zinc-950/5 p-4 dark:border-white/5">
+      <div class="flex w-full flex-col border-b border-zinc-950/5 p-4 dark:border-white/5">
         ${renderLogo({ size: "md", showText: true, variant: "white", version, href: "/admin/content" })}
         <!-- Tenant switcher (injected by tenantMiddleware when the multi-tenant plugin is active) -->
         <!-- TENANT_SWITCHER -->

--- a/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
+++ b/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
@@ -242,7 +242,10 @@ export function renderAdminLayoutCatalyst(
       transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
       transition-duration: 150ms;
     }
+    .plugins-closed [data-plugins-submenu] { display: none; }
   </style>
+  <!-- Restore plugins submenu state before first paint (no flash) -->
+  <script>(function(){try{var c=document.cookie.split(';').reduce(function(v,p){var t=p.trim().split('=');return t[0]==='plugins_menu_open'?t[1]:v;},null);if(c==='0'){document.documentElement.classList.add('plugins-closed');document.addEventListener('DOMContentLoaded',function(){var ch=document.querySelector('[data-plugins-chevron]');if(ch)ch.classList.remove('rotate-180');});};}catch(e){}})();</script>
 
   <!-- Scripts -->
   <script src="https://unpkg.com/htmx.org@2.0.3"></script>
@@ -536,31 +539,22 @@ export function renderAdminLayoutCatalyst(
 
     // Plugins accordion toggle
     function togglePluginsMenu(btn) {
-      var accordion = btn.closest('[data-plugins-accordion]');
-      var submenu = accordion.querySelector('[data-plugins-submenu]');
+      var isNowClosed = document.documentElement.classList.toggle('plugins-closed');
       var chevron = btn.querySelector('[data-plugins-chevron]');
-      var isNowHidden = submenu.classList.toggle('hidden');
       if (chevron) chevron.classList.toggle('rotate-180');
-      document.cookie = 'plugins_menu_open=' + (isNowHidden ? '0' : '1') + ';path=/;max-age=31536000';
+      document.cookie = 'plugins_menu_open=' + (isNowClosed ? '0' : '1') + ';path=/;max-age=31536000';
     }
 
-    // Restore plugins submenu state from cookie (active sub-item always wins open)
+    // Auto-expand plugins submenu if a sub-item is currently active (overrides closed cookie)
     document.addEventListener('DOMContentLoaded', function() {
-      var cookieOpen = document.cookie.split(';').reduce(function(v, p) {
-        var parts = p.trim().split('=');
-        return parts[0] === 'plugins_menu_open' ? parts[1] : v;
-      }, null);
       document.querySelectorAll('[data-plugins-submenu]').forEach(function(submenu) {
-        var accordion = submenu.closest('[data-plugins-accordion]');
-        var chevron = accordion ? accordion.querySelector('[data-plugins-chevron]') : null;
-        var hasActive = !!submenu.querySelector('[data-current="true"]');
-        var shouldOpen = hasActive || cookieOpen !== '0';
-        if (shouldOpen) {
-          submenu.classList.remove('hidden');
-          if (chevron) chevron.classList.add('rotate-180');
-        } else {
-          submenu.classList.add('hidden');
-          if (chevron) chevron.classList.remove('rotate-180');
+        if (submenu.querySelector('[data-current="true"]')) {
+          document.documentElement.classList.remove('plugins-closed');
+          var accordion = submenu.closest('[data-plugins-accordion]');
+          if (accordion) {
+            var chevron = accordion.querySelector('[data-plugins-chevron]');
+            if (chevron) chevron.classList.add('rotate-180');
+          }
         }
       });
     });

--- a/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
+++ b/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
@@ -571,13 +571,6 @@ function renderCatalystSidebar(
 ): string {
   let baseMenuItems = [
     {
-      label: "Home",
-      path: "/admin",
-      icon: `<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
-        <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"/>
-      </svg>`,
-    },
-    {
       label: "Content",
       path: "/admin/content",
       icon: `<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">

--- a/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
+++ b/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
@@ -662,6 +662,8 @@ function renderCatalystSidebar(
       <!-- Sidebar Header -->
       <div class="flex flex-col border-b border-zinc-950/5 p-4 dark:border-white/5">
         ${renderLogo({ size: "md", showText: true, variant: "white", version, href: "/admin/content" })}
+        <!-- Tenant switcher (injected by tenantMiddleware when the multi-tenant plugin is active) -->
+        <!-- TENANT_SWITCHER -->
       </div>
 
       <!-- Sidebar Body -->
@@ -816,9 +818,6 @@ function renderCatalystSidebar(
           `;
         })()}
       </div>
-
-      <!-- Tenant switcher (injected by tenantMiddleware when the multi-tenant plugin is active) -->
-      <!-- TENANT_SWITCHER -->
 
       <!-- Sidebar Footer (User) -->
       ${

--- a/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
+++ b/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
@@ -539,20 +539,28 @@ export function renderAdminLayoutCatalyst(
       var accordion = btn.closest('[data-plugins-accordion]');
       var submenu = accordion.querySelector('[data-plugins-submenu]');
       var chevron = btn.querySelector('[data-plugins-chevron]');
-      submenu.classList.toggle('hidden');
+      var isNowHidden = submenu.classList.toggle('hidden');
       if (chevron) chevron.classList.toggle('rotate-180');
+      document.cookie = 'plugins_menu_open=' + (isNowHidden ? '0' : '1') + ';path=/;max-age=31536000';
     }
 
-    // Auto-expand plugins submenu if a sub-item is currently active
+    // Restore plugins submenu state from cookie (active sub-item always wins open)
     document.addEventListener('DOMContentLoaded', function() {
+      var cookieOpen = document.cookie.split(';').reduce(function(v, p) {
+        var parts = p.trim().split('=');
+        return parts[0] === 'plugins_menu_open' ? parts[1] : v;
+      }, null);
       document.querySelectorAll('[data-plugins-submenu]').forEach(function(submenu) {
-        if (submenu.querySelector('[data-current="true"]')) {
+        var accordion = submenu.closest('[data-plugins-accordion]');
+        var chevron = accordion ? accordion.querySelector('[data-plugins-chevron]') : null;
+        var hasActive = !!submenu.querySelector('[data-current="true"]');
+        var shouldOpen = hasActive || cookieOpen !== '0';
+        if (shouldOpen) {
           submenu.classList.remove('hidden');
-          var accordion = submenu.closest('[data-plugins-accordion]');
-          if (accordion) {
-            var chevron = accordion.querySelector('[data-plugins-chevron]');
-            if (chevron) chevron.classList.add('rotate-180');
-          }
+          if (chevron) chevron.classList.add('rotate-180');
+        } else {
+          submenu.classList.add('hidden');
+          if (chevron) chevron.classList.remove('rotate-180');
         }
       });
     });

--- a/packages/core/src/templates/pages/admin-user-edit.template.ts
+++ b/packages/core/src/templates/pages/admin-user-edit.template.ts
@@ -167,7 +167,7 @@ export function renderUserEditPage(data: UserEditPageData): string {
       </div>
 
       <!-- Alert Messages -->
-      <div id="form-messages">
+      <div id="form-messages" class="mb-6 empty:mb-0">
         ${data.error ? renderAlert({ type: 'error', message: data.error, dismissible: true }) : ''}
         ${data.success ? renderAlert({ type: 'success', message: data.success, dismissible: true }) : ''}
       </div>

--- a/packages/core/src/templates/pages/admin-user-edit.template.ts
+++ b/packages/core/src/templates/pages/admin-user-edit.template.ts
@@ -29,13 +29,105 @@ export interface UserEditPageData {
   error?: string
   success?: string
   customProfileFieldsHtml?: string
-  /** When the multi-tenant plugin is active: link to this user's per-tenant membership management. */
-  tenantMembershipsHref?: string
+  /** When the multi-tenant plugin is active: inline membership matrix data. */
+  tenantMemberships?: {
+    memberships: Array<{ slug: string; name: string; role: string }>
+    availableTenants: Array<{ slug: string; name: string }>
+    memberRoles: string[]
+  }
   user?: {
     name: string
     email: string
     role: string
   }
+}
+
+function renderTenantMembershipsSection(
+  userId: string,
+  tm?: UserEditPageData['tenantMemberships'],
+): string {
+  if (!tm) return ''
+  const uid = escapeHtml(userId)
+  const redirectField = `<input type="hidden" name="_redirect" value="/admin/users/${uid}/edit">`
+  const count = tm.memberships.length
+
+  const rows = count
+    ? tm.memberships.map((m) => {
+        const slug = escapeHtml(m.slug)
+        const roleOpts = tm.memberRoles
+          .map((r) => `<option value="${r}" ${r === m.role ? 'selected' : ''}>${r}</option>`)
+          .join('')
+        return `
+        <tr data-membership-row="${slug}" class="border-b border-zinc-950/5 last:border-0 dark:border-white/5">
+          <td class="px-4 py-3">
+            <div class="font-medium text-zinc-950 dark:text-white">${escapeHtml(m.name)}</div>
+            <div class="font-mono text-xs text-zinc-500 dark:text-zinc-400">${slug}</div>
+          </td>
+          <td class="px-4 py-3">
+            <form method="POST" action="/admin/tenants/users/${uid}/memberships/${slug}/role" class="flex items-center gap-2">
+              ${redirectField}
+              <select name="role" onchange="this.form.requestSubmit ? this.form.requestSubmit() : this.form.submit()"
+                class="rounded-lg border border-zinc-950/10 bg-white px-2 py-1.5 text-sm text-zinc-950 dark:border-white/10 dark:bg-zinc-800 dark:text-white">
+                ${roleOpts}
+              </select>
+            </form>
+          </td>
+          <td class="px-4 py-3 text-right">
+            <form method="POST" action="/admin/tenants/users/${uid}/memberships/${slug}/delete" class="inline"
+              onsubmit="return confirm('Remove this user from ${slug}?')">
+              ${redirectField}
+              <button type="submit" data-remove-membership="${slug}" class="rounded-lg px-2.5 py-1.5 text-sm font-medium text-red-600 hover:bg-red-500/10 dark:text-red-400">Remove</button>
+            </form>
+          </td>
+        </tr>`
+      }).join('')
+    : `<tr><td colspan="3" class="px-4 py-6 text-sm text-zinc-500 text-center dark:text-zinc-400">Not a member of any tenant.</td></tr>`
+
+  const addForm = tm.availableTenants.length
+    ? `<div class="mt-4 border-t border-zinc-950/5 pt-4 dark:border-white/5">
+        <form method="POST" action="/admin/tenants/users/${uid}/memberships" class="flex flex-wrap items-end gap-3">
+          ${redirectField}
+          <div class="flex-1 min-w-[12rem]">
+            <label class="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">Add to tenant</label>
+            <select name="slug" class="w-full rounded-lg border border-zinc-950/10 bg-white px-2 py-2 text-sm text-zinc-950 dark:border-white/10 dark:bg-zinc-800 dark:text-white">
+              ${tm.availableTenants.map((t) => `<option value="${escapeHtml(t.slug)}">${escapeHtml(t.name)}</option>`).join('')}
+            </select>
+          </div>
+          <div>
+            <label class="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">Role</label>
+            <select name="role" class="rounded-lg border border-zinc-950/10 bg-white px-2 py-2 text-sm text-zinc-950 dark:border-white/10 dark:bg-zinc-800 dark:text-white">
+              ${tm.memberRoles.map((r) => `<option value="${r}" ${r === 'viewer' ? 'selected' : ''}>${r}</option>`).join('')}
+            </select>
+          </div>
+          <button type="submit" class="rounded-lg bg-zinc-950 px-3.5 py-2 text-sm font-semibold text-white hover:bg-zinc-800 dark:bg-white dark:text-zinc-950 dark:hover:bg-zinc-200">Add</button>
+        </form>
+      </div>`
+    : `<p class="mt-4 text-sm text-zinc-500 dark:text-zinc-400">Member of all tenants.</p>`
+
+  const defaultOpen = count <= 5
+  return `
+    <details class="group mt-6" ${defaultOpen ? 'open' : ''} data-tenant-memberships>
+      <summary class="flex cursor-pointer list-none items-center justify-between rounded-xl bg-white px-6 py-4 shadow-sm ring-1 ring-zinc-950/5 dark:bg-zinc-900 dark:ring-white/10 select-none">
+        <div class="flex items-center gap-3">
+          <svg class="h-4 w-4 text-zinc-400 transition-transform group-open:rotate-90 dark:text-zinc-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+          <h3 class="text-base font-semibold text-zinc-950 dark:text-white">Tenant memberships</h3>
+        </div>
+        <span class="text-sm font-normal text-zinc-500 dark:text-zinc-400">${count} tenant${count !== 1 ? 's' : ''}</span>
+      </summary>
+      <div class="mt-1 rounded-xl bg-white shadow-sm ring-1 ring-zinc-950/5 dark:bg-zinc-900 dark:ring-white/10">
+        <table class="w-full text-left">
+          <thead>
+            <tr class="border-b border-zinc-950/5 text-xs font-medium uppercase tracking-wide text-zinc-500 dark:border-white/5 dark:text-zinc-400">
+              <th class="px-4 py-3">Tenant</th>
+              <th class="px-4 py-3">Role</th>
+              <th class="px-4 py-3 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>${rows}</tbody>
+        </table>
+        <div class="px-4 pb-4">${addForm}</div>
+      </div>
+    </details>`
 }
 
 export function renderUserEditPage(data: UserEditPageData): string {
@@ -170,16 +262,6 @@ export function renderUserEditPage(data: UserEditPageData): string {
 
               ${data.customProfileFieldsHtml || ''}
 
-              ${data.tenantMembershipsHref ? `
-              <!-- Tenant Memberships (multi-tenant plugin) -->
-              <div class="mb-8">
-                <h3 class="text-base font-semibold text-zinc-950 dark:text-white mb-2">Tenant memberships</h3>
-                <p class="text-sm text-zinc-600 dark:text-zinc-400 mb-3">Assign this user to one or more tenants and set their role within each.</p>
-                <a href="${data.tenantMembershipsHref}" data-tenant-memberships-link class="inline-flex items-center gap-2 rounded-lg bg-zinc-950 px-3.5 py-2 text-sm font-semibold text-white hover:bg-zinc-800 dark:bg-white dark:text-zinc-950 dark:hover:bg-zinc-200">
-                  Manage tenant memberships
-                  <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
-                </a>
-              </div>` : ''}
 
               <!-- Set Password -->
               <div class="mb-8">
@@ -345,6 +427,8 @@ export function renderUserEditPage(data: UserEditPageData): string {
         </div>
       </div>
     </div>
+
+    ${renderTenantMembershipsSection(data.userToEdit.id, data.tenantMemberships)}
 
     <script>
       let userIdToDelete = null;


### PR DESCRIPTION
## Summary

Full multi-tenancy plugin feature set built on the existing document model:

- **Sidebar**: Remove Home nav link (Content is entry point); tenant switcher below logo with border separation; plugins submenu expanded by default with cookie persistence and no-flash CSS class pattern
- **Tenant list**: Member count column
- **Members page**: Email typeahead (HTMX datalist) on add-member form; autofill suppression; duplicate-member bug fix (replaced broken `isMember()` call with direct SQL check); honest invitation email status (green/amber/red based on actual send result, console-provider detection); amber warning with "Try again" button on send failure; resend route `POST /:slug/invitations/:id/resend`
- **User edit page**: Inline tenant memberships matrix (collapsible `<details>`, open ≤5 tenants) replaces separate page link; `_redirect` field on membership POST forms bounces back to edit page; `?message` query param wired to edit page alerts
- **Invitation accept flow**: Public `/join/invite` routes (outside `/admin/*` auth gate) handle unauthenticated invitees — new users get a registration form (email pre-filled/readonly), existing users get a sign-in form; both create a BA session and accept the invite atomically
- **Tenant switch**: Content detail pages redirect to `/admin/content` list on tenant switch

## Test plan

- [ ] Create tenant, add member by email (typeahead works, duplicate blocked)
- [ ] Send invitation — amber warning shown when no email plugin active
- [ ] Click accept link as new user → registration form → account created + joined tenant
- [ ] Click accept link as existing user → sign-in form → joined tenant
- [ ] Logged-in user clicks accept link → immediate acceptance
- [ ] Plugins submenu: expand/collapse persists across refresh (no flash)
- [ ] Tenant switch from content detail → lands on content list
- [ ] User edit page: tenant memberships matrix expands/collapses, role change + remove work inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)