### PR TITLE
fix(create-app): bump compatibility_date to fix crypto import error on npm run dev

### DIFF
--- a/packages/create-app/templates/starter/wrangler.toml
+++ b/packages/create-app/templates/starter/wrangler.toml
@@ -1,6 +1,6 @@
 name = "my-sonicjs-app"
 main = "src/index.ts"
-compatibility_date = "2024-01-01"
+compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
 
 # Cloudflare Workers settings


### PR DESCRIPTION
## Summary
- Bumps `compatibility_date` in the `create-sonicjs` starter template from `2024-01-01` to `2024-09-23`
- Fixes `Could not resolve "crypto"` error when running `npm run dev` after `npx create-sonicjs`

## Root Cause
`better-auth` (bundled into `@sonicjs-cms/core`) imports `crypto` without the `node:` prefix. Wrangler requires `compatibility_date >= 2024-09-23` to resolve bare Node built-in names like `crypto`. The old date of `2024-01-01` was too early.

## Test Plan
- [ ] Run `npx create-sonicjs` to scaffold a new project
- [ ] Run `npm run dev` — should start without the `Could not resolve "crypto"` build error

🤖 Generated with [Claude Code](https://claude.com/claude-code)