### PR TITLE
fix(www): resolve build errors blocking deploy

### DIFF
--- a/www/src/app/blog/[slug]/page.tsx
+++ b/www/src/app/blog/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { ShareButtons } from '../components/ShareButtons'
 import { RelatedPosts } from '../components/RelatedPosts'
 import { BlogPostSchema, BreadcrumbSchema } from '../components/StructuredData'
 import { TLDRBox } from '../components/TLDRBox'
+import { Callout } from '@/components/Callout'
 
 // Force static generation - required for Cloudflare Workers deployment
 export const dynamic = 'force-static'
@@ -82,6 +83,7 @@ export default async function BlogPostPage({ params }: PageProps) {
     source: post.content,
     components: {
       TLDRBox,
+      Callout,
     },
     options: {
       mdxOptions: {

--- a/www/src/mdx/rehype.mjs
+++ b/www/src/mdx/rehype.mjs
@@ -8,9 +8,9 @@ import { visit } from 'unist-util-visit'
 function rehypeParseCodeBlocks() {
   return (tree) => {
     visit(tree, 'element', (node, _nodeIndex, parentNode) => {
-      if (node.tagName === 'code') {
-        parentNode.properties.language = node.properties.className
-          ? node.properties?.className[0]?.replace(/^language-/, '')
+      if (node.tagName === 'code' && parentNode?.properties != null) {
+        parentNode.properties.language = node.properties?.className
+          ? node.properties.className[0]?.replace(/^language-/, '')
           : 'txt'
       }
     })


### PR DESCRIPTION
## Summary
- **rehype.mjs**: Guard `parentNode?.properties != null` before setting `.language` — inline code inside MDX JSX flow elements (`<li>`, `<span>`) are `mdxJsxFlowElement` nodes with no `properties` object, crashing the build with `Cannot set properties of undefined (setting 'language')`
- **blog/[slug]/page.tsx**: Add `Callout` to `compileMDX` components map — blog posts using `<Callout>` crashed at prerender with `Expected component Callout to be defined`

## Test plan
- [ ] `npm run deploy:www` builds successfully (Next.js 85/85 pages + opennextjs bundle)
- [ ] `/changelog` renders without errors
- [ ] `/blog/sonicjs-plugin-architecture-deep-dive` renders with Callout