### PR TITLE
fix(admin): show only active plugins in sidebar sub-nav

### DIFF
--- a/packages/core/src/middleware/plugin-menu.ts
+++ b/packages/core/src/middleware/plugin-menu.ts
@@ -5,10 +5,11 @@ import { PLUGIN_REGISTRY } from '../plugins/manifest-registry'
 // Build menu plugin data from the auto-generated registry.
 // Any plugin with an adminMenu entry in its manifest.json will
 // automatically appear in the sidebar when active.
+// `id` matches the `slug` column in the documents table (how plugins are stored).
 const REGISTRY_MENU_PLUGINS = Object.values(PLUGIN_REGISTRY)
   .filter(p => p.adminMenu !== null)
   .map(p => ({
-    codeName: p.codeName,
+    id: p.id,
     label: p.adminMenu!.label,
     path: p.adminMenu!.path,
     icon: p.adminMenu!.icon,
@@ -78,17 +79,17 @@ export function pluginMenuMiddleware() {
     let activeMenuItems: Array<{ label: string; path: string; icon?: string; order: number }> = []
     try {
       const db = c.env.DB
-      const pluginCodeNames = REGISTRY_MENU_PLUGINS.map(p => p.codeName)
-      if (pluginCodeNames.length > 0) {
-        const placeholders = pluginCodeNames.map(() => '?').join(',')
+      const pluginIds = REGISTRY_MENU_PLUGINS.map(p => p.id)
+      if (pluginIds.length > 0) {
+        const placeholders = pluginIds.map(() => '?').join(',')
         const result = await db.prepare(
           `SELECT slug FROM documents WHERE type_id = 'plugin' AND tenant_id = 'default' AND slug IN (${placeholders}) AND q_plugin_status = 'active' AND is_current_draft = 1 AND deleted_at IS NULL`
-        ).bind(...pluginCodeNames).all()
+        ).bind(...pluginIds).all()
 
-        const activeNames = new Set((result.results || []).map((r: any) => r.slug))
+        const activeIds = new Set((result.results || []).map((r: any) => r.slug))
 
         for (const plugin of REGISTRY_MENU_PLUGINS) {
-          if (activeNames.has(plugin.codeName)) {
+          if (activeIds.has(plugin.id)) {
             activeMenuItems.push({
               label: plugin.label,
               path: plugin.path,

--- a/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
+++ b/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
@@ -1,6 +1,5 @@
 import { HtmlEscapedString } from "hono/utils/html";
 import { renderLogo } from "../components/logo.template";
-import { resolvePluginMenuItems } from "../../services/plugin-menu-singleton";
 
 // Catalyst Checkbox Component (HTML implementation)
 export interface CatalystCheckboxProps {
@@ -574,12 +573,9 @@ function renderCatalystSidebar(
   enableExperimentalFeatures?: boolean
 ): string {
   // Fall back to the declarative plugin menu singleton when no explicit
-  // dynamicMenuItems were passed in. The singleton is populated by
-  // registerPlugins() collecting each plugin's `menu: [...]` entries.
-  const resolvedMenuItems =
-    dynamicMenuItems && dynamicMenuItems.length > 0
-      ? dynamicMenuItems
-      : resolvePluginMenuItems(user);
+  // Active plugin nav items injected by pluginMenuMiddleware via dynamicMenuItems.
+  // When not provided, the marker below is replaced by the middleware post-render.
+  const resolvedMenuItems = dynamicMenuItems ?? [];
   let baseMenuItems = [
     {
       label: "Content",


### PR DESCRIPTION
## Summary

Admin sidebar plugin sub-navigation now displays only plugins with active status from the database, not all registered plugins.

## Changes

- **`admin-layout-catalyst.template.ts`**: Remove singleton fallback that showed all registered plugins. Now always uses dynamic plugin menu items injected by middleware (empty array triggers marker for post-render replacement).
- **`plugin-menu.ts`**: Use plugin `id` instead of `codeName` in DB query to match how plugins are stored (`slug = plugin.id` in documents table). Fixes `ai-search` and other plugins where `id != codeName`.

## Testing

Requires E2E test coverage (Playwright). Sidebar should show only plugins marked as active in database.

🤖 Generated with Claude Code