### PR TITLE
feat(auth): support configurable post-login redirect via ?redirect= param

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -615,6 +615,7 @@ export class PermissionManager {
 Renders the login HTML form. Supports query parameters:
 - `?error=<message>` - Display error message
 - `?message=<message>` - Display info message
+- `?redirect=<path>` - Redirect to this path after successful login (must start with `/`; external URLs are ignored and fall back to `/admin/content`)
 
 ### Registration Page
 
@@ -657,6 +658,8 @@ Renders the registration HTML form.
 **POST** `/auth/login/form`
 
 Handles HTML form submissions. Returns HTMX-compatible HTML response.
+
+Supports `?redirect=<path>` query parameter — same rules as the GET page above. Example: link customers to `/auth/login?redirect=/dash` to land them on `/dash` after login.
 
 ### Register (API)
 

--- a/packages/core/src/routes/auth.ts
+++ b/packages/core/src/routes/auth.ts
@@ -68,11 +68,13 @@ const authRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>()
 authRoutes.get('/login', async (c) => {
   const error = c.req.query('error')
   const message = c.req.query('message')
-  
+  const redirect = c.req.query('redirect')
+
   const pageData: LoginPageData = {
     error: error || undefined,
     message: message || undefined,
-    version: c.get('appVersion')
+    version: c.get('appVersion'),
+    redirect: redirect && redirect.startsWith('/') ? redirect : undefined,
   }
   
   // Check if demo login plugin is active
@@ -675,6 +677,9 @@ authRoutes.post('/login/form',
 
     await setCsrfCookie(c)
 
+    const rawRedirect = c.req.query('redirect')
+    const redirectUrl = rawRedirect && rawRedirect.startsWith('/') ? rawRedirect : '/admin/content'
+
     return c.html(html`
       <div id="form-response">
         <div class="rounded-lg bg-green-100 dark:bg-lime-500/10 p-4 ring-1 ring-green-400 dark:ring-lime-500/20">
@@ -687,7 +692,7 @@ authRoutes.post('/login/form',
             </div>
           </div>
           <script>
-            setTimeout(() => { window.location.href = '/admin/content'; }, 500);
+            setTimeout(() => { window.location.href = '${redirectUrl}'; }, 500);
           </script>
         </div>
       </div>

--- a/packages/core/src/templates/pages/auth-login.template.ts
+++ b/packages/core/src/templates/pages/auth-login.template.ts
@@ -4,6 +4,7 @@ export interface LoginPageData {
   error?: string
   message?: string
   version?: string
+  redirect?: string
 }
 
 export function renderLoginPage(data: LoginPageData, demoLoginActive: boolean = false): string {
@@ -71,7 +72,7 @@ export function renderLoginPage(data: LoginPageData, demoLoginActive: boolean = 
             <!-- Form -->
             <form
               id="login-form"
-              hx-post="/auth/login/form"
+              hx-post="/auth/login/form${data.redirect ? `?redirect=${encodeURIComponent(data.redirect)}` : ''}"
               hx-target="#form-response"
               hx-swap="innerHTML"
               class="space-y-6"

--- a/tests/e2e/68-login-redirect.spec.ts
+++ b/tests/e2e/68-login-redirect.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test'
+import { ensureAdminUserExists, ADMIN_CREDENTIALS, TEST_ORIGIN } from './utils/test-helpers'
+
+test.describe('Login redirect param', () => {
+  test.beforeEach(async ({ page }) => {
+    await ensureAdminUserExists(page)
+  })
+
+  test('redirects to /admin/content by default', async ({ page }) => {
+    await page.goto('/auth/login')
+    await page.fill('#email', ADMIN_CREDENTIALS.email)
+    await page.fill('#password', ADMIN_CREDENTIALS.password)
+    await page.click('button[type="submit"]')
+    await page.waitForURL(/\/admin\/content/, { timeout: 5000 })
+    expect(page.url()).toContain('/admin/content')
+  })
+
+  test('redirects to ?redirect= path after login', async ({ page }) => {
+    await page.goto('/auth/login?redirect=/admin/settings')
+    await page.fill('#email', ADMIN_CREDENTIALS.email)
+    await page.fill('#password', ADMIN_CREDENTIALS.password)
+    await page.click('button[type="submit"]')
+    await page.waitForURL(/\/admin\/settings/, { timeout: 5000 })
+    expect(page.url()).toContain('/admin/settings')
+  })
+
+  test('ignores external redirect (open-redirect guard)', async ({ page }) => {
+    await page.goto('/auth/login?redirect=https://evil.example.com')
+    await page.fill('#email', ADMIN_CREDENTIALS.email)
+    await page.fill('#password', ADMIN_CREDENTIALS.password)
+    await page.click('button[type="submit"]')
+    // Must NOT navigate to the external URL — falls back to /admin/content
+    await page.waitForURL(/\/admin\/content/, { timeout: 5000 })
+    expect(page.url()).not.toContain('evil.example.com')
+  })
+})


### PR DESCRIPTION
## Summary
- `GET /auth/login` and `POST /auth/login/form` now accept a `?redirect=<path>` query param
- After successful login the browser navigates to that path instead of the hardcoded `/admin/content`
- Open-redirect guard: value must start with `/`; external URLs are silently ignored (fallback to `/admin/content`)

## Changes
- `packages/core/src/routes/auth.ts` — read `?redirect=` in GET handler + use it in POST form handler with guard
- `packages/core/src/templates/pages/auth-login.template.ts` — pass redirect through to `hx-post` action
- `docs/authentication.md` — document `?redirect=` on both GET and POST endpoints
- `tests/e2e/68-login-redirect.spec.ts` — E2E tests: default redirect, custom redirect, open-redirect guard

## Testing
- [x] E2E tests pass locally (3/3)
- [x] No new TypeScript errors

## Usage
Link customers to `/auth/login?redirect=/dash` — they land on `/dash` after login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)