### PR TITLE
feat(stats): auto-deploy stats.sonicjs.com on main merges

### DIFF
--- a/.github/workflows/deploy-stats.yml
+++ b/.github/workflows/deploy-stats.yml
@@ -1,0 +1,41 @@
+name: Deploy Stats
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/stats/**'
+      - 'packages/core/src/**'
+      - '.github/workflows/deploy-stats.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build core package
+        run: npm run build:core
+
+      - name: Type check stats
+        run: cd packages/stats && npx tsc --noEmit
+
+      - name: Deploy stats to Cloudflare Workers (production)
+        run: cd packages/stats && npx wrangler deploy --env production
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build:core": "npm run plugins:generate && npm run build --workspace=@sonicjs-cms/core",
     "deploy": "npm run deploy --workspace=my-sonicjs-app",
     "deploy:www": "npm run deploy --workspace=www",
+    "deploy:stats": "npm run deploy:production --workspace=sonicjs-stats",
     "test": "npm run test --workspace=@sonicjs-cms/core",
     "test:cov": "npm run test:cov --workspace=@sonicjs-cms/core",
     "test:watch": "npm run test:watch --workspace=@sonicjs-cms/core",

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -8,6 +8,7 @@
     "dev": "wrangler dev",
     "build": "echo 'Worker build is handled by wrangler during deployment'",
     "deploy": "wrangler deploy",
+    "deploy:production": "wrangler deploy --env production",
     "db:migrate": "wrangler d1 migrations apply DB",
     "db:migrate:local": "wrangler d1 migrations apply DB --local",
     "type-check": "tsc --noEmit"

--- a/packages/stats/wrangler.toml
+++ b/packages/stats/wrangler.toml
@@ -1,6 +1,6 @@
 name = "sonicjs-stats"
 main = "src/index.ts"
-compatibility_date = "2024-09-23"
+compatibility_date = "2025-05-05"
 compatibility_flags = ["nodejs_compat"]
 
 # Cloudflare Workers settings


### PR DESCRIPTION
## Summary

- New `deploy-stats.yml` CI workflow — triggers on push to `main` when `packages/stats/**` or `packages/core/src/**` changes, plus `workflow_dispatch` for manual runs
- Workflow: checkout → npm ci → build:core → tsc type-check → `wrangler deploy --env production` (deploys as `sonicjs-stats-production`)
- Added `deploy:production` script to `packages/stats/package.json`
- Added `deploy:stats` convenience script to root `package.json` (`npm run deploy:stats`)
- Updated `wrangler.toml` compatibility date from `2024-09-23` → `2025-05-05`

## Test plan

- [ ] Merge to main → check Actions tab for Deploy Stats workflow run
- [ ] Confirm `sonicjs-stats-production` worker updated in Cloudflare dashboard
- [ ] Verify `stats.sonicjs.com` still serves (custom domain should stay attached to production worker)
- [ ] Test manual trigger via `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)