### PR TITLE
feat(dev): deterministic per-worktree dev port

### DIFF
--- a/my-sonicjs-app/package.json
+++ b/my-sonicjs-app/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "npm run dev:build && npm run dev:watch",
     "dev:build": "cd ../packages/core && npm run build",
-    "dev:watch": "npm run dev:core & npx wait-on ../packages/core/dist/index.js && wrangler dev 2>&1 | grep -v '\\[wrangler:inf\\]'",
+    "dev:watch": "npm run dev:core & npx wait-on ../packages/core/dist/index.js && PORT=$(($(echo -n \"$(basename $(cd .. && pwd))\" | cksum | cut -d' ' -f1) % 1000 + 9000)) && echo \"Dev server: http://localhost:$PORT\" && wrangler dev --port $PORT 2>&1 | grep -v '\\[wrangler:inf\\]'",
     "dev:core": "cd ../packages/core && npm run dev",
     "build": "echo 'Worker build is handled by wrangler during deployment'",
     "deploy": "wrangler deploy",


### PR DESCRIPTION
## Summary
- Derives wrangler dev port from worktree directory name (`cksum % 1000 + 9000`, range 9000–9999)
- No port collisions when running multiple worktrees simultaneously
- Same port every restart — deterministic, no manual config needed
- Prints `Dev server: http://localhost:PORT` on startup

## Test plan
- [ ] Run `npm run dev` in two different worktrees, verify different ports
- [ ] Restart same worktree, verify same port each time

🤖 Generated with [Claude Code](https://claude.com/claude-code)