### PR TITLE
fix(auth): return JWT token from POST /auth/login

### DIFF
--- a/packages/core/src/routes/auth.ts
+++ b/packages/core/src/routes/auth.ts
@@ -301,6 +301,23 @@ authRoutes.post('/login',
       const baBody = await baRes.json() as any
       const user = baBody.user ?? {}
 
+      // Mint a JWT so API callers can use Bearer token auth (same as /register)
+      const tokenTtl = await getJwtExpirySecondsFromDb(c.env.DB, c.env)
+      const token = await AuthManager.generateToken(
+        user.id,
+        user.email,
+        user.role ?? 'viewer',
+        c.env.JWT_SECRET,
+        tokenTtl
+      )
+
+      setCookie(c, 'auth_token', token, {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'Strict',
+        maxAge: tokenTtl,
+      })
+
       return c.json({
         user: {
           id: user.id,
@@ -308,7 +325,8 @@ authRoutes.post('/login',
           firstName: user.name?.split(' ')[0] ?? '',
           lastName: user.name?.split(' ').slice(1).join(' ') ?? '',
           role: user.role ?? 'viewer',
-        }
+        },
+        token,
       })
     } catch (error) {
       console.error('Login error:', error)

--- a/tests/e2e/83-login-returns-token.spec.ts
+++ b/tests/e2e/83-login-returns-token.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('POST /auth/login returns token', () => {
+  test.beforeAll(async ({ request }) => {
+    await request.post('/auth/seed-admin')
+  })
+
+  test('login response includes token field', async ({ request }) => {
+    const res = await request.post('/auth/login', {
+      data: { email: 'admin@sonicjs.com', password: 'sonicjs!' },
+    })
+    expect(res.ok()).toBe(true)
+    const body = await res.json()
+    expect(body.user).toBeTruthy()
+    expect(typeof body.token).toBe('string')
+    expect(body.token.length).toBeGreaterThan(0)
+  })
+
+  test('returned token works for Bearer auth on /auth/me', async ({ request }) => {
+    const loginRes = await request.post('/auth/login', {
+      data: { email: 'admin@sonicjs.com', password: 'sonicjs!' },
+    })
+    const { token } = await loginRes.json()
+
+    const meRes = await request.get('/auth/me', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(meRes.ok()).toBe(true)
+    const body = await meRes.json()
+    expect(body.user?.email).toBe('admin@sonicjs.com')
+  })
+
+  test('auth_token cookie set on login', async ({ request }) => {
+    const res = await request.post('/auth/login', {
+      data: { email: 'admin@sonicjs.com', password: 'sonicjs!' },
+    })
+    expect(res.ok()).toBe(true)
+    // Verify the response body includes the token (primary signal)
+    const body = await res.json()
+    expect(typeof body.token).toBe('string')
+    // Cookie header may contain multiple cookies joined by \n
+    const headers = res.headers()
+    const cookies = (headers['set-cookie'] ?? '').split('\n').join('; ')
+    expect(cookies).toContain('auth_token')
+  })
+})


### PR DESCRIPTION
## Summary

- `POST /auth/login` delegated to Better Auth for session cookies but never minted a JWT — API callers got `{ user }` with no `token` field
- `POST /auth/register` already returned `{ user, token }`; login now matches
- After successful BA sign-in, generates JWT via `AuthManager.generateToken`, returns it in response body + sets `auth_token` cookie

## Test plan

- [x] `POST /auth/login` response includes `token` field (JWT string)
- [x] Returned token works for `Authorization: Bearer <token>` on `/auth/me`
- [x] `auth_token` cookie set in response headers
- [x] All 3 E2E tests pass (`tests/e2e/83-login-returns-token.spec.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)