### PR TITLE
refactor: replace page_blocks with e2e_test collection

### DIFF
--- a/my-sonicjs-app/src/collections/e2e-test.collection.ts
+++ b/my-sonicjs-app/src/collections/e2e-test.collection.ts
@@ -1,11 +1,11 @@
 import type { CollectionConfig } from "@sonicjs-cms/core";
 
 export default {
-  name: "page_blocks",
-  displayName: "Page Blocks",
-  slug: "page-blocks",
-  description: "Page layouts built from block components",
-  icon: "🧱",
+  name: "e2e_test",
+  displayName: "E2E Test",
+  slug: "e2e-test",
+  description: "Comprehensive field-type coverage for E2E testing — not for production use",
+  icon: "🧪",
 
   schema: {
     type: "object",
@@ -21,6 +21,53 @@ export default {
         title: "URL Slug",
         required: true,
         maxLength: 200,
+      },
+      description: {
+        type: "textarea",
+        title: "Description",
+        maxLength: 500,
+      },
+      count: {
+        type: "number",
+        title: "Count",
+      },
+      isActive: {
+        type: "boolean",
+        title: "Is Active",
+      },
+      publishDate: {
+        type: "date",
+        title: "Publish Date",
+      },
+      publishDatetime: {
+        type: "datetime",
+        title: "Publish Datetime",
+      },
+      author: {
+        type: "user",
+        title: "Author",
+      },
+      featuredImage: {
+        type: "media",
+        title: "Featured Image",
+      },
+      category: {
+        type: "select",
+        title: "Category",
+        enum: ["news", "tutorial", "showcase"],
+        enumLabels: ["News", "Tutorial", "Showcase"],
+        default: "news",
+      },
+      displayMode: {
+        type: "radio",
+        title: "Display Mode",
+        enum: ["list", "grid", "card"],
+        enumLabels: ["List", "Grid", "Card"],
+        default: "list",
+      },
+      richContent: {
+        type: "lexical",
+        title: "Rich Content",
       },
       seo: {
         type: "object",
@@ -101,6 +148,16 @@ export default {
               properties: {
                 heading: { type: "string", title: "Heading" },
                 body: { type: "textarea", title: "Body" },
+              },
+            },
+            callToAction: {
+              label: "Call to Action",
+              description: "CTA section with button",
+              properties: {
+                title: { type: "string", title: "Title" },
+                body: { type: "textarea", title: "Body" },
+                buttonLabel: { type: "string", title: "Button Label" },
+                buttonUrl: { type: "string", title: "Button URL" },
               },
             },
           },

--- a/my-sonicjs-app/src/index.ts
+++ b/my-sonicjs-app/src/index.ts
@@ -23,10 +23,10 @@ import './user-profile.model';
 // Import code-defined collections
 import { siteSettingsCollection } from '@sonicjs-cms/core';
 import blogPostsCollection from './collections/blog-posts.collection';
-import pageBlocksCollection from './collections/page-blocks.collection';
+import e2eTestCollection from './collections/e2e-test.collection';
 
 // Register collections so they appear in admin UI
-registerCollections([siteSettingsCollection, blogPostsCollection, pageBlocksCollection]);
+registerCollections([siteSettingsCollection, blogPostsCollection, e2eTestCollection]);
 
 const config: SonicJSConfig = {
   plugins: {

--- a/tests/e2e/38-content-blocks.spec.ts
+++ b/tests/e2e/38-content-blocks.spec.ts
@@ -1,16 +1,16 @@
 import { test, expect } from '@playwright/test'
 import { loginAsAdmin } from './utils/test-helpers'
 
-// Skip in CI - depends on Page Blocks collection which may not be configured in CI environment
+// Skip in CI - depends on E2E Test collection which may not be configured in CI environment
 test.describe.skip('Content Blocks (Code-Based Collections)', () => {
   test('should allow adding block content in code-based collections', async ({ page }) => {
     await loginAsAdmin(page)
 
     await page.goto('/admin/content/new')
 
-    const pageBlocksLink = page.locator('a[href^="/admin/content/new?collection="]').filter({ hasText: 'Page Blocks' })
-    await expect(pageBlocksLink).toBeVisible()
-    await pageBlocksLink.click()
+    const e2eTestLink = page.locator('a[href^="/admin/content/new?collection="]').filter({ hasText: 'E2E Test' })
+    await expect(e2eTestLink).toBeVisible()
+    await e2eTestLink.click()
 
     await page.waitForLoadState('networkidle')
     await expect(page.locator('form#content-form')).toBeVisible()

--- a/tests/e2e/42-dynamic-field-tdz.spec.ts
+++ b/tests/e2e/42-dynamic-field-tdz.spec.ts
@@ -15,28 +15,28 @@ import { loginAsAdmin } from './utils/test-helpers'
  */
 test.describe('Dynamic Field TDZ Bug Fix', () => {
   /**
-   * Helper to find and navigate to Page Blocks collection
+   * Helper to find and navigate to E2E Test collection
    * Returns true if collection was found and navigated to, false otherwise
    */
-  async function navigateToPageBlocksCollection(page: any): Promise<boolean> {
+  async function navigateToE2eTestCollection(page: any): Promise<boolean> {
     // Navigate to the new content page to see available collections
     await page.goto('/admin/content/new')
     await page.waitForLoadState('networkidle')
 
-    // Look for Page Blocks collection which has object and array fields
-    // The collection might be named "page_blocks" or listed as "Page Blocks"
-    const pageBlocksLink = page.locator('a[href*="collection=page_blocks"]')
-    const hasPageBlocks = await pageBlocksLink.count() > 0
+    // Look for E2E Test collection which has object and array fields
+    // The collection might be named "e2e_test" or listed as "E2E Test"
+    const e2eTestLink = page.locator('a[href*="collection=e2e_test"]')
+    const hasE2eTest = await e2eTestLink.count() > 0
 
-    if (!hasPageBlocks) {
+    if (!hasE2eTest) {
       // Collection not found in content new page
       // Try triggering collection sync by visiting collections page
       await page.goto('/admin/collections')
       await page.waitForLoadState('networkidle')
 
-      // Check if page_blocks appears in the collections list
-      const hasPageBlocksInList = await page.locator('text=page_blocks').count() > 0
-      if (!hasPageBlocksInList) {
+      // Check if e2e_test appears in the collections list
+      const hasE2eTestInList = await page.locator('text=E2E Test').count() > 0
+      if (!hasE2eTestInList) {
         return false
       }
 
@@ -45,14 +45,14 @@ test.describe('Dynamic Field TDZ Bug Fix', () => {
       await page.waitForLoadState('networkidle')
 
       // Try again
-      const pageBlocksLinkRetry = page.locator('a[href*="collection=page_blocks"]')
-      if (await pageBlocksLinkRetry.count() === 0) {
+      const e2eTestLinkRetry = page.locator('a[href*="collection=e2e_test"]')
+      if (await e2eTestLinkRetry.count() === 0) {
         return false
       }
 
-      await pageBlocksLinkRetry.click()
+      await e2eTestLinkRetry.click()
     } else {
-      await pageBlocksLink.click()
+      await e2eTestLink.click()
     }
 
     await page.waitForLoadState('networkidle')
@@ -62,12 +62,12 @@ test.describe('Dynamic Field TDZ Bug Fix', () => {
   test('should render content form with object fields without TDZ crash', async ({ page }) => {
     await loginAsAdmin(page)
 
-    // Navigate to Page Blocks collection
-    const found = await navigateToPageBlocksCollection(page)
+    // Navigate to E2E Test collection
+    const found = await navigateToE2eTestCollection(page)
 
     if (!found) {
-      // If Page Blocks collection doesn't exist, skip the test
-      test.skip(true, 'Page Blocks collection not available - code-based collection required')
+      // If E2E Test collection doesn't exist, skip the test
+      test.skip(true, 'E2E Test collection not available - code-based collection required')
       return
     }
 
@@ -77,7 +77,7 @@ test.describe('Dynamic Field TDZ Bug Fix', () => {
     // Check if collection was found or if there's an error
     const collectionNotFound = page.locator('text=Collection not found')
     if (await collectionNotFound.isVisible({ timeout: 2000 }).catch(() => false)) {
-      test.skip(true, 'Page Blocks collection not synced to database')
+      test.skip(true, 'E2E Test collection not synced to database')
       return
     }
 
@@ -118,18 +118,18 @@ test.describe('Dynamic Field TDZ Bug Fix', () => {
   test('should allow adding blocks to array field without errors', async ({ page }) => {
     await loginAsAdmin(page)
 
-    // Navigate to Page Blocks collection
-    const found = await navigateToPageBlocksCollection(page)
+    // Navigate to E2E Test collection
+    const found = await navigateToE2eTestCollection(page)
 
     if (!found) {
-      test.skip(true, 'Page Blocks collection not available')
+      test.skip(true, 'E2E Test collection not available')
       return
     }
 
     // Check for collection not found error
     const collectionNotFound = page.locator('text=Collection not found')
     if (await collectionNotFound.isVisible({ timeout: 2000 }).catch(() => false)) {
-      test.skip(true, 'Page Blocks collection not synced to database')
+      test.skip(true, 'E2E Test collection not synced to database')
       return
     }
 
@@ -147,7 +147,7 @@ test.describe('Dynamic Field TDZ Bug Fix', () => {
       }
 
       // If form not visible but no TDZ error, collection might not exist
-      test.skip(true, 'Page Blocks collection form not available')
+      test.skip(true, 'E2E Test collection form not available')
       return
     }
 

--- a/tests/e2e/53-block-media-persist.spec.ts
+++ b/tests/e2e/53-block-media-persist.spec.ts
@@ -56,14 +56,14 @@ test.describe('Block Media Persistence', () => {
     const title = `Block Media ${Date.now()}`;
     const slug = `block-media-${Date.now()}`;
     await page.goto('/admin/content/new');
-    const pageBlocksLink = page.locator('a[href^="/admin/content/new?collection="]').filter({ hasText: 'Page Blocks' });
-    const hasPageBlocks = await pageBlocksLink.isVisible().catch(() => false);
-    if (!hasPageBlocks) {
-      test.skip(true, 'Page Blocks collection not available');
+    const e2eTestLink = page.locator('a[href^="/admin/content/new?collection="]').filter({ hasText: 'E2E Test' });
+    const hasE2eTest = await e2eTestLink.isVisible().catch(() => false);
+    if (!hasE2eTest) {
+      test.skip(true, 'E2E Test collection not available');
       return;
     }
 
-    await pageBlocksLink.click();
+    await e2eTestLink.click();
     await page.waitForLoadState('networkidle');
     await expect(page.locator('form#content-form')).toBeVisible();
 
@@ -108,7 +108,7 @@ test.describe('Block Media Persistence', () => {
       if (editUrlMatch?.[1]) {
         createdContentId = editUrlMatch[1];
       } else {
-        await page.goto('/admin/content?collection=page_blocks');
+        await page.goto('/admin/content?collection=e2e_test');
         const contentLink = page.locator(`a:has-text("${title}")`).first();
         await expect(contentLink).toBeVisible({ timeout: 10000 });
         const href = await contentLink.getAttribute('href');
@@ -123,7 +123,7 @@ test.describe('Block Media Persistence', () => {
     } finally {
       if (!createdContentId) {
         try {
-          await page.goto('/admin/content?collection=page_blocks');
+          await page.goto('/admin/content?collection=e2e_test');
           const fallbackLink = page.locator(`a:has-text("${title}")`).first();
           if (await fallbackLink.isVisible({ timeout: 3000 }).catch(() => false)) {
             const href = await fallbackLink.getAttribute('href');

--- a/tests/e2e/53-object-layout.spec.ts
+++ b/tests/e2e/53-object-layout.spec.ts
@@ -6,11 +6,11 @@ test.describe('Object Layout', () => {
     await loginAsAdmin(page)
 
     await page.goto('/admin/content/new')
-    const pageBlocksLink = page
+    const e2eTestLink = page
       .locator('a[href^="/admin/content/new?collection="]')
-      .filter({ hasText: 'Page Blocks' })
-    await expect(pageBlocksLink).toBeVisible()
-    await pageBlocksLink.click()
+      .filter({ hasText: 'E2E Test' })
+    await expect(e2eTestLink).toBeVisible()
+    await e2eTestLink.click()
     await page.waitForLoadState('networkidle')
     await expect(page.locator('form#content-form')).toBeVisible()
 

--- a/tests/e2e/54-hero-cta-style-persistence.spec.ts
+++ b/tests/e2e/54-hero-cta-style-persistence.spec.ts
@@ -16,9 +16,9 @@ test.describe('Hero CTA Style Persistence', () => {
       await loginAsAdmin(page)
 
       await page.goto('/admin/content/new')
-      const pageBlocksLink = page.locator('a[href^="/admin/content/new?collection="]').filter({ hasText: 'Page Blocks' })
-      await expect(pageBlocksLink).toBeVisible()
-      await pageBlocksLink.click()
+      const e2eTestLink = page.locator('a[href^="/admin/content/new?collection="]').filter({ hasText: 'E2E Test' })
+      await expect(e2eTestLink).toBeVisible()
+      await e2eTestLink.click()
 
       await page.waitForLoadState('networkidle')
       await expect(page.locator('form#content-form')).toBeVisible()
@@ -64,7 +64,7 @@ test.describe('Hero CTA Style Persistence', () => {
       await page.click('button[name="action"][value="save_and_publish"]')
       await page.waitForTimeout(2000)
 
-      await page.goto('/admin/content?collection=page_blocks')
+      await page.goto('/admin/content?collection=e2e_test')
       const contentLink = page.locator(`a:has-text("${title}")`).first()
       await expect(contentLink).toBeVisible()
       const href = await contentLink.getAttribute('href')
@@ -105,7 +105,7 @@ test.describe('Hero CTA Style Persistence', () => {
       if (contentId) {
         await page.goto(`/admin/content/${contentId}/edit`)
       } else {
-        await page.goto('/admin/content?collection=page_blocks')
+        await page.goto('/admin/content?collection=e2e_test')
         await page.locator(`a:has-text("${updatedTitle}")`).first().click()
       }
 
@@ -141,7 +141,7 @@ test.describe('Hero CTA Style Persistence', () => {
         }
 
         if (!contentId) {
-          await page.goto('/admin/content?collection=page_blocks')
+          await page.goto('/admin/content?collection=e2e_test')
           const updatedLink = page.locator(`a:has-text("${updatedTitle}")`).first()
           if (await updatedLink.count()) {
             contentId = tryExtractContentIdFromHref(await updatedLink.getAttribute('href'))

--- a/tests/e2e/55-collapsible-state-persistence.spec.ts
+++ b/tests/e2e/55-collapsible-state-persistence.spec.ts
@@ -5,15 +5,15 @@ async function resolvePageBlocksCollectionKey(page: Page): Promise<string> {
   await page.goto('/admin/content/new')
   await page.waitForLoadState('networkidle', { timeout: 15000 })
 
-  const pageBlocksLink = page
+  const e2eTestLink = page
     .locator('a[href^="/admin/content/new?collection="]')
-    .filter({ hasText: 'Page Blocks' })
+    .filter({ hasText: 'E2E Test' })
     .first()
 
-  await expect(pageBlocksLink).toBeVisible({ timeout: 10000 })
-  const href = await pageBlocksLink.getAttribute('href')
+  await expect(e2eTestLink).toBeVisible({ timeout: 10000 })
+  const href = await e2eTestLink.getAttribute('href')
   const match = href?.match(/[?&]collection=([^&]+)/)
-  return match?.[1] || 'page_blocks'
+  return match?.[1] || 'e2e_test'
 }
 
 async function gotoPageBlocksNewForm(page: Page) {
@@ -26,12 +26,12 @@ async function gotoPageBlocksNewForm(page: Page) {
     return collectionKey
   }
 
-  const pageBlocksLink = page
+  const e2eTestLink = page
     .locator('a[href^="/admin/content/new?collection="]')
-    .filter({ hasText: 'Page Blocks' })
+    .filter({ hasText: 'E2E Test' })
     .first()
-  if (await pageBlocksLink.count()) {
-    await pageBlocksLink.click()
+  if (await e2eTestLink.count()) {
+    await e2eTestLink.click()
     await page.waitForLoadState('networkidle', { timeout: 15000 })
     await expect(page.locator('input[name="title"]').first()).toBeVisible({ timeout: 10000 })
     return collectionKey

--- a/tests/e2e/56-collapsible-validation-visibility.spec.ts
+++ b/tests/e2e/56-collapsible-validation-visibility.spec.ts
@@ -13,12 +13,12 @@ test.describe.skip('Collapsible Validation Visibility', () => {
     await page.goto('/admin/content/new')
     await page.waitForLoadState('networkidle', { timeout: 15000 })
 
-    const pageBlocksLink = page
+    const e2eTestLink = page
       .locator('a[href^="/admin/content/new?collection="]')
-      .filter({ hasText: 'Page Blocks' })
+      .filter({ hasText: 'E2E Test' })
       .first()
-    await expect(pageBlocksLink).toBeVisible({ timeout: 10000 })
-    await pageBlocksLink.click()
+    await expect(e2eTestLink).toBeVisible({ timeout: 10000 })
+    await e2eTestLink.click()
     await page.waitForLoadState('networkidle', { timeout: 15000 })
 
     await page.fill('input[name="title"]', `Test Validation Visibility ${Date.now()}`)

--- a/tests/e2e/57-nested-array-serialization-scope.spec.ts
+++ b/tests/e2e/57-nested-array-serialization-scope.spec.ts
@@ -5,15 +5,15 @@ async function resolvePageBlocksCollectionKey(page: Page): Promise<string> {
   await page.goto('/admin/content/new')
   await page.waitForLoadState('networkidle', { timeout: 15000 })
 
-  const pageBlocksLink = page
+  const e2eTestLink = page
     .locator('a[href^="/admin/content/new?collection="]')
-    .filter({ hasText: 'Page Blocks' })
+    .filter({ hasText: 'E2E Test' })
     .first()
 
-  await expect(pageBlocksLink).toBeVisible({ timeout: 10000 })
-  const href = await pageBlocksLink.getAttribute('href')
+  await expect(e2eTestLink).toBeVisible({ timeout: 10000 })
+  const href = await e2eTestLink.getAttribute('href')
   const match = href?.match(/[?&]collection=([^&]+)/)
-  return match?.[1] || 'page_blocks'
+  return match?.[1] || 'e2e_test'
 }
 
 async function gotoWithRetry(page: Page, url: string): Promise<void> {

--- a/tests/e2e/58-nested-object-serialization.spec.ts
+++ b/tests/e2e/58-nested-object-serialization.spec.ts
@@ -5,16 +5,16 @@ async function resolvePageBlocksCollectionKey(page: import('@playwright/test').P
   await page.goto('/admin/content/new')
   await page.waitForLoadState('networkidle', { timeout: 15000 })
 
-  const pageBlocksLink = page
+  const e2eTestLink = page
     .locator('a[href^="/admin/content/new?collection="]')
-    .filter({ hasText: 'Page Blocks' })
+    .filter({ hasText: 'E2E Test' })
     .first()
 
-  if (!(await pageBlocksLink.isVisible({ timeout: 5000 }).catch(() => false))) {
+  if (!(await e2eTestLink.isVisible({ timeout: 5000 }).catch(() => false))) {
     return null
   }
 
-  const href = await pageBlocksLink.getAttribute('href')
+  const href = await e2eTestLink.getAttribute('href')
   const match = href?.match(/[?&]collection=([^&]+)/)
   return match?.[1] || null
 }
@@ -24,7 +24,7 @@ test.describe.skip('Nested Object Serialization', () => {
     await loginAsAdmin(page)
 
     const collectionKey = await resolvePageBlocksCollectionKey(page)
-    test.skip(!collectionKey, 'Page Blocks collection not available')
+    test.skip(!collectionKey, 'E2E Test collection not available')
 
     await page.goto('/admin/content/new?collection=' + encodeURIComponent(collectionKey!))
     await page.waitForLoadState('networkidle')

--- a/tests/e2e/59-array-media-picker-targeting.spec.ts
+++ b/tests/e2e/59-array-media-picker-targeting.spec.ts
@@ -50,16 +50,16 @@ async function resolvePageBlocksCollectionKey(page: Page): Promise<string | null
   await page.goto('/admin/content/new')
   await page.waitForLoadState('networkidle', { timeout: 15000 })
 
-  const pageBlocksLink = page
+  const e2eTestLink = page
     .locator('a[href^="/admin/content/new?collection="]')
-    .filter({ hasText: 'Page Blocks' })
+    .filter({ hasText: 'E2E Test' })
     .first()
 
-  if (!(await pageBlocksLink.isVisible({ timeout: 5000 }).catch(() => false))) {
+  if (!(await e2eTestLink.isVisible({ timeout: 5000 }).catch(() => false))) {
     return null
   }
 
-  const href = await pageBlocksLink.getAttribute('href')
+  const href = await e2eTestLink.getAttribute('href')
   const match = href?.match(/[?&]collection=([^&]+)/)
   return match?.[1] || null
 }
@@ -122,7 +122,7 @@ test.describe('Array Media Picker Targeting', () => {
     const slug = `gallery-media-targeting-${Date.now()}`
 
     const collectionKey = await resolvePageBlocksCollectionKey(page)
-    test.skip(!collectionKey, 'Page Blocks collection not available')
+    test.skip(!collectionKey, 'E2E Test collection not available')
 
     await page.goto('/admin/content/new?collection=' + encodeURIComponent(collectionKey!))
     await page.waitForLoadState('networkidle', { timeout: 15000 })

--- a/tests/e2e/65-default-blog-post-seed.spec.ts
+++ b/tests/e2e/65-default-blog-post-seed.spec.ts
@@ -10,7 +10,7 @@ test.describe('default content seed', () => {
     const names = collections.map((collection: any) => collection.name)
     // Core collections expected on a fresh install
     expect(names).toContain('blog_post')
-    expect(names).toContain('page_blocks')
+    expect(names).toContain('e2e_test')
     // Legacy collections from old DB schema must not appear
     expect(names).not.toContain('pages')
     expect(names).not.toContain('news')


### PR DESCRIPTION
## Summary
- `page_blocks` collection removed from sample app — it has no place in a base install
- Replaced with `e2e_test` collection covering **all field types**: string, slug, textarea, number, boolean, date, datetime, user, media, select, radio, lexical, object (flat layout), array/blocks (hero, text, callToAction blocks)
- 10 E2E specs updated to reference `e2e_test` / `E2E Test` instead of `page_blocks` / `Page Blocks`

## Changes
- `my-sonicjs-app/src/collections/page-blocks.collection.ts` — deleted
- `my-sonicjs-app/src/collections/e2e-test.collection.ts` — new comprehensive test fixture collection
- `my-sonicjs-app/src/index.ts` — swapped import/registration
- `tests/e2e/38,42,53,54,55,56,57,58,59,65-*.spec.ts` — collection name updated

## Notes
- Starter template (`packages/create-app/templates/starter`) unaffected — it never included `page_blocks`
- `e2e_test` collection is dev-app only; new installs via `create-app` won't see it

## Testing
- [ ] E2E specs referencing `e2e_test` pass against local dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)