### PR TITLE
docs(www): fix v3 changelog placement and stale doc errors

### DIFF
--- a/www/src/app/changelog/page.mdx
+++ b/www/src/app/changelog/page.mdx
@@ -1,5 +1,6 @@
 export const sections = [
   { title: 'Unreleased', id: 'unreleased' },
+  { title: 'Version 3.x', id: 'version-3-x' },
   { title: 'Version 2.x', id: 'version-2-x' },
   { title: 'Version 1.0.x', id: 'version-1-0-x' },
   { title: 'Earlier Versions', id: 'earlier-versions' },
@@ -61,7 +62,7 @@ export const sections = [
 
 ---
 
-## Version 3.0.0-beta
+## Version 3.x
 
 <div className="not-prose space-y-6 my-8">
 
@@ -94,16 +95,6 @@ export const sections = [
     </div>
   </div>
 </div>
-
-</div>
-
----
-
-## Version 2.x
-
-<div className="not-prose space-y-6 my-8">
-
-
 
 
 
@@ -184,6 +175,14 @@ export const sections = [
     </div>
   </div>
 </div>
+
+</div>
+
+---
+
+## Version 2.x
+
+<div className="not-prose space-y-6 my-8">
 
 {/* Version 2.19.0 */}
 <div className="relative pl-8 pb-8 border-l-2 border-emerald-200 dark:border-emerald-800">

--- a/www/src/app/troubleshooting/page.mdx
+++ b/www/src/app/troubleshooting/page.mdx
@@ -64,7 +64,7 @@ fetch('/api/content', {
 
 **Causes:**
 - Token's `exp` timestamp has passed
-- Default token lifetime is 24 hours
+- Default token lifetime is 30 days (overridable via `JWT_EXPIRES_IN` env var)
 
 **Solutions:**
 


### PR DESCRIPTION
## Summary
- v3.0.0-beta.3 changelog entry was nested under \"Version 2.x\" section — moved into correct \"Version 3.x\" section
- Added \"Version 3.x\" to changelog sidebar nav (was missing entirely)
- Fixed JWT default lifetime doc: said 24h, code says 30d (`DEFAULT_JWT_EXPIRES_IN_SECONDS`)
- Fixed stale `{/* v2.19.0 */}` comment on homepage that mislabeled v3.0.0-beta.3 entry

## Test plan
- [ ] Visit `/changelog` — v3.0.0-beta.3 appears under Version 3.x, not Version 2.x
- [ ] Sidebar nav shows Version 3.x anchor
- [ ] Visit `/troubleshooting` — JWT lifetime shows 30 days