### PR TITLE
docs: update READMEs to reflect v3 current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,8 +241,7 @@ sonicjs-ai/
 │                          # Used for testing the published package
 │
 ├── www/                   # 🌐 Marketing website
-├── tests/e2e/             # End-to-end test suites
-└── drizzle/               # Database migrations
+└── tests/e2e/             # End-to-end test suites
 ```
 
 ### Important Notes
@@ -256,32 +255,52 @@ sonicjs-ai/
 ## 🔧 Content Management
 
 ### Creating Collections
-SonicJS uses a dynamic field system. Create collections through the admin interface or define them in the database:
 
-```sql
--- Example: Blog Posts collection with custom fields
-INSERT INTO collections (id, name, display_name, description, schema) VALUES (
-  'blog-posts', 'blog_posts', 'Blog Posts', 'Article content collection',
-  '{"type":"object","properties":{"title":{"type":"string","required":true}}}'
-);
+Collections are TypeScript config objects registered at app startup — no database table required.
 
--- Add dynamic fields
-INSERT INTO content_fields (collection_id, field_name, field_type, field_label, field_options) VALUES
-  ('blog-posts', 'title', 'text', 'Title', '{"maxLength": 200, "required": true}'),
-  ('blog-posts', 'content', 'richtext', 'Content', '{"toolbar": "full", "height": 400}'),
-  ('blog-posts', 'excerpt', 'text', 'Excerpt', '{"maxLength": 500, "rows": 3}'),
-  ('blog-posts', 'featured_image', 'media', 'Featured Image', '{"accept": "image/*"}'),
-  ('blog-posts', 'publish_date', 'date', 'Publish Date', '{"defaultToday": true}'),
-  ('blog-posts', 'is_featured', 'boolean', 'Featured Post', '{"default": false}');
+```typescript
+// src/collections/blog-posts.collection.ts
+import type { CollectionConfig } from '@sonicjs-cms/core'
+
+export default {
+  name: 'blog_post',
+  displayName: 'Blog Post',
+  slug: 'blog-posts',
+  description: 'Article content collection',
+
+  schema: {
+    type: 'object',
+    properties: {
+      title: { type: 'string', title: 'Title', required: true, maxLength: 200 },
+      content: { type: 'lexical', title: 'Content', required: true },
+      publishedAt: { type: 'datetime', title: 'Published Date' },
+    },
+    required: ['title', 'content'],
+  },
+
+  managed: true,
+  isActive: true,
+} satisfies CollectionConfig
+```
+
+```typescript
+// src/index.ts — register before createSonicJSApp
+import { registerCollections, createSonicJSApp } from '@sonicjs-cms/core'
+import blogPostsCollection from './collections/blog-posts.collection'
+
+registerCollections([blogPostsCollection])
+export default createSonicJSApp({ plugins: { register: [] } })
 ```
 
 ### Field Types
-- **text**: Single-line text with validation
-- **richtext**: WYSIWYG editor with TinyMCE
+- **string**: Single-line text with validation
+- **lexical**: Rich text editor
 - **number**: Numeric input with min/max constraints
 - **boolean**: Checkbox with custom labels
-- **date**: Date picker with format options
+- **datetime**: Date/time picker
 - **select**: Dropdown with single/multi-select
+- **slug**: URL slug with auto-generation
+- **user**: User reference picker
 - **media**: File picker with preview
 
 ## 🌐 API Endpoints
@@ -373,17 +392,21 @@ Create plugins for extending SonicJS functionality:
 
 ```typescript
 // src/plugins/my-plugin/index.ts
-import { Plugin } from '@sonicjs-cms/core'
+import type { Plugin, PluginContext } from '@sonicjs-cms/core'
 
 export default {
   name: 'my-plugin',
-  hooks: {
-    'content:beforeCreate': async (content) => {
-      // Plugin logic here
-      return content
-    }
-  }
-} as Plugin
+  version: '1.0.0',
+  description: 'My custom plugin',
+
+  async activate(context: PluginContext) {
+    // Runs when the plugin is activated
+  },
+
+  async install(context: PluginContext) {
+    // Runs once on install — migrations, seed data, etc.
+  },
+} satisfies Plugin
 ```
 
 ## 📄 License
@@ -411,9 +434,9 @@ SonicJS is 100% open source and free forever. If you find it useful, please cons
 
 ## 📞 Support
 
-- [GitHub Issues](https://github.com/lane711/sonicjs-ai/issues)
+- [GitHub Issues](https://github.com/lane711/sonicjs/issues)
 - [Documentation](docs/)
-- [Community Discussions](https://github.com/lane711/sonicjs-ai/discussions)
+- [Community Discussions](https://github.com/lane711/sonicjs/discussions)
 
 ---
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -14,7 +14,7 @@
 To create a new SonicJS project, use:
 
 ```bash
-npx create-sonicjs my-app
+npx create-sonicjs@latest my-app
 ```
 
 This is the recommended way to get started with SonicJS. It sets up everything you need with a single command.
@@ -28,9 +28,9 @@ This is the recommended way to get started with SonicJS. It sets up everything y
 - 🔒 **Type-Safe**: Full TypeScript support with comprehensive type definitions
 - 🔌 **Plugin System**: Extensible architecture with hooks and middleware
 - ⚡ **Three-Tier Caching**: Memory, KV, and database layers for optimal performance
-- 🎨 **Admin Interface**: Beautiful glass morphism design system
-- 🔐 **Authentication**: JWT-based auth with role-based permissions
-- 📝 **Content Management**: Dynamic collections with versioning and workflows
+- 🎨 **Admin Interface**: Glass-morphism design system
+- 🔐 **Authentication**: Better Auth with session management and role-based permissions
+- 📝 **Content Management**: Document-model collections with versioning
 - 🖼️ **Media Management**: R2 storage with automatic optimization
 - 🌐 **REST API**: Auto-generated endpoints for all collections
 
@@ -54,22 +54,24 @@ npm install wrangler drizzle-kit  # For development
 
 ## 🚀 Quick Start
 
-### 1. Create Your Application
+### 1. Register Collections and Create Your Application
 
 ```typescript
 // src/index.ts
-import { createSonicJSApp } from '@sonicjs-cms/core'
+import {
+  createSonicJSApp,
+  registerCollections,
+} from '@sonicjs-cms/core'
 import type { SonicJSConfig } from '@sonicjs-cms/core'
+import blogPostsCollection from './collections/blog-posts.collection'
+
+// Register code-defined collections before creating the app
+registerCollections([blogPostsCollection])
 
 const config: SonicJSConfig = {
-  collections: {
-    directory: './src/collections',
-    autoSync: true
-  },
   plugins: {
-    directory: './src/plugins',
-    autoLoad: false
-  }
+    register: [/* your plugins here */],
+  },
 }
 
 export default createSonicJSApp(config)
@@ -77,13 +79,16 @@ export default createSonicJSApp(config)
 
 ### 2. Define Collections
 
+Collections are TypeScript config objects — no database table required.
+
 ```typescript
 // src/collections/blog-posts.collection.ts
 import type { CollectionConfig } from '@sonicjs-cms/core'
 
 export default {
-  name: 'blog-posts',
-  displayName: 'Blog Posts',
+  name: 'blog_post',
+  displayName: 'Blog Post',
+  slug: 'blog-posts',
   description: 'Manage your blog posts',
 
   schema: {
@@ -93,26 +98,23 @@ export default {
         type: 'string',
         title: 'Title',
         required: true,
-        maxLength: 200
+        maxLength: 200,
       },
       content: {
-        type: 'markdown',
+        type: 'lexical',
         title: 'Content',
-        required: true
+        required: true,
       },
       publishedAt: {
         type: 'datetime',
-        title: 'Published Date'
+        title: 'Published Date',
       },
-      status: {
-        type: 'select',
-        title: 'Status',
-        enum: ['draft', 'published', 'archived'],
-        default: 'draft'
-      }
     },
-    required: ['title', 'content']
-  }
+    required: ['title', 'content'],
+  },
+
+  managed: true,
+  isActive: true,
 } satisfies CollectionConfig
 ```
 
@@ -131,7 +133,7 @@ database_id = "your-database-id"
 migrations_dir = "./node_modules/@sonicjs-cms/core/migrations"
 
 [[r2_buckets]]
-binding = "BUCKET"
+binding = "MEDIA_BUCKET"
 bucket_name = "my-sonicjs-media"
 ```
 
@@ -152,7 +154,7 @@ Visit `http://localhost:8787/admin` to access the admin interface.
 ### Main Application
 
 ```typescript
-import { createSonicJSApp } from '@sonicjs-cms/core'
+import { createSonicJSApp, registerCollections } from '@sonicjs-cms/core'
 import type { SonicJSConfig, SonicJSApp, Bindings, Variables } from '@sonicjs-cms/core'
 ```
 
@@ -161,7 +163,6 @@ import type { SonicJSConfig, SonicJSApp, Bindings, Variables } from '@sonicjs-cm
 ```typescript
 import {
   loadCollectionConfigs,
-  syncCollections,
   MigrationService,
   Logger,
   PluginService
@@ -223,8 +224,8 @@ import {
 import {
   createDb,
   users,
-  collections,
   content,
+  contentVersions,
   media
 } from '@sonicjs-cms/core'
 ```
@@ -272,31 +273,29 @@ customRoutes.get('/api/custom', requireAuth(), async (c) => {
 
 // In your app config
 export default createSonicJSApp({
-  routes: [{ path: '/custom', handler: customRoutes }]
+  plugins: {
+    register: [{ name: 'custom', version: '1.0.0', register: (app) => app.route('/custom', customRoutes) }],
+  },
 })
 ```
 
 ### Custom Plugin
 
 ```typescript
-import type { Plugin } from '@sonicjs-cms/core'
+import type { Plugin, PluginContext } from '@sonicjs-cms/core'
 
 export default {
   name: 'my-plugin',
   version: '1.0.0',
   description: 'My custom plugin',
 
-  async onActivate() {
+  async activate(context: PluginContext) {
     console.log('Plugin activated!')
   },
 
-  hooks: {
-    'content.beforeSave': async (content) => {
-      // Transform content before saving
-      content.metadata = { modified: new Date() }
-      return content
-    }
-  }
+  async install(context: PluginContext) {
+    // Run once on install — migrations, seed data, etc.
+  },
 } satisfies Plugin
 ```
 
@@ -409,16 +408,16 @@ The `generate-migrations.ts` script:
 
 SonicJS follows semantic versioning:
 
-- **v2.x.x** - Current npm package (core extracted)
-- **v1.x.x** - Legacy monolith (deprecated)
+- **v3.x.x** - Current (document model, Better Auth, edge-first)
+- **v2.x.x** - Legacy monolith (deprecated)
 
-**Current Version**: `2.0.0-alpha.1`
+**Current Version**: `3.0.0-beta.9`
 
 ### Upgrade Path
 
 ```bash
-# Install the new package
-npm install @sonicjs-cms/core@2.0.0-alpha.1
+# Install the latest package
+npm install @sonicjs-cms/core@latest
 
 # Run any new migrations
 wrangler d1 migrations apply DB
@@ -467,12 +466,12 @@ MIT © SonicJS Team - See [LICENSE](./LICENSE) for details.
 
 ## 🛡️ Security
 
-- JWT authentication
-- Role-based access control (RBAC)
+- Better Auth (sessions + RBAC)
+- Role-based access control
 - Permission system
 - Secure headers
 - Input sanitization
 
 ---
 
-**Built with ❤️ for the edge** | v2.0.0-alpha.1
+**Built with ❤️ for the edge** | v3.0.0-beta.9


### PR DESCRIPTION
## Summary

- Fix version references: `2.0.0-alpha.1` → `3.0.0-beta.9`
- Fix auth description: JWT → Better Auth (sessions + RBAC)
- Replace stale Quick Start config (deprecated `autoSync`/`autoLoad` no-ops) with correct `registerCollections()` + `plugins.register` pattern
- Remove `syncCollections` from exports list (removed) and `collections` from DB exports (table never exists on greenfield)
- Fix plugin example: `onActivate` → `activate(context: PluginContext)` to match actual `Plugin` interface
- Root README: replace raw `INSERT INTO collections` SQL block (dead) with TypeScript `CollectionConfig` + `registerCollections()` pattern
- Root README: fix plugin hooks example to use correct `Plugin` interface (`activate`/`install` lifecycle hooks)
- Root README: remove `drizzle/` from project structure (directory does not exist)
- Root README: fix GitHub links (`sonicjs-ai` → `sonicjs`)

## Test plan

- [ ] README-only change — no code modified, no E2E tests required
- [ ] Verify npm README renders correctly after next publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)