### PR TITLE
feat(content): New Content dropdown with shared collection filtering

### DIFF
--- a/packages/core/src/routes/admin-collections.ts
+++ b/packages/core/src/routes/admin-collections.ts
@@ -17,7 +17,7 @@ import { requireAuth } from '../middleware'
 import { isPluginActive } from '../middleware/plugin-middleware'
 import { renderCollectionsListPage } from '../templates/pages/admin-collections-list.template'
 import { renderCollectionFormPage } from '../templates/pages/admin-collections-form.template'
-import { loadCollectionConfigs } from '../services/collection-loader'
+import { loadCollectionConfigs, isCodeCollectionInternal, isDbDocTypeInternal } from '../services/collection-loader'
 import { getCollectionRegistry } from '../services/collection-registry'
 import { renderAdminLayoutCatalyst } from '../templates/layouts/admin-layout-catalyst.template'
 import { getCoreVersion } from '../utils/version'
@@ -151,7 +151,7 @@ adminCollectionsRoutes.get('/', async (c) => {
           field_count: fieldCount,
           managed: cfg.managed !== false,
           source_type: 'code',
-          internal: cfg.internal === true,
+          internal: isCodeCollectionInternal(cfg),
         } as Collection]
       })
     )
@@ -183,7 +183,7 @@ adminCollectionsRoutes.get('/', async (c) => {
           field_count: fieldCount,
           managed: false,
           source_type: (row.source === 'code' || row.source === 'system' || row.source === 'plugin') ? 'code' : 'user',
-          internal: row.source === 'system' || row.source === 'plugin',
+          internal: isDbDocTypeInternal(row.source),
         }
       })
 

--- a/packages/core/src/routes/admin-content.ts
+++ b/packages/core/src/routes/admin-content.ts
@@ -17,7 +17,7 @@ import { DocumentsService } from '../services/documents'
 import { renderDocumentFormPage } from '../templates/pages/admin-documents-form.template'
 import { createDocumentSchema } from '../schemas/document'
 import type { QueryableField } from '../schemas/document'
-import { loadCollectionConfigs } from '../services/collection-loader'
+import { loadCollectionConfigs, getVisibleCollections } from '../services/collection-loader'
 
 const adminContentRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>()
 
@@ -469,6 +469,9 @@ adminContentRoutes.get('/', async (c) => {
       ...docTypes.filter(dt => !collectionNames.has(dt.id)).map(dt => ({ name: `doc:${dt.id}`, displayName: dt.displayName })),
     ]
 
+    // Non-internal collections for the "New Content" dropdown — same filtering as /admin/collections.
+    const newContentCollections = await getVisibleCollections(db)
+
     // ── Document-type branch: query documents table instead of content ──────────
     // Triggered by a `doc:` model OR a document-backed collection (collection name == doc type id).
     const docBackedCollection = !modelName.startsWith('doc:') && modelName !== 'all'
@@ -527,7 +530,7 @@ adminContentRoutes.get('/', async (c) => {
       })
 
       return c.html(renderContentListPage({
-        modelName, status, page, search, models, contentItems,
+        modelName, status, page, search, models, newContentCollections, contentItems,
         totalItems: countRow?.count ?? 0,
         itemsPerPage: limit,
         user: user ? { name: user.email, email: user.email, role: user.role } : undefined,
@@ -587,7 +590,7 @@ adminContentRoutes.get('/', async (c) => {
       }))
 
       return c.html(renderContentListPage({
-        modelName, status, page, search, models, contentItems,
+        modelName, status, page, search, models, newContentCollections, contentItems,
         totalItems: countRow?.count ?? 0,
         itemsPerPage: limit,
         user: user ? { name: user.email, email: user.email, role: user.role } : undefined,
@@ -601,6 +604,7 @@ adminContentRoutes.get('/', async (c) => {
       page,
       search,
       models,
+      newContentCollections,
       contentItems: [],
       totalItems: 0,
       itemsPerPage: limit,
@@ -746,6 +750,7 @@ adminContentRoutes.get('/', async (c) => {
       page,
       search,
       models,
+      newContentCollections,
       contentItems,
       totalItems,
       itemsPerPage: limit,

--- a/packages/core/src/services/collection-loader.ts
+++ b/packages/core/src/services/collection-loader.ts
@@ -5,7 +5,60 @@
  * Supports both development (reading from filesystem) and production (bundled).
  */
 
+import type { D1Database } from '@cloudflare/workers-types'
 import { CollectionConfig, CollectionConfigModule } from '../types/collection-config'
+import { getCollectionRegistry } from './collection-registry'
+
+export interface VisibleCollection {
+  name: string
+  displayName: string
+}
+
+/** True when a code-registry collection should be hidden from user-facing menus. */
+export function isCodeCollectionInternal(cfg: { internal?: boolean }): boolean {
+  return cfg.internal === true
+}
+
+/** True when a document_types DB row should be hidden from user-facing menus. */
+export function isDbDocTypeInternal(source?: string | null): boolean {
+  return source === 'system' || source === 'plugin'
+}
+
+/**
+ * Returns collections visible to users (non-internal) for UI menus like "New Content".
+ * Canonical filtering logic shared with /admin/collections:
+ *   - Code registry: cfg.internal !== true
+ *   - DB document_types: source is not 'system' or 'plugin'
+ * Code registry wins on name collisions.
+ */
+export async function getVisibleCollections(db: D1Database): Promise<VisibleCollection[]> {
+  const codeRegistry = getCollectionRegistry().list()
+  const codeMap = new Map<string, VisibleCollection>()
+  for (const cfg of codeRegistry) {
+    if (!isCodeCollectionInternal(cfg)) {
+      codeMap.set(cfg.name, { name: cfg.name, displayName: cfg.displayName })
+    }
+  }
+
+  let dbRows: any[] = []
+  try {
+    const { results } = await db.prepare(
+      "SELECT name, display_name, source FROM document_types WHERE is_active = 1 ORDER BY display_name"
+    ).all()
+    dbRows = results ?? []
+  } catch {
+    // document_types may not exist in early dev
+  }
+
+  const merged = new Map<string, VisibleCollection>(codeMap)
+  for (const row of dbRows) {
+    if (!isDbDocTypeInternal(row.source) && !merged.has(row.name)) {
+      merged.set(row.name, { name: String(row.name), displayName: String(row.display_name) })
+    }
+  }
+
+  return Array.from(merged.values())
+}
 
 // Global registry for externally registered collections
 const registeredCollections: CollectionConfig[] = []

--- a/packages/core/src/templates/pages/admin-content-list.template.ts
+++ b/packages/core/src/templates/pages/admin-content-list.template.ts
@@ -24,6 +24,11 @@ export interface ContentListPageData {
     name: string
     displayName: string
   }>
+  /** Non-internal collections for the "New Content" dropdown — same set as /admin/collections. */
+  newContentCollections: Array<{
+    name: string
+    displayName: string
+  }>
   contentItems: ContentItem[]
   totalItems: number
   itemsPerPage: number
@@ -224,13 +229,43 @@ export function renderContentListPage(data: ContentListPageData): string {
           <h1 class="text-2xl/8 font-semibold text-zinc-950 dark:text-white sm:text-xl/8">Content Management</h1>
           <p class="mt-2 text-sm/6 text-zinc-500 dark:text-zinc-400">Manage and organize your content items</p>
         </div>
-        <div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
-          <a href="/admin/content/new" class="inline-flex items-center justify-center rounded-lg bg-zinc-950 dark:bg-white px-3.5 py-2.5 text-sm font-semibold text-white dark:text-zinc-950 hover:bg-zinc-800 dark:hover:bg-zinc-100 transition-colors shadow-sm">
+        <div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none relative" id="new-content-dropdown">
+          <button
+            onclick="toggleNewContentDropdown()"
+            class="inline-flex items-center justify-center rounded-lg bg-zinc-950 dark:bg-white px-3.5 py-2.5 text-sm font-semibold text-white dark:text-zinc-950 hover:bg-zinc-800 dark:hover:bg-zinc-100 transition-colors shadow-sm"
+          >
             <svg class="-ml-0.5 mr-1.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
               <path d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z" />
             </svg>
             New Content
-          </a>
+            <svg class="ml-1.5 h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
+            </svg>
+          </button>
+          <div
+            id="new-content-menu"
+            class="hidden absolute right-0 mt-2 w-56 origin-top-right rounded-lg bg-white dark:bg-zinc-900 shadow-xl ring-1 ring-zinc-950/5 dark:ring-white/10 z-50 py-1"
+          >
+            ${data.newContentCollections.length === 0 ? `
+              <p class="px-4 py-2 text-sm text-zinc-500 dark:text-zinc-400">No collections available</p>
+            ` : data.newContentCollections.map(col => `<a
+                href="/admin/content/new?collection=${col.name}"
+                class="flex items-center px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-white/5 hover:text-zinc-950 dark:hover:text-white transition-colors"
+              >${col.displayName}</a>`).join('')}
+          </div>
+          <script>
+            function toggleNewContentDropdown() {
+              var menu = document.getElementById('new-content-menu');
+              menu.classList.toggle('hidden');
+            }
+            document.addEventListener('click', function(e) {
+              var dropdown = document.getElementById('new-content-dropdown');
+              var menu = document.getElementById('new-content-menu');
+              if (dropdown && menu && !dropdown.contains(e.target)) {
+                menu.classList.add('hidden');
+              }
+            });
+          </script>
         </div>
       </div>
       <!-- Filters -->

--- a/tests/e2e/78-new-content-dropdown.spec.ts
+++ b/tests/e2e/78-new-content-dropdown.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test'
+import { loginAsAdmin } from './utils/test-helpers'
+
+test.describe('New Content dropdown', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page)
+  })
+
+  test('shows dropdown button instead of plain link', async ({ page }) => {
+    await page.goto('/admin/content')
+    await expect(page.locator('#new-content-dropdown button')).toBeVisible()
+    await expect(page.locator('#new-content-dropdown button')).toContainText('New Content')
+  })
+
+  test('dropdown is hidden by default', async ({ page }) => {
+    await page.goto('/admin/content')
+    await expect(page.locator('#new-content-menu')).toBeHidden()
+  })
+
+  test('dropdown opens on click and shows collection links', async ({ page }) => {
+    await page.goto('/admin/content')
+    await page.locator('#new-content-dropdown button').click()
+    await expect(page.locator('#new-content-menu')).toBeVisible()
+    // At least one collection link should appear
+    const links = page.locator('#new-content-menu a')
+    await expect(links.first()).toBeVisible()
+  })
+
+  test('collection links point to new content form', async ({ page }) => {
+    await page.goto('/admin/content')
+    await page.locator('#new-content-dropdown button').click()
+    const firstLink = page.locator('#new-content-menu a').first()
+    const href = await firstLink.getAttribute('href')
+    expect(href).toMatch(/\/admin\/content\/new\?collection=/)
+  })
+
+  test('dropdown closes when clicking outside', async ({ page }) => {
+    await page.goto('/admin/content')
+    await page.locator('#new-content-dropdown button').click()
+    await expect(page.locator('#new-content-menu')).toBeVisible()
+    await page.locator('h1').click()
+    await expect(page.locator('#new-content-menu')).toBeHidden()
+  })
+})


### PR DESCRIPTION
## Summary

- Replaces the plain "New Content" link with a dropdown listing user-visible collections
- Internal collections (`cfg.internal=true`, `source=system/plugin`) are excluded — matches `/admin/collections` filtering exactly
- Extracts shared filtering logic (`isCodeCollectionInternal`, `isDbDocTypeInternal`, `getVisibleCollections`) into `collection-loader.ts` so both the dropdown and `/admin/collections` use one definition

## Test plan

- [ ] Open `/admin/content` — "New Content" button shows chevron and opens a dropdown
- [ ] Dropdown lists only user-facing collections (no system/plugin types)
- [ ] Each item navigates to `/admin/content/new?collection=<name>`
- [ ] Dropdown closes on outside click
- [ ] `/admin/collections` page unchanged
- [ ] E2E: `tests/e2e/78-new-content-dropdown.spec.ts` (5 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)