### PR TITLE
fix(api): gate collection in meta behind ?include=collection

### DIFF
--- a/packages/core/src/routes/api.ts
+++ b/packages/core/src/routes/api.ts
@@ -741,7 +741,8 @@ apiRoutes.get('/collections/:collection/content', optionalAuth(), async (c) => {
     // Generate cache key
     const cacheEnabled = c.get('cacheEnabled')
     const cache = getCacheService(CACHE_CONFIGS.api!)
-    const cacheKey = cache.generateKey('collection-content-filtered', `${collection}:${JSON.stringify({ filter: normalizedFilter, query: queryResult.sql })}`)
+    const includeCollection = queryParams.include?.split(',').map(s => s.trim()).includes('collection')
+    const cacheKey = cache.generateKey('collection-content-filtered', `${collection}:${JSON.stringify({ filter: normalizedFilter, query: queryResult.sql, includeCollection })}`)
 
     // Only check cache if plugin is enabled
     if (cacheEnabled) {
@@ -798,10 +799,12 @@ apiRoutes.get('/collections/:collection/content', optionalAuth(), async (c) => {
     const responseData = {
       data: transformedResults,
       meta: addTimingMeta(c, {
-        collection: {
-          ...(collectionResult as any),
-          schema: (collectionResult as any).schema ? JSON.parse((collectionResult as any).schema) : {}
-        },
+        ...(includeCollection ? {
+          collection: {
+            ...(collectionResult as any),
+            schema: (collectionResult as any).schema ? JSON.parse((collectionResult as any).schema) : {}
+          }
+        } : {}),
         count: results.length,
         timestamp: new Date().toISOString(),
         filter: normalizedFilter,


### PR DESCRIPTION
## Summary
- `collection` property in API response meta is now **opt-in**, excluded by default
- Callers who need it pass `?include=collection` (comma-separated, extensible)
- Cache key updated to include the flag, preventing stale hits across variants

## Changes
- `packages/core/src/routes/api.ts`: Gate `collection` in meta behind `includeCollection`; include flag in cache key

## Usage
```
# Default — smaller payload, no collection
GET /api/collections/posts/content

# Opt-in
GET /api/collections/posts/content?include=collection
```

## Checklist
- [x] No breaking change for clients that ignore `meta.collection`
- [x] Cache key updated to prevent cross-variant contamination

🤖 Generated with [Claude Code](https://claude.com/claude-code)