### PR TITLE
feat(stats): stats.sonicjs.com — document model migration + dashboard plugin

### DIFF
--- a/.github/workflows/deploy-stats.yml
+++ b/.github/workflows/deploy-stats.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Type check stats
         run: cd packages/stats && npx tsc --noEmit
 
+      - name: Apply D1 migrations (production)
+        run: cd packages/stats && npx wrangler d1 migrations apply DB --env production --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: Deploy stats to Cloudflare Workers (production)
         run: cd packages/stats && npx wrangler deploy --env production
         env:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -202,6 +202,8 @@ export {
   getConfirmationDialogScript,
   // Filter bar templates
   renderFilterBar,
+  // Admin layout (catalyst)
+  renderAdminLayoutCatalyst,
 } from './templates'
 
 export type {
@@ -215,6 +217,7 @@ export type {
   FilterBarData,
   Filter,
   FilterOption,
+  AdminLayoutCatalystData,
 } from './templates'
 
 // Types - Week 1 (COMPLETED)

--- a/packages/stats/migrations/0001_core.sql
+++ b/packages/stats/migrations/0001_core.sql
@@ -1,0 +1,184 @@
+-- Migration 0001: Auth tables
+-- auth_user, auth_session, auth_account, auth_verification + BA plugin tables + RBAC + auth support.
+-- Only auth_* prefixed tables live here. All content lives in document_* tables (0002_documents.sql).
+
+-- ── auth_user ────────────────────────────────────────────────────────────────
+-- BA user model + SonicJS domain columns as BA additionalFields.
+CREATE TABLE IF NOT EXISTS auth_user (
+  id TEXT PRIMARY KEY,
+  name TEXT,
+  email TEXT NOT NULL UNIQUE,
+  email_verified INTEGER NOT NULL DEFAULT 0,
+  image TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  -- SonicJS additionalFields
+  first_name TEXT NOT NULL,
+  last_name TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'viewer',
+  -- Platform super-admin: bypasses the multi-tenant membership gate, uses global roles in every
+  -- tenant. Opt-in (default 0); intentionally NOT derived from the 'admin' role.
+  is_super_admin INTEGER NOT NULL DEFAULT 0,
+  avatar TEXT,
+  password_hash TEXT,
+  is_active INTEGER NOT NULL DEFAULT 1,
+  last_login_at INTEGER,
+  phone TEXT,
+  bio TEXT,
+  timezone TEXT DEFAULT 'UTC',
+  language TEXT DEFAULT 'en',
+  email_notifications INTEGER DEFAULT 1,
+  theme TEXT DEFAULT 'dark',
+  invitation_token TEXT,
+  invited_by TEXT,
+  invited_at INTEGER,
+  accepted_invitation_at INTEGER,
+  failed_login_count INTEGER NOT NULL DEFAULT 0,
+  locked_until INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_user_email ON auth_user(email);
+CREATE INDEX IF NOT EXISTS idx_auth_user_role ON auth_user(role);
+CREATE INDEX IF NOT EXISTS idx_auth_user_invitation_token ON auth_user(invitation_token);
+CREATE INDEX IF NOT EXISTS idx_auth_user_locked_until ON auth_user(locked_until) WHERE locked_until IS NOT NULL;
+
+-- ── auth_session ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS auth_session (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES auth_user(id) ON DELETE CASCADE,
+  token TEXT NOT NULL UNIQUE,
+  expires_at INTEGER NOT NULL,
+  ip_address TEXT,
+  user_agent TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_auth_session_user_id ON auth_session(user_id);
+CREATE INDEX IF NOT EXISTS idx_auth_session_token ON auth_session(token);
+CREATE INDEX IF NOT EXISTS idx_auth_session_expires_at ON auth_session(expires_at);
+
+-- ── auth_account ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS auth_account (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES auth_user(id) ON DELETE CASCADE,
+  account_id TEXT NOT NULL,
+  provider_id TEXT NOT NULL,
+  access_token TEXT,
+  refresh_token TEXT,
+  access_token_expires_at INTEGER,
+  refresh_token_expires_at INTEGER,
+  scope TEXT,
+  id_token TEXT,
+  password TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_auth_account_user_id ON auth_account(user_id);
+CREATE INDEX IF NOT EXISTS idx_auth_account_provider ON auth_account(provider_id, account_id);
+
+-- ── auth_verification ────────────────────────────────────────────────────────
+-- Covers email verification, password reset, magic-link tokens, OTP codes.
+CREATE TABLE IF NOT EXISTS auth_verification (
+  id TEXT PRIMARY KEY,
+  identifier TEXT NOT NULL,
+  value TEXT NOT NULL,
+  expires_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_auth_verification_identifier ON auth_verification(identifier);
+
+-- ── BA plugin tables ──────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS auth_two_factor (
+  id           TEXT PRIMARY KEY,
+  secret       TEXT NOT NULL,
+  backup_codes TEXT NOT NULL,
+  user_id      TEXT NOT NULL REFERENCES auth_user(id) ON DELETE CASCADE,
+  verified     INTEGER NOT NULL DEFAULT 1,
+  created_at   INTEGER NOT NULL,
+  updated_at   INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_auth_two_factor_user_id ON auth_two_factor(user_id);
+
+CREATE TABLE IF NOT EXISTS auth_tenant (
+  id         TEXT PRIMARY KEY,
+  name       TEXT NOT NULL,
+  slug       TEXT NOT NULL UNIQUE,
+  logo       TEXT,
+  metadata   TEXT,
+  -- SonicJS tenant-resolution fields (BA organization additionalFields):
+  status     TEXT NOT NULL DEFAULT 'active',
+  domain     TEXT,
+  notes      TEXT NOT NULL DEFAULT '',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_auth_tenant_domain ON auth_tenant(domain);
+
+CREATE TABLE IF NOT EXISTS auth_tenant_member (
+  id        TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL REFERENCES auth_tenant(id) ON DELETE CASCADE,
+  user_id   TEXT NOT NULL REFERENCES auth_user(id)   ON DELETE CASCADE,
+  role      TEXT NOT NULL DEFAULT 'member',
+  email     TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE(tenant_id, user_id)
+);
+CREATE INDEX IF NOT EXISTS idx_auth_tenant_member_tenant ON auth_tenant_member(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_auth_tenant_member_user   ON auth_tenant_member(user_id);
+
+CREATE TABLE IF NOT EXISTS auth_tenant_invitation (
+  id         TEXT PRIMARY KEY,
+  tenant_id  TEXT NOT NULL REFERENCES auth_tenant(id) ON DELETE CASCADE,
+  email      TEXT NOT NULL,
+  role       TEXT NOT NULL DEFAULT 'member',
+  status     TEXT NOT NULL DEFAULT 'pending',
+  expires_at INTEGER NOT NULL,
+  inviter_id TEXT REFERENCES auth_user(id) ON DELETE SET NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_auth_tenant_invitation_tenant ON auth_tenant_invitation(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_auth_tenant_invitation_email  ON auth_tenant_invitation(email);
+
+CREATE TABLE IF NOT EXISTS auth_tenant_team (
+  id        TEXT PRIMARY KEY,
+  name      TEXT NOT NULL,
+  tenant_id TEXT NOT NULL REFERENCES auth_tenant(id) ON DELETE CASCADE,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- ── RBAC ─────────────────────────────────────────────────────────────────────
+-- RBAC roles, verbs, and user-role assignments are document-backed (is_auth doc
+-- types rbac_role / rbac_verb / rbac_user_roles — see services/rbac.ts). The
+-- system roles/verbs/grants are seeded at bootstrap by RbacService.ensureSystemRbacSeed().
+-- No auth_rbac_* tables.
+
+-- ── Auth support tables ───────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS auth_password_history (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES auth_user(id) ON DELETE CASCADE,
+  password_hash TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_auth_password_history_user_id ON auth_password_history(user_id);
+
+CREATE TABLE IF NOT EXISTS auth_api_tokens (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  token TEXT NOT NULL UNIQUE,
+  user_id TEXT NOT NULL REFERENCES auth_user(id),
+  permissions TEXT NOT NULL,
+  expires_at INTEGER,
+  last_used_at INTEGER,
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_auth_api_tokens_user ON auth_api_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_auth_api_tokens_token ON auth_api_tokens(token);
+
+-- User profiles moved to the document model: a `user_profile` document (is_auth type),
+-- one per user, addressed by slug = userId. See services/document-types-seed.ts and
+-- plugins/core-plugins/user-profiles/user-profile-document.ts. No auth_user_profiles table.

--- a/packages/stats/migrations/0002_documents.sql
+++ b/packages/stats/migrations/0002_documents.sql
@@ -1,0 +1,163 @@
+-- Migration 0002: Document Schema (v3 greenfield)
+-- Contains only the new document data model tables, generated columns, and indexes.
+
+-- Document type registry
+CREATE TABLE IF NOT EXISTS document_types (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  display_name TEXT NOT NULL,
+  description TEXT,
+  schema TEXT NOT NULL DEFAULT '{}',
+  queryable_fields TEXT NOT NULL DEFAULT '[]',
+  settings TEXT NOT NULL DEFAULT '{}',
+  plugin_id TEXT,
+  source TEXT NOT NULL DEFAULT 'code' CHECK (source IN ('code', 'plugin', 'system')),
+  schema_version INTEGER NOT NULL DEFAULT 1,
+  is_system INTEGER NOT NULL DEFAULT 0,
+  is_active INTEGER NOT NULL DEFAULT 1,
+  is_auth INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS idx_document_types_plugin ON document_types(plugin_id);
+CREATE INDEX IF NOT EXISTS idx_document_types_active ON document_types(is_active);
+
+-- Documents: canonical document rows and historical versions.
+CREATE TABLE IF NOT EXISTS documents (
+  id TEXT PRIMARY KEY,
+  root_id TEXT NOT NULL,
+  type_id TEXT NOT NULL REFERENCES document_types(id),
+  type_version INTEGER NOT NULL DEFAULT 1,
+
+  version_of_id TEXT REFERENCES documents(id),
+  version_number INTEGER NOT NULL DEFAULT 1,
+
+  is_current_draft INTEGER NOT NULL DEFAULT 1,
+  is_published INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'published', 'archived')),
+
+  parent_root_id TEXT NOT NULL DEFAULT '',
+  slug TEXT,
+  path TEXT,
+  title TEXT,
+  zone TEXT,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  visible INTEGER NOT NULL DEFAULT 1,
+
+  published_at INTEGER,
+  scheduled_at INTEGER,
+  expires_at INTEGER,
+  deleted_at INTEGER,
+
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  locale TEXT NOT NULL DEFAULT 'default',
+  translation_group_id TEXT NOT NULL DEFAULT '',
+
+  data TEXT NOT NULL DEFAULT '{}',
+  metadata TEXT NOT NULL DEFAULT '{}',
+
+  owner_id TEXT,
+  created_by TEXT,
+  updated_by TEXT,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+-- Queryable scalar fields (VIRTUAL generated columns) and their q_* filter indexes
+-- are AUTO-GENERATED at runtime from each document type's queryableFields config —
+-- see DocumentTypeRegistry.register() -> ensureScalarSchema() (document-scalar-schema.ts).
+-- Do not hand-add q_* columns/indexes here; declare the field in the type instead.
+
+-- Revision chain
+CREATE INDEX IF NOT EXISTS idx_documents_root ON documents(root_id, version_number DESC);
+
+-- List / lifecycle
+CREATE INDEX IF NOT EXISTS idx_documents_published ON documents(tenant_id, type_id, locale, is_published)
+  WHERE is_published = 1 AND deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_documents_drafts ON documents(tenant_id, type_id, status, is_current_draft)
+  WHERE is_current_draft = 1;
+CREATE INDEX IF NOT EXISTS idx_documents_parent ON documents(tenant_id, parent_root_id, sort_order, is_published);
+CREATE INDEX IF NOT EXISTS idx_documents_path ON documents(tenant_id, path);
+CREATE INDEX IF NOT EXISTS idx_documents_translation ON documents(translation_group_id, locale);
+CREATE INDEX IF NOT EXISTS idx_documents_deleted ON documents(deleted_at);
+CREATE INDEX IF NOT EXISTS idx_documents_scheduled ON documents(scheduled_at) WHERE scheduled_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_documents_expires ON documents(expires_at) WHERE expires_at IS NOT NULL;
+
+-- Stable keyset/cursor pagination for published lists
+CREATE INDEX IF NOT EXISTS idx_documents_published_cursor
+  ON documents(tenant_id, type_id, updated_at DESC, id DESC)
+  WHERE is_published = 1 AND deleted_at IS NULL;
+
+-- (q_* generated-column filter indexes are auto-created at runtime — see note above.)
+
+-- Partial unique indexes: the hard concurrency guarantees for draft/publish invariants.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_one_current_draft
+  ON documents(root_id) WHERE is_current_draft = 1;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_one_published
+  ON documents(root_id) WHERE is_published = 1;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_unique_version
+  ON documents(root_id, version_number);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_unique_slug
+  ON documents(tenant_id, locale, type_id, parent_root_id, slug)
+  WHERE is_current_draft = 1 AND deleted_at IS NULL AND slug IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_one_translation_per_locale
+  ON documents(tenant_id, translation_group_id, locale)
+  WHERE is_current_draft = 1 AND translation_group_id <> '';
+
+-- Document references: typed document-to-document edges.
+CREATE TABLE IF NOT EXISTS document_references (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  from_root_id TEXT NOT NULL,
+  from_document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+  field_name TEXT NOT NULL,
+  ordinal INTEGER NOT NULL DEFAULT 0,
+  to_root_id TEXT NOT NULL,
+  ref_strength TEXT NOT NULL DEFAULT 'weak' CHECK (ref_strength IN ('strong', 'weak')),
+  created_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS idx_docref_to   ON document_references(tenant_id, to_root_id);
+CREATE INDEX IF NOT EXISTS idx_docref_from ON document_references(from_document_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_docref_unique
+  ON document_references(from_document_id, field_name, ordinal);
+
+-- Document facets: indexed rows for multi-valued scalar fields (e.g. tags arrays).
+CREATE TABLE IF NOT EXISTS document_facets (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+  root_id TEXT NOT NULL,
+  type_id TEXT NOT NULL,
+  field_name TEXT NOT NULL,
+  ordinal INTEGER NOT NULL DEFAULT 0,
+  value_text TEXT,
+  value_number REAL,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS idx_facets_lookup ON document_facets(tenant_id, type_id, field_name, value_text);
+CREATE INDEX IF NOT EXISTS idx_facets_doc    ON document_facets(document_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_facets_unique
+  ON document_facets(document_id, field_name, ordinal);
+
+-- Document permissions: per-document ACL overrides.
+CREATE TABLE IF NOT EXISTS document_permissions (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  root_id TEXT NOT NULL,
+  principal_type TEXT NOT NULL CHECK (principal_type IN ('user', 'role', 'group', 'public', 'token')),
+  principal_id TEXT NOT NULL,
+  permission TEXT NOT NULL CHECK (permission IN ('read', 'create', 'update', 'delete', 'publish', 'manage')),
+  effect TEXT NOT NULL DEFAULT 'allow' CHECK (effect IN ('allow', 'deny')),
+  inherited INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  created_by TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_document_permissions_root ON document_permissions(tenant_id, root_id);
+CREATE INDEX IF NOT EXISTS idx_document_permissions_principal
+  ON document_permissions(tenant_id, principal_type, principal_id, permission);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_document_permissions_unique
+  ON document_permissions(root_id, principal_type, principal_id, permission);

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -12,7 +12,8 @@
     "db:migrate": "wrangler d1 migrations apply DB",
     "db:migrate:local": "wrangler d1 migrations apply DB --local",
     "db:migrate:production": "wrangler d1 migrations apply DB --env production --remote",
-    "db:reset:local": "wrangler d1 execute DB --local --command 'DROP TABLE IF EXISTS documents; DROP TABLE IF EXISTS document_types; DROP TABLE IF EXISTS document_references; DROP TABLE IF EXISTS document_facets; DROP TABLE IF EXISTS document_permissions; DROP TABLE IF EXISTS session; DROP TABLE IF EXISTS account; DROP TABLE IF EXISTS user; DROP TABLE IF EXISTS verification;' && wrangler d1 migrations apply DB --local",
+    "db:reset:local": "rm -rf .wrangler/state/v3/d1 && wrangler d1 migrations apply DB --local && node scripts/seed-local.mjs",
+    "setup:db": "npm run db:reset:local",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -17,7 +17,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@sonicjs-cms/core": "^3.0.0-beta.0"
+    "@sonicjs-cms/core": "*"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250620.0",

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -12,7 +12,7 @@
     "db:migrate": "wrangler d1 migrations apply DB",
     "db:migrate:local": "wrangler d1 migrations apply DB --local",
     "db:migrate:production": "wrangler d1 migrations apply DB --env production --remote",
-    "db:reset:local": "rm -rf .wrangler/state/v3/d1 && wrangler d1 migrations apply DB --local && node scripts/seed-local.mjs",
+    "db:reset:local": "bash scripts/setup-local.sh",
     "setup:db": "npm run db:reset:local",
     "type-check": "tsc --noEmit"
   },

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -11,6 +11,8 @@
     "deploy:production": "wrangler deploy --env production",
     "db:migrate": "wrangler d1 migrations apply DB",
     "db:migrate:local": "wrangler d1 migrations apply DB --local",
+    "db:migrate:production": "wrangler d1 migrations apply DB --env production --remote",
+    "db:reset:local": "wrangler d1 execute DB --local --command 'DROP TABLE IF EXISTS documents; DROP TABLE IF EXISTS document_types; DROP TABLE IF EXISTS document_references; DROP TABLE IF EXISTS document_facets; DROP TABLE IF EXISTS document_permissions; DROP TABLE IF EXISTS session; DROP TABLE IF EXISTS account; DROP TABLE IF EXISTS user; DROP TABLE IF EXISTS verification;' && wrangler d1 migrations apply DB --local",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
@@ -19,8 +21,6 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250620.0",
     "@types/node": "^20.19.1",
-    "drizzle-kit": "^0.31.8",
-    "drizzle-orm": "^0.45.2",
     "hono": "^4.12.26",
     "typescript": "^5.8.3",
     "wrangler": "^4.78.0"

--- a/packages/stats/scripts/migrate-legacy-data.mjs
+++ b/packages/stats/scripts/migrate-legacy-data.mjs
@@ -1,0 +1,114 @@
+/**
+ * Migrates legacy v2 stats data (backup JSON) into the document model.
+ *
+ * Usage:
+ *   node scripts/migrate-legacy-data.mjs --remote   (production D1)
+ *   node scripts/migrate-legacy-data.mjs            (local D1)
+ *
+ * Reads from:
+ *   ../.context/events-backup-all.json
+ *   ../.context/installs-backup.json
+ *
+ * Note: created_at in backup is milliseconds (v2 legacy) — converted to seconds.
+ */
+
+import { execSync } from 'child_process'
+import { readFileSync, writeFileSync, unlinkSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const contextDir = join(__dir, '../../../.context')
+const statsDir = join(__dir, '..')
+
+const isRemote = process.argv.includes('--remote')
+const remoteFlag = isRemote ? '--env production --remote' : '--local'
+
+function toSeconds(val) {
+  if (!val) return Math.floor(Date.now() / 1000)
+  const n = Number(val)
+  if (!isNaN(n)) {
+    // already numeric: >1e10 = ms, else seconds
+    return n > 1e10 ? Math.floor(n / 1000) : Math.floor(n)
+  }
+  // ISO string
+  return Math.floor(new Date(val).getTime() / 1000)
+}
+
+function escapeSql(str) {
+  return String(str ?? '').replace(/'/g, "''")
+}
+
+function runSqlFile(path) {
+  execSync(`npx wrangler d1 execute DB ${remoteFlag} --file "${path}"`, {
+    cwd: statsDir,
+    encoding: 'utf8',
+    stdio: 'inherit',
+  })
+}
+
+function buildInserts(rows, typeId) {
+  const now = Math.floor(Date.now() / 1000)
+  return rows.map(row => {
+    const id = crypto.randomUUID()
+    const createdAt = toSeconds(row.created_at)
+    const data = escapeSql(row.data)
+    const title = escapeSql(row.title ?? '')
+    return `INSERT OR IGNORE INTO documents ` +
+      `(id, root_id, type_id, type_version, version_number, is_current_draft, is_published, status, ` +
+      `parent_root_id, title, sort_order, visible, tenant_id, locale, data, created_at, updated_at) VALUES ` +
+      `('${id}','${id}','${typeId}',1,1,0,1,'published','','${title}',0,1,'default','default','${data}',${createdAt},${createdAt});`
+  })
+}
+
+function runInChunks(statements, label, chunkSize = 90) {
+  const total = statements.length
+  let done = 0
+  for (let i = 0; i < total; i += chunkSize) {
+    const chunk = statements.slice(i, i + chunkSize)
+    const tmpFile = join(contextDir, `_tmp_chunk.sql`)
+    writeFileSync(tmpFile, chunk.join('\n'))
+    runSqlFile(tmpFile)
+    unlinkSync(tmpFile)
+    done += chunk.length
+    console.log(`  ${label}: ${done}/${total}`)
+  }
+}
+
+console.log(`\nMigrating to ${isRemote ? 'REMOTE (production)' : 'LOCAL'} D1...\n`)
+
+// Seed document types
+const now = Math.floor(Date.now() / 1000)
+const seedSql = join(contextDir, '_seed_types.sql')
+writeFileSync(seedSql, `
+INSERT OR IGNORE INTO document_types
+  (id, name, display_name, description, schema, queryable_fields, settings, source, schema_version, is_system, is_active, is_auth, created_at, updated_at)
+VALUES
+  ('events','events','Events','Telemetry events from SonicJS installations','{}','[]','{}','code',1,0,1,0,${now},${now}),
+  ('installs','installs','Installs','Anonymous installation records','{}','[]','{}','code',1,0,1,0,${now},${now});
+`.trim())
+runSqlFile(seedSql)
+unlinkSync(seedSql)
+console.log('Document types seeded.')
+
+// Migrate events
+const eventsOffset = parseInt(process.env.EVENTS_OFFSET ?? '0')
+const events = JSON.parse(readFileSync(join(contextDir, 'events-backup-all.json'), 'utf8')).slice(eventsOffset)
+console.log(`Migrating ${events.length} events (offset ${eventsOffset})...`)
+runInChunks(buildInserts(events, 'events'), 'events')
+
+// Migrate installs
+const installsOffset = parseInt(process.env.INSTALLS_OFFSET ?? '0')
+const installs = JSON.parse(readFileSync(join(contextDir, 'installs-backup.json'), 'utf8')).slice(installsOffset)
+console.log(`Migrating ${installs.length} installs (offset ${installsOffset})...`)
+runInChunks(buildInserts(installs, 'installs'), 'installs')
+
+// Verify
+console.log('\nVerifying...')
+const result = execSync(
+  `npx wrangler d1 execute DB ${remoteFlag} --json --command "SELECT type_id, COUNT(*) as n FROM documents GROUP BY type_id;"`,
+  { cwd: statsDir, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
+)
+const rows = JSON.parse(result)[0]?.results ?? []
+console.log('Documents by type:', rows)
+console.log('\nDone.')

--- a/packages/stats/scripts/seed-local.mjs
+++ b/packages/stats/scripts/seed-local.mjs
@@ -54,13 +54,15 @@ function hashPassword(password) {
 const EMAIL = 'admin@sonicjs.com'
 const PASSWORD = 'sonicjs!'
 
+let userId
 const existing = db.prepare('SELECT id FROM auth_user WHERE email = ?').get(EMAIL)
 
 if (existing) {
+  userId = existing.id
   console.log('✓ Admin user already exists')
 } else {
   const now = Math.floor(Date.now() / 1000)
-  const userId = `admin-${Date.now()}-${randomBytes(4).toString('hex')}`
+  userId = `admin-${Date.now()}-${randomBytes(4).toString('hex')}`
   const passwordHash = hashPassword(PASSWORD)
 
   db.prepare(`
@@ -78,6 +80,189 @@ if (existing) {
   console.log('  Password:', PASSWORD)
   console.log('  Role: admin')
 }
+
+// ── RBAC bootstrap ──────────────────────────────────────────────────────────
+// Bootstrap normally runs these via RbacService on first request, but seed
+// must do it upfront so requireRbac('portal','access') passes on first login.
+
+const now = Math.floor(Date.now() / 1000)
+
+// Ensure document_types exist for rbac_role and rbac_user_roles
+const rbacTypes = [
+  { id: 'rbac_role', name: 'rbac_role', display_name: 'RBAC Role' },
+  { id: 'rbac_verb', name: 'rbac_verb', display_name: 'RBAC Verb' },
+  { id: 'rbac_user_roles', name: 'rbac_user_roles', display_name: 'RBAC User Roles' },
+]
+const upsertType = db.prepare(`
+  INSERT INTO document_types (id, name, display_name, description, schema, queryable_fields, settings, source, is_system, is_auth, created_at, updated_at)
+  VALUES (?, ?, ?, NULL, '{}', '[]', '{}', 'system', 1, 1, ?, ?)
+  ON CONFLICT(id) DO NOTHING
+`)
+for (const t of rbacTypes) {
+  upsertType.run(t.id, t.name, t.display_name, now, now)
+}
+console.log('✓ RBAC document_types ensured')
+
+// Ensure role-admin document exists
+const adminRoleId = `role-admin-seed`
+const adminRoleData = JSON.stringify({
+  name: 'admin',
+  displayName: 'Administrator',
+  description: 'Full access',
+  isSystem: true,
+  grants: [
+    { resource: '*', verb: '*', scope: 'any' },
+    { resource: 'portal', verb: 'access', scope: 'any' },
+  ],
+})
+db.prepare(`
+  INSERT INTO documents (id, root_id, type_id, type_version, version_number, is_current_draft, is_published,
+    status, parent_root_id, slug, title, tenant_id, locale, translation_group_id, data, metadata,
+    visible, sort_order, created_at, updated_at)
+  VALUES (?, ?, 'rbac_role', 1, 1, 1, 0, 'draft', '', 'role-admin', 'Administrator', 'default', 'default', '', ?, '{}', 1, 0, ?, ?)
+  ON CONFLICT(id) DO NOTHING
+`).run(adminRoleId, adminRoleId, adminRoleData, now, now)
+console.log('✓ role-admin document ensured')
+
+// Ensure user-roles document for this admin user
+const userRolesId = `rbac-user-roles-${userId}`
+const userRolesData = JSON.stringify({ roleIds: ['role-admin'] })
+db.prepare(`
+  INSERT INTO documents (id, root_id, type_id, type_version, version_number, is_current_draft, is_published,
+    status, parent_root_id, slug, title, tenant_id, locale, translation_group_id, data, metadata,
+    visible, sort_order, created_at, updated_at)
+  VALUES (?, ?, 'rbac_user_roles', 1, 1, 1, 0, 'draft', '', ?, 'User Roles', 'default', 'default', '', ?, '{}', 1, 0, ?, ?)
+  ON CONFLICT(id) DO NOTHING
+`).run(userRolesId, userRolesId, userId, userRolesData, now, now)
+console.log('✓ RBAC user-role link ensured (admin → role-admin)')
+
+// ── plugin document_type ────────────────────────────────────────────────────
+// documents.type_id FK requires document_types row to exist first.
+db.prepare(`
+  INSERT INTO document_types (id, name, display_name, description, schema, queryable_fields, settings, source, is_system, is_auth, created_at, updated_at)
+  VALUES ('plugin', 'plugin', 'Plugin', NULL, '{}', '[]', '{}', 'system', 1, 0, ?, ?)
+  ON CONFLICT(id) DO NOTHING
+`).run(now, now)
+console.log('✓ plugin document_type ensured')
+
+// ── stats-dashboard plugin document ─────────────────────────────────────────
+// Ensures stats-dashboard appears as active in the plugin list UI.
+// plugin-bootstrap would normally install this on first boot via PLUGIN_REGISTRY,
+// but seeding it here avoids the chicken-and-egg (need DB + running server).
+
+const pluginId = 'plugin-stats-dashboard-seed'
+const pluginData = JSON.stringify({
+  name: 'stats-dashboard',
+  displayName: 'Stats Dashboard',
+  description: 'Weekly installation funnel dashboard for stats.sonicjs.com.',
+  version: '1.0.0',
+  author: 'SonicJS Team',
+  category: 'analytics',
+  icon: '📊',
+  status: 'active',
+  isCore: false,
+  settings: {},
+  permissions: ['admin:access'],
+  dependencies: [],
+  downloadCount: 0,
+  rating: 0,
+})
+db.prepare(`
+  INSERT INTO documents (id, root_id, type_id, version_number, is_current_draft, is_published, status,
+    parent_root_id, slug, title, tenant_id, locale, translation_group_id,
+    data, metadata, created_at, updated_at)
+  VALUES (?, ?, 'plugin', 1, 1, 1, 'published',
+    '', 'stats-dashboard', 'Stats Dashboard', 'default', 'default', '',
+    ?, '{}', ?, ?)
+  ON CONFLICT(id) DO NOTHING
+`).run(pluginId, pluginId, pluginData, now, now)
+console.log('✓ stats-dashboard plugin document ensured (active)')
+
+// ── events document_type ────────────────────────────────────────────────────
+db.prepare(`
+  INSERT INTO document_types (id, name, display_name, description, schema, queryable_fields, settings, source, is_system, is_auth, created_at, updated_at)
+  VALUES ('events', 'events', 'Events', NULL, '{}', '[]', '{}', 'system', 0, 0, ?, ?)
+  ON CONFLICT(id) DO NOTHING
+`).run(now, now)
+console.log('✓ events document_type ensured')
+
+// ── test event data (13 weeks of install funnel) ────────────────────────────
+// Realistic-looking weekly funnel: started > completed > failed
+// Timestamps spaced one week apart, ending at seed time.
+
+const WEEK_S = 7 * 24 * 60 * 60  // seconds per week
+
+// [started, completed, failed] per week, oldest first
+const weeklyFunnel = [
+  [12,  8, 2],
+  [18, 12, 3],
+  [15, 10, 2],
+  [22, 16, 4],
+  [19, 14, 3],
+  [25, 18, 4],
+  [30, 22, 5],
+  [27, 20, 4],
+  [35, 26, 6],
+  [32, 24, 5],
+  [40, 30, 7],
+  [38, 29, 6],
+  [45, 34, 8],
+]
+
+const insertEvent = db.prepare(`
+  INSERT INTO documents (id, root_id, type_id, version_number, is_current_draft, is_published, status,
+    parent_root_id, slug, title, tenant_id, locale, translation_group_id,
+    data, metadata, created_at, updated_at)
+  VALUES (?, ?, 'events', 1, 1, 1, 'published',
+    '', ?, 'event', 'default', 'default', '',
+    ?, '{}', ?, ?)
+  ON CONFLICT(id) DO NOTHING
+`)
+
+let eventCount = 0
+const weeksAgo = weeklyFunnel.length
+
+for (let w = 0; w < weeklyFunnel.length; w++) {
+  const [started, completed, failed] = weeklyFunnel[w]
+  // Offset: oldest week first, most recent is ~current week
+  const weekOffset = (weeksAgo - 1 - w) * WEEK_S
+  const weekBase = now - weekOffset
+
+  // Generate unique install IDs for this week's starters
+  const installIds = Array.from({ length: started }, (_, i) =>
+    `install-seed-w${w}-${i}-${randomBytes(4).toString('hex')}`
+  )
+
+  // installation_started events
+  for (let i = 0; i < started; i++) {
+    const id = `evt-seed-started-w${w}-${i}`
+    const ts = weekBase + i * 600  // spread 10 min apart
+    const data = JSON.stringify({ installation_id: installIds[i], event_type: 'installation_started', timestamp: new Date(ts * 1000).toISOString() })
+    insertEvent.run(id, id, id, data, ts, ts)
+    eventCount++
+  }
+
+  // installation_completed events (subset of starters)
+  for (let i = 0; i < completed; i++) {
+    const id = `evt-seed-completed-w${w}-${i}`
+    const ts = weekBase + i * 600 + 1800  // 30 min after start
+    const data = JSON.stringify({ installation_id: installIds[i], event_type: 'installation_completed', timestamp: new Date(ts * 1000).toISOString() })
+    insertEvent.run(id, id, id, data, ts, ts)
+    eventCount++
+  }
+
+  // installation_failed events (different install IDs — ones that didn't complete)
+  for (let i = 0; i < failed; i++) {
+    const failIdx = started - 1 - i  // use last starters as the failed ones
+    const id = `evt-seed-failed-w${w}-${i}`
+    const ts = weekBase + failIdx * 600 + 900  // 15 min after start
+    const data = JSON.stringify({ installation_id: installIds[failIdx], event_type: 'installation_failed', timestamp: new Date(ts * 1000).toISOString() })
+    insertEvent.run(id, id, id, data, ts, ts)
+    eventCount++
+  }
+}
+
+console.log(`✓ ${eventCount} test events seeded (13 weeks of install funnel)`)
 
 db.close()
 console.log('✓ Seed complete')

--- a/packages/stats/scripts/seed-local.mjs
+++ b/packages/stats/scripts/seed-local.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Local-only seed: inserts admin user directly into the miniflare SQLite file.
+ * No Cloudflare auth or getPlatformProxy required.
+ *
+ * Usage: node scripts/seed-local.mjs [path-to-sqlite]
+ */
+
+import { createRequire } from 'module'
+import { createHash, randomBytes, pbkdf2Sync } from 'node:crypto'
+import { readdirSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const require = createRequire(import.meta.url)
+const Database = require('better-sqlite3')
+
+// ── Locate SQLite file ──────────────────────────────────────────────────────
+
+const scriptDir = new URL('.', import.meta.url).pathname
+const appDir = join(scriptDir, '..')
+const d1Dir = join(appDir, '.wrangler/state/v3/d1/miniflare-D1DatabaseObject')
+
+let dbPath = process.argv[2]
+
+if (!dbPath) {
+  if (!existsSync(d1Dir)) {
+    console.error('❌ No .wrangler/state/v3/d1 directory found.')
+    console.error('   Run migrations first: echo "y" | npx wrangler d1 migrations apply <db-name> --local')
+    process.exit(1)
+  }
+  const files = readdirSync(d1Dir).filter(f => f.endsWith('.sqlite'))
+  if (files.length === 0) {
+    console.error('❌ No SQLite file found in', d1Dir)
+    process.exit(1)
+  }
+  dbPath = join(d1Dir, files[0])
+}
+
+console.log('📂 Using SQLite:', dbPath)
+
+const db = new Database(dbPath)
+
+// ── Password hashing (PBKDF2, matches seed-admin.ts) ───────────────────────
+
+function hashPassword(password) {
+  const iterations = 100000
+  const salt = randomBytes(16)
+  const hash = pbkdf2Sync(password, salt, iterations, 32, 'sha256')
+  return `pbkdf2:${iterations}:${salt.toString('hex')}:${hash.toString('hex')}`
+}
+
+// ── Admin user ──────────────────────────────────────────────────────────────
+
+const EMAIL = 'admin@sonicjs.com'
+const PASSWORD = 'sonicjs!'
+
+const existing = db.prepare('SELECT id FROM auth_user WHERE email = ?').get(EMAIL)
+
+if (existing) {
+  console.log('✓ Admin user already exists')
+} else {
+  const now = Math.floor(Date.now() / 1000)
+  const userId = `admin-${Date.now()}-${randomBytes(4).toString('hex')}`
+  const passwordHash = hashPassword(PASSWORD)
+
+  db.prepare(`
+    INSERT INTO auth_user (id, email, first_name, last_name, role, is_active, created_at, updated_at, name, email_verified)
+    VALUES (?, ?, 'Admin', 'User', 'admin', 1, ?, ?, 'Admin User', 1)
+  `).run(userId, EMAIL, now, now)
+
+  db.prepare(`
+    INSERT INTO auth_account (id, user_id, account_id, provider_id, password, created_at, updated_at)
+    VALUES (?, ?, ?, 'credential', ?, ?, ?)
+  `).run(randomBytes(16).toString('hex'), userId, userId, passwordHash, now, now)
+
+  console.log('✓ Admin user created')
+  console.log('  Email:', EMAIL)
+  console.log('  Password:', PASSWORD)
+  console.log('  Role: admin')
+}
+
+db.close()
+console.log('✓ Seed complete')

--- a/packages/stats/scripts/setup-local.sh
+++ b/packages/stats/scripts/setup-local.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+# Generate .dev.vars with BETTER_AUTH_SECRET if missing
+if [ ! -f .dev.vars ]; then
+  SECRET=$(openssl rand -hex 32 2>/dev/null || node -e "console.log(require('crypto').randomBytes(32).toString('hex'))")
+  echo "BETTER_AUTH_SECRET=\"${SECRET}\"" > .dev.vars
+  echo "✓ Created .dev.vars"
+elif ! grep -q '^BETTER_AUTH_SECRET=' .dev.vars; then
+  SECRET=$(openssl rand -hex 32 2>/dev/null || node -e "console.log(require('crypto').randomBytes(32).toString('hex'))")
+  echo "BETTER_AUTH_SECRET=\"${SECRET}\"" >> .dev.vars
+  echo "✓ Appended BETTER_AUTH_SECRET to .dev.vars"
+fi
+
+echo "Resetting local D1..."
+rm -rf .wrangler/state/v3/d1
+
+echo "Applying migrations..."
+echo "y" | npx wrangler d1 migrations apply DB --local
+
+echo "Seeding admin user..."
+node scripts/seed-local.mjs
+
+echo ""
+echo "=========================================="
+echo "Stats DB ready!"
+echo "Admin: admin@sonicjs.com / sonicjs!"
+echo "Run: npx wrangler dev"
+echo "=========================================="

--- a/packages/stats/src/index.ts
+++ b/packages/stats/src/index.ts
@@ -28,7 +28,6 @@ const config: SonicJSConfig = {
   },
   plugins: {
     autoLoad: false,
-    disableAll: true,  // Disable core plugins — stats-only worker
     register: [statsDashboardPlugin],
   }
 }

--- a/packages/stats/src/index.ts
+++ b/packages/stats/src/index.ts
@@ -12,6 +12,9 @@ import type { SonicJSConfig } from '@sonicjs-cms/core'
 import installsCollection from './collections/installs.collection'
 import eventsCollection from './collections/events.collection'
 
+// Import plugins
+import { statsDashboardPlugin } from './plugins/stats-dashboard'
+
 // Register collections
 registerCollections([
   installsCollection,
@@ -25,7 +28,8 @@ const config: SonicJSConfig = {
   },
   plugins: {
     autoLoad: false,
-    disableAll: true  // No plugins needed for stats collector
+    disableAll: true,  // Disable core plugins — stats-only worker
+    register: [statsDashboardPlugin],
   }
 }
 

--- a/packages/stats/src/plugins/stats-dashboard/index.ts
+++ b/packages/stats/src/plugins/stats-dashboard/index.ts
@@ -1,0 +1,25 @@
+import { definePlugin } from '@sonicjs-cms/core'
+import { statsDashboardAdminRoutes } from './routes/admin'
+
+export const statsDashboardPlugin = definePlugin({
+  id: 'stats-dashboard',
+  version: '1.0.0',
+  name: 'Stats Dashboard',
+  description: 'Weekly installation funnel dashboard for stats.sonicjs.com.',
+  sonicjsVersionRange: '^3.0.0',
+  author: { name: 'SonicJS Team', email: 'team@sonicjs.com' },
+
+  register(app) {
+    app.route('/admin/dashboard', statsDashboardAdminRoutes as any)
+  },
+
+  menu: [
+    {
+      label: 'Dashboard',
+      path: '/admin/dashboard',
+      icon: 'chart',
+      order: 0,
+      permissions: ['admin'],
+    },
+  ],
+})

--- a/packages/stats/src/plugins/stats-dashboard/index.ts
+++ b/packages/stats/src/plugins/stats-dashboard/index.ts
@@ -1,6 +1,8 @@
 import { definePlugin } from '@sonicjs-cms/core'
 import { statsDashboardAdminRoutes } from './routes/admin'
 
+const DASHBOARD_ICON = '<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"/></svg>'
+
 export const statsDashboardPlugin = definePlugin({
   id: 'stats-dashboard',
   version: '1.0.0',
@@ -10,6 +12,21 @@ export const statsDashboardPlugin = definePlugin({
   author: { name: 'SonicJS Team', email: 'team@sonicjs.com' },
 
   register(app) {
+    // Inject Dashboard into sidebar menu for all admin pages.
+    // pluginMenuMiddleware only reads from the compiled manifest registry,
+    // so dynamically-registered plugins must self-inject via context.
+    // This middleware runs inside pluginMenuMiddleware's next(), so the
+    // context var is already initialised when we prepend our item.
+    app.use('/admin/*', async (c, next) => {
+      const existing = (c.get('pluginMenuItems') ?? []) as Array<{ label: string; path: string; icon: string }>
+      if (!existing.some((m) => m.path === '/admin/dashboard')) {
+        c.set('pluginMenuItems', [
+          { label: 'Dashboard', path: '/admin/dashboard', icon: DASHBOARD_ICON },
+          ...existing,
+        ] as any)
+      }
+      return next()
+    })
     app.route('/admin/dashboard', statsDashboardAdminRoutes as any)
   },
 
@@ -17,7 +34,7 @@ export const statsDashboardPlugin = definePlugin({
     {
       label: 'Dashboard',
       path: '/admin/dashboard',
-      icon: 'chart',
+      icon: 'chart-bar',
       order: 0,
       permissions: ['admin'],
     },

--- a/packages/stats/src/plugins/stats-dashboard/routes/admin.ts
+++ b/packages/stats/src/plugins/stats-dashboard/routes/admin.ts
@@ -1,0 +1,194 @@
+import { Hono } from 'hono'
+import { requireAuth } from '@sonicjs-cms/core'
+import { renderAdminLayoutCatalyst } from '@sonicjs-cms/core'
+import type { Bindings, Variables } from '@sonicjs-cms/core'
+
+const adminRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>()
+
+adminRoutes.use('*', requireAuth())
+adminRoutes.use('*', async (c, next) => {
+  const user = c.get('user')
+  if (user?.role !== 'admin') return c.text('Access denied', 403)
+  return next()
+})
+
+interface WeekRow {
+  week: string
+  event_type: string
+  count: number
+}
+
+interface TotalsRow {
+  total_events: number
+  unique_installs: number
+}
+
+adminRoutes.get('/', async (c) => {
+  const db = c.env.DB
+  const user = c.get('user')
+
+  // Last 13 weeks of weekly counts grouped by event_type
+  const [weeklyResult, totalsResult] = await Promise.all([
+    db
+      .prepare(
+        `SELECT
+           strftime('%Y-%W', datetime(created_at, 'unixepoch')) AS week,
+           json_extract(data, '$.event_type') AS event_type,
+           COUNT(*) AS count
+         FROM documents
+         WHERE type_id = 'events'
+           AND tenant_id = 'default'
+           AND is_published = 1
+           AND deleted_at IS NULL
+         GROUP BY week, event_type
+         ORDER BY week DESC
+         LIMIT 78`
+      )
+      .all(),
+    db
+      .prepare(
+        `SELECT
+           COUNT(*) AS total_events,
+           COUNT(DISTINCT json_extract(data, '$.installation_id')) AS unique_installs
+         FROM documents
+         WHERE type_id = 'events'
+           AND tenant_id = 'default'
+           AND is_published = 1
+           AND deleted_at IS NULL`
+      )
+      .first() as Promise<TotalsRow | null>,
+  ])
+
+  const rows = (weeklyResult.results ?? []) as unknown as WeekRow[]
+  const totals = totalsResult ?? { total_events: 0, unique_installs: 0 }
+
+  // Build sorted list of unique weeks (ascending)
+  const weekSet = new Set(rows.map((r) => r.week))
+  const weeks = Array.from(weekSet).sort()
+
+  // Index by week → event_type → count
+  const byWeek = new Map<string, Map<string, number>>()
+  for (const row of rows) {
+    if (!byWeek.has(row.week)) byWeek.set(row.week, new Map())
+    byWeek.get(row.week)!.set(row.event_type, row.count)
+  }
+
+  // Compute overall completion rate
+  let totalStarted = 0
+  let totalCompleted = 0
+  for (const [, types] of byWeek) {
+    totalStarted += types.get('installation_started') ?? 0
+    totalCompleted += types.get('installation_completed') ?? 0
+  }
+  const completionRate = totalStarted > 0 ? Math.round((totalCompleted / totalStarted) * 100) : 0
+
+  // Max value across all weeks for bar scaling
+  const maxWeekStarted = Math.max(1, ...weeks.map((w) => byWeek.get(w)?.get('installation_started') ?? 0))
+
+  const weekRows = weeks
+    .slice()
+    .reverse()
+    .map((week) => {
+      const types = byWeek.get(week) ?? new Map()
+      const started = types.get('installation_started') ?? 0
+      const completed = types.get('installation_completed') ?? 0
+      const failed = types.get('installation_failed') ?? 0
+      const rate = started > 0 ? Math.round((completed / started) * 100) : 0
+      const barPct = Math.round((started / maxWeekStarted) * 100)
+      return { week, started, completed, failed, rate, barPct }
+    })
+
+  const content = `
+<div class="space-y-8">
+  <div>
+    <h1 class="text-2xl font-semibold text-zinc-950 dark:text-white">Installation Stats</h1>
+    <p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">Weekly install funnel — started vs completed</p>
+  </div>
+
+  <!-- Summary cards -->
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+    <div class="rounded-lg bg-white dark:bg-zinc-800 p-6 ring-1 ring-zinc-950/5 dark:ring-white/10">
+      <p class="text-sm font-medium text-zinc-500 dark:text-zinc-400">Total Events</p>
+      <p class="mt-2 text-3xl font-semibold text-zinc-950 dark:text-white">${totals.total_events.toLocaleString()}</p>
+    </div>
+    <div class="rounded-lg bg-white dark:bg-zinc-800 p-6 ring-1 ring-zinc-950/5 dark:ring-white/10">
+      <p class="text-sm font-medium text-zinc-500 dark:text-zinc-400">Unique Installations</p>
+      <p class="mt-2 text-3xl font-semibold text-zinc-950 dark:text-white">${totals.unique_installs.toLocaleString()}</p>
+    </div>
+    <div class="rounded-lg bg-white dark:bg-zinc-800 p-6 ring-1 ring-zinc-950/5 dark:ring-white/10">
+      <p class="text-sm font-medium text-zinc-500 dark:text-zinc-400">Overall Completion Rate</p>
+      <p class="mt-2 text-3xl font-semibold ${completionRate >= 50 ? 'text-emerald-600 dark:text-emerald-400' : 'text-amber-600 dark:text-amber-400'}">${completionRate}%</p>
+      <p class="mt-1 text-xs text-zinc-500 dark:text-zinc-400">${totalStarted.toLocaleString()} started → ${totalCompleted.toLocaleString()} completed</p>
+    </div>
+  </div>
+
+  <!-- Weekly table -->
+  <div class="rounded-lg bg-white dark:bg-zinc-800 ring-1 ring-zinc-950/5 dark:ring-white/10">
+    <div class="px-6 py-4 border-b border-zinc-950/5 dark:border-white/10">
+      <h2 class="text-lg font-semibold text-zinc-950 dark:text-white">Weekly Breakdown</h2>
+    </div>
+    ${weekRows.length === 0 ? `
+      <div class="px-6 py-12 text-center text-sm text-zinc-500 dark:text-zinc-400">No event data yet.</div>
+    ` : `
+    <div class="overflow-x-auto">
+      <table class="w-full text-sm">
+        <thead class="bg-zinc-50 dark:bg-zinc-800/50 text-xs uppercase tracking-wide">
+          <tr>
+            <th class="px-6 py-3 text-left font-medium text-zinc-500 dark:text-zinc-400">Week</th>
+            <th class="px-6 py-3 text-right font-medium text-zinc-500 dark:text-zinc-400">Started</th>
+            <th class="px-6 py-3 text-right font-medium text-zinc-500 dark:text-zinc-400">Completed</th>
+            <th class="px-6 py-3 text-right font-medium text-zinc-500 dark:text-zinc-400">Failed</th>
+            <th class="px-6 py-3 text-right font-medium text-zinc-500 dark:text-zinc-400">Completion %</th>
+            <th class="px-6 py-3 text-left font-medium text-zinc-500 dark:text-zinc-400 w-48">Volume</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-zinc-950/5 dark:divide-white/5">
+          ${weekRows
+            .map(
+              (r) => `
+          <tr class="hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
+            <td class="px-6 py-3 font-mono text-zinc-700 dark:text-zinc-300">${r.week}</td>
+            <td class="px-6 py-3 text-right text-zinc-700 dark:text-zinc-300">${r.started.toLocaleString()}</td>
+            <td class="px-6 py-3 text-right text-emerald-600 dark:text-emerald-400 font-medium">${r.completed.toLocaleString()}</td>
+            <td class="px-6 py-3 text-right ${r.failed > 0 ? 'text-red-600 dark:text-red-400' : 'text-zinc-400 dark:text-zinc-600'}">${r.failed.toLocaleString()}</td>
+            <td class="px-6 py-3 text-right">
+              <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium
+                ${r.rate >= 70 ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400' :
+                  r.rate >= 40 ? 'bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400' :
+                  'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400'}">
+                ${r.rate}%
+              </span>
+            </td>
+            <td class="px-6 py-3">
+              <div class="flex items-center gap-2">
+                <div class="flex-1 h-2 rounded-full bg-zinc-100 dark:bg-zinc-700 overflow-hidden">
+                  <div class="h-full rounded-full bg-indigo-500 dark:bg-indigo-400" style="width:${r.barPct}%"></div>
+                </div>
+              </div>
+            </td>
+          </tr>`
+            )
+            .join('')}
+        </tbody>
+      </table>
+    </div>
+    `}
+  </div>
+</div>`
+
+  return c.html(
+    renderAdminLayoutCatalyst({
+      title: 'Dashboard',
+      pageTitle: 'Stats Dashboard',
+      currentPath: '/admin/dashboard',
+      version: c.get('appVersion'),
+      user: user
+        ? { name: user.email.split('@')[0] || 'Admin', email: user.email, role: user.role }
+        : undefined,
+      content,
+      dynamicMenuItems: c.get('pluginMenuItems'),
+    })
+  )
+})
+
+export { adminRoutes as statsDashboardAdminRoutes }

--- a/packages/stats/wrangler.toml
+++ b/packages/stats/wrangler.toml
@@ -24,6 +24,12 @@ ENVIRONMENT = "development"
 name = "sonicjs-stats-production"
 vars = { ENVIRONMENT = "production" }
 
+[[env.production.d1_databases]]
+binding = "DB"
+database_name = "sonicjs-stats-db"
+database_id = "93150491-63c3-4b9a-ac9a-792ba416a240"
+migrations_dir = "./migrations"
+
 # Observability
 [observability]
 enabled = true


### PR DESCRIPTION
## Summary

- Migrates stats app DB to document model (events + installs as `documents`)
- Adds `stats-dashboard` plugin: weekly install funnel at `/admin/dashboard`
- Fixes local dev seed: RBAC documents bootstrapped so `requireRbac('portal','access')` passes on first login
- Removes `disableAll: true` so plugin properly boots, mounts routes, and injects sidebar menu
- Bumps `@sonicjs-cms/core` dep to `"*"` for workspace symlink resolution
- Regenerates manifest-registry with `versioning` + `stats-dashboard` entries

## Test plan

- [ ] `cd packages/stats && npm run setup:db` — local D1 reset + migrations + seed
- [ ] `npm run dev` → login `admin@sonicjs.com` / `sonicjs!` → Dashboard appears in sidebar
- [ ] `/admin/dashboard` shows weekly funnel table (empty until events seeded)
- [ ] Production: `https://stats.sonicjs.com/admin/dashboard` accessible after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)