### PR TITLE
feat(analytics): migrate core-analytics plugin to document model

### DIFF
--- a/packages/core/src/plugins/core-plugins/analytics/index.ts
+++ b/packages/core/src/plugins/core-plugins/analytics/index.ts
@@ -1,84 +1,15 @@
 /**
- * Core Analytics Plugin — Payload-shaped port.
+ * Core Analytics Plugin — document-model backed.
  *
- * Stub-grade analytics tracking + reporting routes. Legacy non-typed hooks
- * (request:start, request:end, user:login, content:view) subscribe via the
- * raw bus in onBoot. Service/middleware/model declarations from the old
- * PluginBuilder shape are dropped; they were stubs the runtime never wired.
+ * Events are stored as `analytics_event` documents. Stub-only hardcoded
+ * `/api/analytics/*` routes removed; real event tracking lives at `/api/events`.
+ * Legacy non-typed hooks (request:start, request:end, user:login, content:view)
+ * subscribe via the raw bus in onBoot.
  */
 
-import { Hono } from 'hono'
 import { definePlugin } from '../../sdk/define-plugin'
 import { analyticsAdminRoutes } from './routes/admin'
-
-const analyticsAPI = new Hono()
-
-analyticsAPI.get('/stats', async (c) => {
-  const timeRange = c.req.query('range') || '7d'
-  return c.json({
-    message: 'Analytics stats',
-    data: {
-      pageviews: 12500,
-      uniqueVisitors: 3200,
-      sessions: 4800,
-      avgSessionDuration: 245,
-      bounceRate: 0.35,
-      topPages: [
-        { path: '/', views: 3200 },
-        { path: '/about', views: 1800 },
-        { path: '/contact', views: 950 },
-      ],
-      timeRange,
-    },
-  })
-})
-
-analyticsAPI.post('/track', async (c) => {
-  const event = await c.req.json()
-  console.info('Analytics event tracked:', event)
-  return c.json({ message: 'Event tracked successfully', eventId: `event-${Date.now()}` })
-})
-
-analyticsAPI.get('/reports', async (c) => {
-  const reportType = c.req.query('type') || 'traffic'
-  const startDate = c.req.query('start')
-  const endDate = c.req.query('end')
-  return c.json({
-    message: 'Analytics report',
-    data: { reportType, dateRange: { start: startDate, end: endDate }, data: [] },
-  })
-})
-
-analyticsAPI.get('/realtime', async (c) => {
-  return c.json({
-    message: 'Real-time analytics',
-    data: {
-      activeUsers: 23,
-      activePages: [
-        { path: '/', users: 8 },
-        { path: '/blog', users: 5 },
-        { path: '/products', users: 4 },
-      ],
-      recentEvents: [],
-    },
-  })
-})
-
-const trackRequestStart = async (data: any) => {
-  data.analytics = {
-    startTime: Date.now(),
-    sessionId: `session-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-  }
-  return data
-}
-
-const trackRequestEnd = async (data: any) => {
-  if (data.analytics) {
-    const duration = Date.now() - data.analytics.startTime
-    console.debug(`Request completed in ${duration}ms`)
-  }
-  return data
-}
+import { eventsApiRoutes } from './routes/api'
 
 export const analyticsPlugin = definePlugin({
   id: 'core-analytics',
@@ -89,7 +20,7 @@ export const analyticsPlugin = definePlugin({
   author: { name: 'SonicJS Team', email: 'team@sonicjs.com' },
 
   register(app) {
-    app.route('/api/analytics', analyticsAPI)
+    app.route('/api/events', eventsApiRoutes as any)
     app.route('/admin/analytics', analyticsAdminRoutes as any)
   },
 
@@ -106,8 +37,20 @@ export const analyticsPlugin = definePlugin({
   async onBoot(ctx) {
     const hooks = (ctx.raw as any)?.hooks
     if (!hooks?.register) return
-    hooks.register('request:start', trackRequestStart, 1)
-    hooks.register('request:end', trackRequestEnd, 1)
+    hooks.register('request:start', async (data: any) => {
+      data.analytics = {
+        startTime: Date.now(),
+        sessionId: `session-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      }
+      return data
+    }, 1)
+    hooks.register('request:end', async (data: any) => {
+      if (data.analytics) {
+        const duration = Date.now() - data.analytics.startTime
+        console.debug(`Request completed in ${duration}ms`)
+      }
+      return data
+    }, 1)
     hooks.register('user:login', async (data: any, context: any) => {
       await context.services?.analyticsService?.trackEvent({
         eventType: 'auth',

--- a/packages/core/src/plugins/core-plugins/analytics/services/event-tracking-service.ts
+++ b/packages/core/src/plugins/core-plugins/analytics/services/event-tracking-service.ts
@@ -1,4 +1,16 @@
 import type { D1Database } from '@cloudflare/workers-types'
+import { DocumentsService } from '../../../../services/documents'
+
+const ANALYTICS_TYPE = 'analytics_event'
+const TENANT = 'default'
+
+const QUERYABLE_FIELDS = [
+  { name: 'event',     kind: 'scalar' as const, type: 'text' as const,    column: 'q_evt_event' },
+  { name: 'category',  kind: 'scalar' as const, type: 'text' as const,    column: 'q_evt_category' },
+  { name: 'userId',    kind: 'scalar' as const, type: 'text' as const,    column: 'q_evt_user_id' },
+  { name: 'sessionId', kind: 'scalar' as const, type: 'text' as const,    column: 'q_evt_session_id' },
+  { name: 'path',      kind: 'scalar' as const, type: 'text' as const,    column: 'q_evt_path' },
+]
 
 export interface TrackEventInput {
   event: string
@@ -30,139 +42,113 @@ export interface EventStats {
 }
 
 export class EventTrackingService {
-  constructor(private db: D1Database) {}
+  private docsService: DocumentsService
+
+  constructor(private db: D1Database) {
+    this.docsService = new DocumentsService(db, {
+      queryableFields: QUERYABLE_FIELDS,
+      maxVersionsPerRoot: 1,
+      tenantId: TENANT,
+    })
+  }
 
   async trackEvent(input: TrackEventInput): Promise<string> {
-    const id = crypto.randomUUID()
-    const category = input.category || 'user-activity'
-
-    await this.db.prepare(`
-      INSERT INTO analytics_events (id, event, category, properties, user_id, session_id, ip_address, user_agent, path)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).bind(
-      id,
-      input.event,
-      category,
-      input.properties ? JSON.stringify(input.properties) : null,
-      input.userId || null,
-      input.sessionId || null,
-      input.ipAddress || null,
-      input.userAgent || null,
-      input.path || null
-    ).run()
-
-    return id
+    const doc = await this.docsService.create({
+      typeId: ANALYTICS_TYPE,
+      title: input.event,
+      publishOnCreate: true,
+      tenantId: TENANT,
+      locale: 'default',
+      parentRootId: '',
+      sortOrder: 0,
+      visible: true,
+      metadata: {},
+      data: {
+        event: input.event,
+        category: input.category ?? 'user-activity',
+        properties: input.properties ?? null,
+        userId: input.userId ?? null,
+        sessionId: input.sessionId ?? null,
+        ipAddress: input.ipAddress ?? null,
+        userAgent: input.userAgent ?? null,
+        path: input.path ?? null,
+      },
+    })
+    return doc.id
   }
 
   async trackBatch(events: TrackEventInput[]): Promise<string[]> {
     const ids: string[] = []
-
-    const stmts = events.map(input => {
-      const id = crypto.randomUUID()
-      ids.push(id)
-      const category = input.category || 'user-activity'
-
-      return this.db.prepare(`
-        INSERT INTO analytics_events (id, event, category, properties, user_id, session_id, ip_address, user_agent, path)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `).bind(
-        id,
-        input.event,
-        category,
-        input.properties ? JSON.stringify(input.properties) : null,
-        input.userId || null,
-        input.sessionId || null,
-        input.ipAddress || null,
-        input.userAgent || null,
-        input.path || null
-      )
-    })
-
-    await this.db.batch(stmts)
+    for (const e of events) {
+      ids.push(await this.trackEvent(e))
+    }
     return ids
   }
 
   async queryEvents(filters: EventQueryFilters = {}): Promise<{ events: any[]; total: number }> {
-    const conditions: string[] = []
-    const params: any[] = []
+    const conditions: string[] = [
+      'type_id = ?', 'tenant_id = ?', 'is_published = 1', 'deleted_at IS NULL',
+    ]
+    const params: (string | number)[] = [ANALYTICS_TYPE, TENANT]
 
-    if (filters.event) {
-      conditions.push('event = ?')
-      params.push(filters.event)
-    }
-    if (filters.category) {
-      conditions.push('category = ?')
-      params.push(filters.category)
-    }
-    if (filters.userId) {
-      conditions.push('user_id = ?')
-      params.push(filters.userId)
-    }
-    if (filters.sessionId) {
-      conditions.push('session_id = ?')
-      params.push(filters.sessionId)
-    }
-    if (filters.startDate) {
-      conditions.push('created_at >= ?')
-      params.push(filters.startDate)
-    }
-    if (filters.endDate) {
-      conditions.push('created_at <= ?')
-      params.push(filters.endDate)
-    }
+    if (filters.event)     { conditions.push('q_evt_event = ?');      params.push(filters.event) }
+    if (filters.category)  { conditions.push('q_evt_category = ?');   params.push(filters.category) }
+    if (filters.userId)    { conditions.push('q_evt_user_id = ?');    params.push(filters.userId) }
+    if (filters.sessionId) { conditions.push('q_evt_session_id = ?'); params.push(filters.sessionId) }
+    if (filters.startDate) { conditions.push('created_at >= ?');      params.push(filters.startDate) }
+    if (filters.endDate)   { conditions.push('created_at <= ?');      params.push(filters.endDate) }
 
-    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
-    const limit = filters.limit || 50
-    const offset = filters.offset || 0
+    const where = `WHERE ${conditions.join(' AND ')}`
+    const limit  = filters.limit  ?? 50
+    const offset = filters.offset ?? 0
 
     const [countResult, eventsResult] = await Promise.all([
-      this.db.prepare(`SELECT COUNT(*) as total FROM analytics_events ${where}`).bind(...params).first() as Promise<{ total: number } | null>,
-      this.db.prepare(`SELECT * FROM analytics_events ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`).bind(...params, limit, offset).all()
+      this.db.prepare(`SELECT COUNT(*) as total FROM documents ${where}`)
+        .bind(...params).first() as Promise<{ total: number } | null>,
+      this.db.prepare(`SELECT * FROM documents ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`)
+        .bind(...params, limit, offset).all(),
     ])
 
-    const events = (eventsResult.results || []).map((e: any) => ({
-      ...e,
-      properties: e.properties ? JSON.parse(e.properties) : null
+    const events = (eventsResult.results ?? []).map((e: any) => ({
+      id: e.id,
+      createdAt: e.created_at,
+      ...(e.data ? JSON.parse(e.data) : {}),
     }))
 
-    return { events, total: countResult?.total || 0 }
+    return { events, total: countResult?.total ?? 0 }
   }
 
   async getStats(startDate?: number, endDate?: number): Promise<EventStats> {
-    const conditions: string[] = []
-    const params: any[] = []
+    const conditions: string[] = [
+      'type_id = ?', 'tenant_id = ?', 'is_published = 1', 'deleted_at IS NULL',
+    ]
+    const params: (string | number)[] = [ANALYTICS_TYPE, TENANT]
 
-    if (startDate) {
-      conditions.push('created_at >= ?')
-      params.push(startDate)
-    }
-    if (endDate) {
-      conditions.push('created_at <= ?')
-      params.push(endDate)
-    }
+    if (startDate) { conditions.push('created_at >= ?'); params.push(startDate) }
+    if (endDate)   { conditions.push('created_at <= ?'); params.push(endDate) }
 
-    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+    const where = `WHERE ${conditions.join(' AND ')}`
 
     const [totals, topEvents] = await Promise.all([
       this.db.prepare(`
         SELECT
           COUNT(*) as total_events,
-          COUNT(DISTINCT user_id) as unique_users,
-          COUNT(DISTINCT session_id) as unique_sessions
-        FROM analytics_events ${where}
+          COUNT(DISTINCT q_evt_user_id) as unique_users,
+          COUNT(DISTINCT q_evt_session_id) as unique_sessions
+        FROM documents ${where}
       `).bind(...params).first() as Promise<{ total_events: number; unique_users: number; unique_sessions: number } | null>,
       this.db.prepare(`
-        SELECT event, COUNT(*) as count
-        FROM analytics_events ${where}
-        GROUP BY event ORDER BY count DESC LIMIT 20
-      `).bind(...params).all()
+        SELECT q_evt_event as event, COUNT(*) as count
+        FROM documents ${where}
+        GROUP BY q_evt_event ORDER BY count DESC LIMIT 20
+      `).bind(...params).all(),
     ])
 
     return {
-      totalEvents: totals?.total_events || 0,
-      uniqueUsers: totals?.unique_users || 0,
-      uniqueSessions: totals?.unique_sessions || 0,
-      topEvents: (topEvents.results || []).map((r: any) => ({ event: r.event, count: r.count }))
+      totalEvents:    totals?.total_events   ?? 0,
+      uniqueUsers:    totals?.unique_users    ?? 0,
+      uniqueSessions: totals?.unique_sessions ?? 0,
+      topEvents: (topEvents.results ?? []).map((r: any) => ({ event: r.event, count: r.count })),
     }
   }
 }

--- a/packages/core/src/services/document-types-seed.ts
+++ b/packages/core/src/services/document-types-seed.ts
@@ -129,6 +129,28 @@ export async function bootstrapDocumentTypes(db: D1Database): Promise<void> {
     ],
   })
 
+  // Analytics event (document-backed; replaces legacy analytics_events table)
+  await registry.register({
+    id: 'analytics_event',
+    name: 'analytics_event',
+    displayName: 'Analytics Event',
+    description: 'Tracked analytics event (page view, user action, custom event)',
+    source: 'system',
+    schema: anyObject,
+    settings: {
+      internal: true,
+      maxVersionsPerRoot: 1,
+      baseGrants: { admin: ['read', 'create', 'manage'] },
+    },
+    queryableFields: [
+      { name: 'event',     kind: 'scalar', type: 'text',    column: 'q_evt_event' },
+      { name: 'category',  kind: 'scalar', type: 'text',    column: 'q_evt_category' },
+      { name: 'userId',    kind: 'scalar', type: 'text',    column: 'q_evt_user_id' },
+      { name: 'sessionId', kind: 'scalar', type: 'text',    column: 'q_evt_session_id' },
+      { name: 'path',      kind: 'scalar', type: 'text',    column: 'q_evt_path' },
+    ],
+  })
+
   // ── RBAC (auth-owned). 3 document types replace 4 relational tables: ──────────
   //   rbac_role        slug = roleId,  data.grants[] embedded (replaces role_grants)
   //   rbac_verb        slug = verbId


### PR DESCRIPTION
## Summary
- Replace `analytics_events` custom table with `analytics_event` document type registered in `bootstrapDocumentTypes`
- `EventTrackingService` now writes via `DocumentsService.create()` (R1-compliant batch writes) and reads/aggregates via raw SQL on `documents` table
- Remove hardcoded fake stub routes (`/api/analytics/stats`, `/api/analytics/realtime`, etc.) — real tracking at `/api/events`
- 5 queryable generated columns auto-created at bootstrap: `q_evt_event`, `q_evt_category`, `q_evt_user_id`, `q_evt_session_id`, `q_evt_path`

## Test plan
- [ ] Dev server boots without error (migration self-heals `q_evt_*` columns via `ensureScalarSchema`)
- [ ] `POST /api/events` tracks a single event → returns `{ success: true, eventId }`
- [ ] `POST /api/events` with array body → batch track → returns `{ eventIds, count }`
- [ ] `GET /api/events/stats` (admin) returns `totalEvents`, `uniqueUsers`, `uniqueSessions`, `topEvents`
- [ ] `GET /api/events` (admin) returns paginated event documents
- [ ] Admin analytics dashboard renders at `/admin/analytics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)