### PR TITLE
fix(create-app): update blog_post collection and disable cache plugin by default

### DIFF
--- a/packages/core/src/plugins/manifest-registry.ts
+++ b/packages/core/src/plugins/manifest-registry.ts
@@ -165,7 +165,7 @@ export const PLUGIN_REGISTRY: Record<string, PluginRegistryEntry> = {
     "category": "system",
     "iconEmoji": "⚡",
     "is_core": true,
-    "defaultActive": true,
+    "defaultActive": false,
     "permissions": [
       "cache.view",
       "cache.clear",

--- a/packages/create-app/templates/starter/src/collections/blog-posts.collection.ts
+++ b/packages/create-app/templates/starter/src/collections/blog-posts.collection.ts
@@ -4,11 +4,12 @@
  * Example collection configuration for blog posts
  */
 
-import type { CollectionConfig } from '@sonicjs-cms/core'
+import type { CollectionConfig } from '@sonicjs-cms/core';
 
 export default {
-  name: 'blog-posts',
-  displayName: 'Blog Posts',
+  name: 'blog_post',
+  displayName: 'Blog Post',
+  slug: 'blog-posts',
   description: 'Manage your blog posts',
   icon: '📝',
 
@@ -19,57 +20,46 @@ export default {
         type: 'string',
         title: 'Title',
         required: true,
-        maxLength: 200
+        maxLength: 200,
       },
       slug: {
         type: 'slug',
         title: 'URL Slug',
         required: true,
-        maxLength: 200
-      },
-      excerpt: {
-        type: 'textarea',
-        title: 'Excerpt',
-        maxLength: 500,
-        helpText: 'A short summary of the post'
+        maxLength: 200,
       },
       content: {
-        type: 'quill',
+        type: 'lexical',
         title: 'Content',
-        required: true
-      },
-      featuredImage: {
-        type: 'media',
-        title: 'Featured Image'
+        required: true,
       },
       author: {
-        type: 'string',
+        type: 'user',
         title: 'Author',
-        required: true
+        required: true,
       },
       publishedAt: {
         type: 'datetime',
-        title: 'Published Date'
+        title: 'Published Date',
       },
-      status: {
-        type: 'select',
-        title: 'Status',
-        enum: ['draft', 'published', 'archived'],
-        enumLabels: ['Draft', 'Published', 'Archived'],
-        default: 'draft'
-      },
-      tags: {
-        type: 'string',
-        title: 'Tags',
-        helpText: 'Comma-separated tags'
-      }
     },
-    required: ['title', 'slug', 'content', 'author']
+    required: ['title', 'slug', 'content', 'author'],
   },
 
   // List view configuration
   listFields: ['title', 'author', 'status', 'publishedAt'],
-  searchFields: ['title', 'excerpt', 'author'],
+  searchFields: ['title', 'content', 'author'],
   defaultSort: 'createdAt',
-  defaultSortOrder: 'desc'
-} satisfies CollectionConfig
+  defaultSortOrder: 'desc',
+
+  // Mark as config-managed (code-based) collection
+  managed: true,
+  isActive: true,
+
+  // Per-collection cache override. TTL in seconds; falls back to the cache plugin
+  // default (CACHE_CONFIGS.api.ttl, currently 300s) if unset.
+  cache: {
+    enabled: true,
+    ttl: 5,
+  },
+} satisfies CollectionConfig;


### PR DESCRIPTION
## Summary
- Switch `blog_post` content field from `quill` → `lexical`
- Update collection schema: proper `name: 'blog_post'`, `slug` field, `author` type changed to `user`, removed stale fields (`excerpt`, `featuredImage`, `status`, `tags`)
- Set `core-cache` plugin `defaultActive: false` — only `lexical-editor` should be on by default

## Test plan
- [ ] Run `npx create-sonicjs` and verify `blog_post` collection uses lexical editor
- [ ] Verify cache plugin is off by default in new installs
- [ ] Verify lexical editor is still on by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)