### PR TITLE
Remove Email Log nav item from sidebar

### DIFF
--- a/packages/core/src/plugins/core-plugins/email-plugin/index.ts
+++ b/packages/core/src/plugins/core-plugins/email-plugin/index.ts
@@ -273,13 +273,6 @@ export const emailPlugin = definePlugin({
       order: 80,
       permissions: ['email:manage'],
     },
-    {
-      label: 'Email Log',
-      path: '/admin/plugins/email/log',
-      icon: 'document',
-      order: 81,
-      permissions: ['email:manage'],
-    },
   ],
 
   configSchema: {


### PR DESCRIPTION
## Summary
- Removes the \"Email Log\" sidebar menu entry from the email plugin
- Routes and APIs at `/admin/plugins/email/log` remain untouched

## Test plan
- [ ] Verify Email Log link no longer appears in sidebar
- [ ] Verify `/admin/plugins/email/log` route still responds (for direct nav / API callers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)