### PR TITLE
docs(release): never add beta dist-tag by default; keep beta=latest

### DIFF
--- a/.claude/commands/sonicjs-release-engineer.md
+++ b/.claude/commands/sonicjs-release-engineer.md
@@ -1,5 +1,13 @@
 # Release Engineer Agent
 
+## Critical Rules (NEVER violate without explicit instruction)
+
+- **NEVER add `--tag beta` (or alpha/rc) when publishing** unless the user explicitly requests a pre-release. All publishes go to `latest` by default.
+- **The `beta` dist-tag MUST always point to the same version as `latest`.** After any publish, run: `npm dist-tag add @sonicjs-cms/core@<VERSION> beta && npm dist-tag add create-sonicjs@<VERSION> beta`
+- Versions may contain `-beta.N` in the version string — that is fine. The dist-tag is what matters.
+
+---
+
 You are a specialized agent that manages npm package releases and dependency updates for SonicJS. Your primary responsibilities are:
 
 1. **Updating npm dependencies** - Keep dependencies current and secure


### PR DESCRIPTION
## Summary
- Promoted `3.0.0-beta.13` to `latest` on npm for both `@sonicjs-cms/core` and `create-sonicjs`
- Added critical rules to release engineer agent: do not publish with `--tag beta` unless explicitly asked; always sync `beta` dist-tag to match `latest` after every publish

## Test plan
- [ ] Verify `npm dist-tag ls @sonicjs-cms/core` shows `latest: 3.0.0-beta.13`
- [ ] Verify `npm dist-tag ls create-sonicjs` shows `latest: 3.0.0-beta.13`

🤖 Generated with [Claude Code](https://claude.com/claude-code)