### PR TITLE
feat(admin): interactive JSON viewer for json-type fields

### DIFF
--- a/my-sonicjs-app/src/collections/e2e-test.collection.ts
+++ b/my-sonicjs-app/src/collections/e2e-test.collection.ts
@@ -65,6 +65,11 @@ export default {
         enumLabels: ["List", "Grid", "Card"],
         default: "list",
       },
+      metadata: {
+        type: "json",
+        title: "Metadata",
+        helpText: "JSON object for arbitrary structured data",
+      },
       richContent: {
         type: "lexical",
         title: "Rich Content",

--- a/packages/core/src/templates/components/dynamic-field.template.ts
+++ b/packages/core/src/templates/components/dynamic-field.template.ts
@@ -1060,6 +1060,85 @@ export function renderDynamicField(field: FieldDefinition, options: FieldRenderO
       break
     }
 
+    case 'json': {
+      const jsonParsedValue =
+        value !== null && value !== undefined && typeof value !== 'string'
+          ? value
+          : typeof value === 'string' && value !== ''
+            ? (() => { try { return JSON.parse(value) } catch { return value } })()
+            : null
+      const jsonDisplayValue =
+        jsonParsedValue !== null && typeof jsonParsedValue !== 'string'
+          ? JSON.stringify(jsonParsedValue, null, 2)
+          : typeof jsonParsedValue === 'string'
+            ? jsonParsedValue
+            : ''
+      const viewerId = `${fieldId}-viewer`
+      const textareaId = `${fieldId}-textarea`
+      const jsonDataAttr = escapeHtml(JSON.stringify(jsonParsedValue ?? null))
+      const isEmpty = jsonParsedValue === null || jsonDisplayValue === ''
+
+      if (disabled) {
+        fieldHTML = `
+          <div
+            id="${viewerId}"
+            class="json-viewer-host rounded-lg px-3 py-2 text-xs bg-white dark:bg-zinc-800 shadow-sm ring-1 ring-inset ring-zinc-950/10 dark:ring-white/10 min-h-[2.5rem] overflow-auto"
+            data-json-viewer
+            data-json="${jsonDataAttr}"
+            data-open="${opts.open ?? 2}"
+          >${isEmpty ? '<span class="text-zinc-400 dark:text-zinc-500 italic">empty</span>' : ''}</div>
+          ${getJsonViewerScript()}
+        `
+      } else {
+        fieldHTML = `
+          <div class="json-field-wrapper space-y-2">
+            <div class="flex items-center justify-end">
+              <button
+                type="button"
+                id="${fieldId}-toggle"
+                class="text-xs text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 underline transition-colors"
+                data-json-toggle
+                data-viewer="${viewerId}"
+                data-textarea="${textareaId}"
+                data-hidden-input="${fieldId}"
+              >Edit JSON</button>
+            </div>
+
+            <div
+              id="${viewerId}"
+              class="json-viewer-host rounded-lg px-3 py-2 text-xs bg-white dark:bg-zinc-800 shadow-sm ring-1 ring-inset ring-zinc-950/10 dark:ring-white/10 min-h-[2.5rem] overflow-auto"
+              data-json-viewer
+              data-json="${jsonDataAttr}"
+              data-open="${opts.open ?? 2}"
+            >${isEmpty ? '<span class="text-zinc-400 dark:text-zinc-500 italic">empty — click &quot;Edit JSON&quot; to add data</span>' : ''}</div>
+
+            <textarea
+              id="${textareaId}"
+              rows="${opts.rows || 8}"
+              placeholder="${opts.placeholder || '{}'}"
+              class="${baseClasses} ${errorClasses} resize-y font-mono text-xs hidden"
+              aria-label="${escapeHtml(field.field_label)}"
+              data-json-edit-area
+              data-viewer="${viewerId}"
+              data-hidden-input="${fieldId}"
+            >${escapeHtml(jsonDisplayValue)}</textarea>
+
+            <input
+              type="hidden"
+              id="${fieldId}"
+              name="${fieldName}"
+              value="${escapeHtml(jsonDisplayValue)}"
+              ${required}
+            >
+
+            <div id="${fieldId}-json-error" class="text-xs text-pink-500 dark:text-pink-400 hidden"></div>
+          </div>
+          ${getJsonViewerScript()}
+        `
+      }
+      break
+    }
+
     default:
       fieldHTML = `
         <input
@@ -1733,6 +1812,121 @@ function normalizeBlockField(fieldConfig: any, fieldName: string) {
     defaultValue: fieldConfig?.default,
     options,
   }
+}
+
+function getJsonViewerScript(): string {
+  return `
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/json-formatter-js@2.5.23/dist/json-formatter.min.css" id="json-formatter-css" onload="this.removeAttribute('onload')" onerror="">
+    <script>
+      (function() {
+        var JS_URL = 'https://cdn.jsdelivr.net/npm/json-formatter-js@2.5.23/dist/json-formatter.umd.min.js';
+
+        function isDark() {
+          return document.documentElement.classList.contains('dark') ||
+                 document.documentElement.dataset.theme === 'dark' ||
+                 window.matchMedia('(prefers-color-scheme: dark)').matches;
+        }
+
+        function initViewer(el) {
+          var raw = el.dataset.json;
+          var open = parseInt(el.dataset.open || '2', 10);
+          if (!raw || raw === 'null') return;
+          var data;
+          try { data = JSON.parse(raw); } catch(e) { el.textContent = raw; return; }
+          var fmt = new JSONFormatter(data, open, {
+            hoverPreviewEnabled: true,
+            hoverPreviewArrayCount: 5,
+            hoverPreviewFieldCount: 5,
+            theme: isDark() ? 'dark' : '',
+            animateOpen: true,
+            animateClose: true,
+          });
+          el.innerHTML = '';
+          el.appendChild(fmt.render());
+        }
+
+        function initAllViewers() {
+          document.querySelectorAll('[data-json-viewer]').forEach(function(el) { initViewer(el); });
+        }
+
+        function ensureLoaded(cb) {
+          if (window.JSONFormatter) { cb(); return; }
+          if (window.__jsonFormatterCallbacks) { window.__jsonFormatterCallbacks.push(cb); return; }
+          window.__jsonFormatterCallbacks = [cb];
+          var s = document.createElement('script');
+          s.src = JS_URL;
+          s.onload = function() {
+            (window.__jsonFormatterCallbacks || []).forEach(function(fn) { fn(); });
+            window.__jsonFormatterCallbacks = null;
+          };
+          document.head.appendChild(s);
+        }
+
+        if (!window.__sonicJsonViewerInit) {
+          window.__sonicJsonViewerInit = true;
+
+          // Toggle between viewer and edit textarea
+          document.addEventListener('click', function(e) {
+            var btn = e.target.closest('[data-json-toggle]');
+            if (!btn) return;
+            var viewerId = btn.dataset.viewer;
+            var textareaId = btn.dataset.textarea;
+            var hiddenId = btn.dataset.hiddenInput;
+            var viewer = document.getElementById(viewerId);
+            var textarea = document.getElementById(textareaId);
+            var hidden = document.getElementById(hiddenId);
+            var errorEl = hidden ? document.getElementById(hiddenId + '-json-error') : null;
+            if (!viewer || !textarea) return;
+            var isEditing = !textarea.classList.contains('hidden');
+            if (isEditing) {
+              // Switching back to viewer — validate + refresh
+              var raw = textarea.value.trim();
+              if (raw) {
+                try {
+                  var parsed = JSON.parse(raw);
+                  if (hidden) hidden.value = raw;
+                  viewer.dataset.json = JSON.stringify(parsed);
+                  ensureLoaded(function() { initViewer(viewer); });
+                  if (errorEl) { errorEl.textContent = ''; errorEl.classList.add('hidden'); }
+                } catch(ex) {
+                  if (errorEl) { errorEl.textContent = 'Invalid JSON: ' + ex.message; errorEl.classList.remove('hidden'); }
+                  return;
+                }
+              } else {
+                if (hidden) hidden.value = '';
+                viewer.innerHTML = '<span class="text-zinc-400 dark:text-zinc-500 italic">empty</span>';
+              }
+              textarea.classList.add('hidden');
+              viewer.classList.remove('hidden');
+              btn.textContent = 'Edit JSON';
+            } else {
+              // Switching to edit — populate textarea from hidden input
+              if (hidden && hidden.value) {
+                try {
+                  textarea.value = JSON.stringify(JSON.parse(hidden.value), null, 2);
+                } catch(e) {
+                  textarea.value = hidden.value;
+                }
+              }
+              viewer.classList.add('hidden');
+              textarea.classList.remove('hidden');
+              btn.textContent = 'Preview';
+            }
+          });
+        }
+
+        function run() {
+          ensureLoaded(initAllViewers);
+        }
+
+        if (document.readyState === 'loading') {
+          document.addEventListener('DOMContentLoaded', run);
+        } else {
+          run();
+        }
+      })();
+    <\/script>
+  `
 }
 
 function getStructuredFieldScript(): string {

--- a/tests/e2e/83-json-field-viewer.spec.ts
+++ b/tests/e2e/83-json-field-viewer.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect } from '@playwright/test'
+import { loginAsAdmin, TEST_ORIGIN } from './utils/test-helpers'
+
+const COLLECTION = 'e2e_test'
+const SAMPLE_JSON = { version: 1, tags: ['a', 'b'], nested: { active: true } }
+
+test.describe('JSON field viewer', () => {
+  let contentId: string
+
+  test.beforeAll(async ({ browser }) => {
+    const ctx = await browser.newContext({ baseURL: TEST_ORIGIN })
+    const page = await ctx.newPage()
+    await page.goto(TEST_ORIGIN)
+    await loginAsAdmin(page)
+
+    const slug = `json-viewer-test-${Date.now()}`
+    const res = await page.request.post(`${TEST_ORIGIN}/api/content`, {
+      data: {
+        collectionId: COLLECTION,
+        title: 'JSON Viewer Test',
+        slug,
+        data: { metadata: SAMPLE_JSON },
+      },
+    })
+    const body = await res.json()
+    contentId = body.data?.id || body.id
+    expect(contentId).toBeTruthy()
+    await ctx.close()
+  })
+
+  test.afterAll(async ({ browser }) => {
+    if (!contentId) return
+    const ctx = await browser.newContext({ baseURL: TEST_ORIGIN })
+    const page = await ctx.newPage()
+    await page.goto(TEST_ORIGIN)
+    await loginAsAdmin(page)
+    await page.request.delete(`${TEST_ORIGIN}/api/content/${contentId}`)
+    await ctx.close()
+  })
+
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page)
+  })
+
+  test('edit form shows JSON viewer, not [object Object]', async ({ page }) => {
+    await page.goto(`${TEST_ORIGIN}/admin/content/${contentId}/edit`)
+    await page.waitForLoadState('domcontentloaded')
+
+    // Must not render [object Object]
+    const bodyText = await page.textContent('body')
+    expect(bodyText).not.toContain('[object Object]')
+
+    // JSON viewer host must exist
+    const viewer = page.locator('[data-json-viewer]').first()
+    await expect(viewer).toBeVisible()
+
+    // Toggle button must exist
+    const toggleBtn = page.locator('[data-json-toggle]').first()
+    await expect(toggleBtn).toBeVisible()
+    await expect(toggleBtn).toHaveText('Edit JSON')
+  })
+
+  test('toggle switches to textarea and back to viewer', async ({ page }) => {
+    await page.goto(`${TEST_ORIGIN}/admin/content/${contentId}/edit`)
+    await page.waitForLoadState('domcontentloaded')
+
+    const toggleBtn = page.locator('[data-json-toggle]').first()
+    await expect(toggleBtn).toBeVisible()
+
+    // Switch to edit mode
+    await toggleBtn.click()
+    await expect(toggleBtn).toHaveText('Preview')
+
+    const textarea = page.locator('[data-json-edit-area]').first()
+    await expect(textarea).toBeVisible()
+
+    // Textarea must contain valid JSON with our sample data
+    const raw = await textarea.inputValue()
+    expect(() => JSON.parse(raw)).not.toThrow()
+    const parsed = JSON.parse(raw)
+    expect(parsed.version).toBe(1)
+    expect(parsed.tags).toEqual(['a', 'b'])
+
+    // Switch back to viewer
+    await toggleBtn.click()
+    await expect(toggleBtn).toHaveText('Edit JSON')
+    await expect(textarea).toBeHidden()
+    await expect(page.locator('[data-json-viewer]').first()).toBeVisible()
+  })
+
+  test('invalid JSON shows inline error and blocks switch back to viewer', async ({ page }) => {
+    await page.goto(`${TEST_ORIGIN}/admin/content/${contentId}/edit`)
+    await page.waitForLoadState('domcontentloaded')
+
+    const toggleBtn = page.locator('[data-json-toggle]').first()
+    await toggleBtn.click()
+    await expect(toggleBtn).toHaveText('Preview')
+
+    const textarea = page.locator('[data-json-edit-area]').first()
+    await textarea.fill('{ invalid json }')
+
+    // Try switching back — should be blocked
+    await toggleBtn.click()
+
+    const errorEl = page.locator('[id$="-json-error"]').first()
+    await expect(errorEl).toBeVisible()
+    await expect(errorEl).toContainText('Invalid JSON')
+
+    // Textarea still visible (not switched back)
+    await expect(textarea).toBeVisible()
+  })
+
+  test('edited JSON saves correctly on form submit', async ({ page }) => {
+    await page.goto(`${TEST_ORIGIN}/admin/content/${contentId}/edit`)
+    await page.waitForLoadState('domcontentloaded')
+
+    const toggleBtn = page.locator('[data-json-toggle]').first()
+    await toggleBtn.click()
+    await expect(toggleBtn).toHaveText('Preview')
+
+    const textarea = page.locator('[data-json-edit-area]').first()
+    const newJson = JSON.stringify({ version: 2, updated: true }, null, 2)
+    await textarea.fill(newJson)
+
+    // Switch to preview (validates + updates hidden input)
+    await toggleBtn.click()
+    await expect(toggleBtn).toHaveText('Edit JSON')
+
+    // Submit the form
+    await page.getByRole('button', { name: /update/i }).click()
+    await page.waitForLoadState('networkidle')
+
+    // Re-open and verify persisted
+    await page.goto(`${TEST_ORIGIN}/admin/content/${contentId}/edit`)
+    await page.waitForLoadState('domcontentloaded')
+
+    await page.locator('[data-json-toggle]').first().click()
+    const savedRaw = await page.locator('[data-json-edit-area]').first().inputValue()
+    const saved = JSON.parse(savedRaw)
+    expect(saved.version).toBe(2)
+    expect(saved.updated).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- JSON fields previously showed `[object Object]` in the admin content edit form
- Adds a collapsible tree viewer (json-formatter-js, CDN, 3.5KB gz, MIT) for `json`-type fields
- Edit mode: tree viewer by default, "Edit JSON" toggle reveals raw textarea; switching back validates JSON and refreshes tree with inline error on invalid input
- View/disabled mode: tree viewer only, no toggle
- Adds `metadata` (type `json`) field to the `e2e_test` collection for test coverage

## Test plan

- [x] 4 Playwright E2E tests in `tests/e2e/83-json-field-viewer.spec.ts`
  - `edit form shows JSON viewer, not [object Object]`
  - `toggle switches to textarea and back to viewer`
  - `invalid JSON shows inline error and blocks switch back to viewer`
  - `edited JSON saves correctly on form submit`
- All 4 tests pass locally against `http://localhost:9032`

🤖 Generated with [Claude Code](https://claude.com/claude-code)