### PR TITLE
fix(docs): add id attr generation for h3 level tags

### DIFF
--- a/www/src/components/Heading.tsx
+++ b/www/src/components/Heading.tsx
@@ -91,7 +91,7 @@ export function Heading<Level extends 2 | 3>({
   })
 
   useEffect(() => {
-    if (level === 2) {
+    if (level === 2 || level === 3) {
       registerHeading({
         id: props.id,
         ref,

--- a/www/src/components/mdx.tsx
+++ b/www/src/components/mdx.tsx
@@ -39,6 +39,15 @@ export const h2 = function H2(
   return <Heading level={2} {...props} />
 }
 
+export const h3 = function H3(
+  props: Omit<
+    React.ComponentPropsWithoutRef<typeof Heading>,
+    'level' | 'anchor'
+  >,
+) {
+  return <Heading level={3} anchor={false} {...props} />
+}
+
 function InfoIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
   return (
     <svg viewBox="0 0 16 16" aria-hidden="true" {...props}>

--- a/www/src/mdx/rehype.mjs
+++ b/www/src/mdx/rehype.mjs
@@ -54,7 +54,10 @@ function rehypeSlugify() {
   return (tree) => {
     let slugify = slugifyWithCounter()
     visit(tree, 'element', (node) => {
-      if (node.tagName === 'h2' && !node.properties.id) {
+      if (
+        (node.tagName === 'h2' || node.tagName === 'h3') &&
+        !node.properties.id
+      ) {
         node.properties.id = slugify(toString(node))
       }
     })


### PR DESCRIPTION
## Description
I noticed the documentation nav failed to navigate to deeper sections although the code clearly intended to. Example the Collections -> Creating via Admin UI would not work and instead just break the menu active state.

<img width="333" height="442" alt="image" src="https://github.com/user-attachments/assets/6e712803-e8b7-4ea3-a2cd-206258784108" />

After a quick debugging turns out the docs were not supporting the generation of id attrs for h3 level tags. This PR address that with minimum code changes.

## Changes

Added support for H3 tag id attr generation where H2 does.
For H3 tags the anchor is ignored and not generated.

## Testing
I run manual check and run the tests.

### Unit Tests
- [ ] Added/updated unit tests
- [x ] All unit tests passing

### E2E Tests
- [ ] Added/updated E2E tests
- [x ] All E2E tests passing

## Screenshots/Videos
It now properly navigate to and highlights the section

<img width="762" height="552" alt="image" src="https://github.com/user-attachments/assets/ea8bab30-d4de-4c58-8536-64bfe6d792ba" />

## Checklist
- [ x] Code follows project conventions
- [ x] Tests added/updated and passing
- [x ] Type checking passes
- [ x] No console errors or warnings
- [ ] Documentation updated (if needed)
