### PR TITLE
feat(auth): API keys plugin + auth hardening (lockout, email, session tests)

### DIFF
--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -41,6 +41,7 @@ import { userProfilesPlugin } from './plugins/core-plugins/user-profiles'
 import { aiSearchPlugin } from './plugins/core-plugins/ai-search-plugin'
 import { securityAuditPlugin } from './plugins/core-plugins/security-audit-plugin'
 import { securityAuditMiddleware, securityAuditApiRoutes, securityAuditAdminRoutes } from './plugins/core-plugins/security-audit-plugin'
+import { apiKeysPlugin, apiKeyAuthMiddleware } from './plugins/core-plugins/api-keys-plugin'
 import { stripePlugin } from './plugins/core-plugins/stripe-plugin'
 import { formsPlugin } from './plugins/core-plugins/forms-plugin'
 import { requireAuth, requireRole, requireRbac } from './middleware/auth'
@@ -279,6 +280,7 @@ export function createSonicJSApp(config: SonicJSConfig = {}): SonicJSApp {
   const magicLinkPlugin = createMagicLinkAuthPlugin()
   const corePluginsBeforeCatchAll = [
     securityAuditPlugin,
+    apiKeysPlugin,
     aiSearchPlugin,
     oauthProvidersPlugin,
     userProfilesPlugin,
@@ -476,6 +478,12 @@ export function createSonicJSApp(config: SonicJSConfig = {}): SonicJSApp {
     }
     await next()
   })
+
+  // API-key auth: if no session resolved a user, accept a programmatic key from
+  // `x-api-key` / `Authorization: Bearer sk_…`. Provided by the api-keys plugin;
+  // gated on that plugin being active. Runs right after the session middleware
+  // so it sits ahead of every route guard, like the security-audit middleware.
+  app.use('*', apiKeyAuthMiddleware())
 
   // Custom middleware - after auth
   if (config.middleware?.afterAuth) {

--- a/packages/core/src/plugins/core-plugins/api-keys-plugin/components/keys-page.ts
+++ b/packages/core/src/plugins/core-plugins/api-keys-plugin/components/keys-page.ts
@@ -1,0 +1,184 @@
+import { renderAdminLayoutCatalyst, AdminLayoutCatalystData } from '../../../../templates/layouts/admin-layout-catalyst.template'
+import { escapeHtml } from '../../../../utils/sanitize'
+import type { ApiKeySummary } from '../services/api-key-service'
+
+interface BaseUser {
+  name: string
+  email: string
+  role: string
+}
+
+export interface ApiKeysPageData {
+  keys: ApiKeySummary[]
+  user?: BaseUser
+  version?: string
+  dynamicMenuItems?: Array<{ label: string; path: string; icon: string }>
+}
+
+function fmtDate(ms: number | null): string {
+  if (!ms) return '—'
+  try {
+    return new Date(ms).toISOString().slice(0, 10)
+  } catch {
+    return '—'
+  }
+}
+
+function keyRow(k: ApiKeySummary): string {
+  const name = escapeHtml(k.name)
+  const prefix = escapeHtml(k.prefix)
+  const id = escapeHtml(k.id)
+  return `
+    <tr class="border-t border-zinc-950/5 dark:border-white/10" data-key-id="${id}">
+      <td class="py-3 pr-4 text-sm font-medium text-zinc-950 dark:text-white">${name}</td>
+      <td class="py-3 pr-4 text-sm font-mono text-zinc-500 dark:text-zinc-400">${prefix}…</td>
+      <td class="py-3 pr-4 text-sm text-zinc-500 dark:text-zinc-400">${fmtDate(k.createdAt ? k.createdAt * 1000 : null)}</td>
+      <td class="py-3 pr-4 text-sm text-zinc-500 dark:text-zinc-400">${k.lastUsedAt ? fmtDate(k.lastUsedAt) : 'Never'}</td>
+      <td class="py-3 pr-4 text-sm text-zinc-500 dark:text-zinc-400">${k.expiresAt ? fmtDate(k.expiresAt) : 'Never'}</td>
+      <td class="py-3 text-right">
+        <button type="button" onclick="revokeApiKey('${id}', '${name.replace(/'/g, "\\'")}')"
+          class="rounded-lg bg-red-50 dark:bg-red-900/20 px-3 py-1.5 text-sm font-medium text-red-700 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/40 ring-1 ring-red-200 dark:ring-red-800 transition-colors">
+          Revoke
+        </button>
+      </td>
+    </tr>`
+}
+
+export function renderApiKeysPage(data: ApiKeysPageData): string {
+  const { keys, user, version, dynamicMenuItems } = data
+
+  const rows = keys.length
+    ? keys.map(keyRow).join('')
+    : `<tr><td colspan="6" class="py-8 text-center text-sm text-zinc-500 dark:text-zinc-400">No API keys yet. Create one to enable programmatic access.</td></tr>`
+
+  const content = `
+    <div>
+      <div class="sm:flex sm:items-center sm:justify-between mb-6">
+        <div class="sm:flex-auto">
+          <h1 class="text-2xl/8 font-semibold text-zinc-950 dark:text-white sm:text-xl/8">API Keys</h1>
+          <p class="mt-2 text-sm/6 text-zinc-500 dark:text-zinc-400">
+            Long-lived secrets for headless / server-to-server REST access. Send a key as the
+            <code class="font-mono">x-api-key</code> header or <code class="font-mono">Authorization: Bearer &lt;key&gt;</code>.
+            The secret is shown once at creation — store it now.
+          </p>
+        </div>
+        <div class="mt-4 sm:mt-0 sm:ml-16">
+          <button type="button" onclick="document.getElementById('create-key-modal').classList.remove('hidden')"
+            class="inline-flex items-center justify-center rounded-lg bg-cyan-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-cyan-500 transition-colors shadow-sm">
+            Create API key
+          </button>
+        </div>
+      </div>
+
+      <!-- Newly-created secret banner (populated by JS, shown once) -->
+      <div id="new-key-banner" class="hidden mb-6 rounded-xl bg-emerald-50 dark:bg-emerald-900/20 p-4 ring-1 ring-emerald-200 dark:ring-emerald-800">
+        <p class="text-sm font-medium text-emerald-800 dark:text-emerald-300 mb-2">
+          Copy your new key now — it will not be shown again.
+        </p>
+        <div class="flex items-center gap-2">
+          <code id="new-key-value" class="flex-1 rounded-lg bg-white dark:bg-zinc-900 px-3 py-2 text-sm font-mono text-zinc-950 dark:text-white ring-1 ring-zinc-950/10 dark:ring-white/10 break-all"></code>
+          <button type="button" onclick="copyNewKey()"
+            class="rounded-lg bg-emerald-600 px-3 py-2 text-sm font-semibold text-white hover:bg-emerald-500 transition-colors">
+            Copy
+          </button>
+        </div>
+      </div>
+
+      <div class="rounded-xl bg-white/80 dark:bg-zinc-900/80 backdrop-blur-xl p-6 ring-1 ring-zinc-950/5 dark:ring-white/10 shadow-sm overflow-x-auto">
+        <table class="w-full text-left">
+          <thead>
+            <tr class="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+              <th class="pb-2 pr-4">Name</th>
+              <th class="pb-2 pr-4">Prefix</th>
+              <th class="pb-2 pr-4">Created</th>
+              <th class="pb-2 pr-4">Last used</th>
+              <th class="pb-2 pr-4">Expires</th>
+              <th class="pb-2 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody id="keys-tbody">${rows}</tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Create modal -->
+    <div id="create-key-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div class="w-full max-w-md rounded-xl bg-white dark:bg-zinc-900 p-6 ring-1 ring-zinc-950/10 dark:ring-white/10 shadow-xl">
+        <h2 class="text-base font-semibold text-zinc-950 dark:text-white mb-4">Create API key</h2>
+        <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">Name</label>
+        <input id="new-key-name" type="text" placeholder="e.g. CI deploy token"
+          class="w-full rounded-lg border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm text-zinc-950 dark:text-white mb-4 ring-1 ring-inset ring-zinc-950/10 dark:ring-white/10">
+        <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">Expires in (days, optional)</label>
+        <input id="new-key-expiry" type="number" min="1" max="3650" placeholder="Never"
+          class="w-full rounded-lg border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm text-zinc-950 dark:text-white mb-4 ring-1 ring-inset ring-zinc-950/10 dark:ring-white/10">
+        <div class="flex justify-end gap-2">
+          <button type="button" onclick="document.getElementById('create-key-modal').classList.add('hidden')"
+            class="rounded-lg bg-white dark:bg-zinc-800 px-4 py-2 text-sm font-semibold text-zinc-950 dark:text-white ring-1 ring-inset ring-zinc-950/10 dark:ring-white/10">
+            Cancel
+          </button>
+          <button type="button" onclick="createApiKey()"
+            class="rounded-lg bg-cyan-600 px-4 py-2 text-sm font-semibold text-white hover:bg-cyan-500 transition-colors">
+            Create
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      // CSRF: the csrf_token cookie is JS-readable (httpOnly:false); echo it back
+      // as X-CSRF-Token on state-changing requests (signed double-submit).
+      function csrfHeader() {
+        const m = document.cookie.match(/(?:^|; )csrf_token=([^;]+)/)
+        return m ? { 'X-CSRF-Token': decodeURIComponent(m[1]) } : {}
+      }
+      async function createApiKey() {
+        const name = document.getElementById('new-key-name').value.trim()
+        if (!name) { window.showNotification && window.showNotification('Name is required', 'error'); return }
+        const expiry = parseInt(document.getElementById('new-key-expiry').value, 10)
+        const body = { name }
+        if (Number.isFinite(expiry) && expiry > 0) body.expiresInDays = expiry
+        const res = await fetch('/admin/plugins/api-keys/api/keys', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...csrfHeader() },
+          body: JSON.stringify(body),
+        })
+        if (!res.ok) {
+          const e = await res.json().catch(() => ({}))
+          window.showNotification && window.showNotification(e.error || 'Failed to create key', 'error')
+          return
+        }
+        const { apiKey } = await res.json()
+        document.getElementById('create-key-modal').classList.add('hidden')
+        document.getElementById('new-key-value').textContent = apiKey.key
+        document.getElementById('new-key-banner').classList.remove('hidden')
+        setTimeout(() => location.reload(), 1500)
+      }
+      function copyNewKey() {
+        const v = document.getElementById('new-key-value').textContent
+        navigator.clipboard.writeText(v).then(() => window.showNotification && window.showNotification('Copied', 'success'))
+      }
+      async function revokeApiKey(id, name) {
+        if (!confirm('Revoke "' + name + '"? This cannot be undone and will break any client using it.')) return
+        const res = await fetch('/admin/plugins/api-keys/api/keys/' + id, { method: 'DELETE', headers: { ...csrfHeader() } })
+        if (res.ok) {
+          const row = document.querySelector('[data-key-id="' + id + '"]')
+          if (row) row.remove()
+          window.showNotification && window.showNotification('Key revoked', 'success')
+        } else {
+          window.showNotification && window.showNotification('Failed to revoke', 'error')
+        }
+      }
+    </script>`
+
+  const layoutData: AdminLayoutCatalystData = {
+    title: 'API Keys',
+    pageTitle: 'API Keys',
+    currentPath: '/admin/plugins/api-keys',
+    user,
+    content,
+    version,
+    dynamicMenuItems,
+  }
+
+  return renderAdminLayoutCatalyst(layoutData)
+}

--- a/packages/core/src/plugins/core-plugins/api-keys-plugin/index.ts
+++ b/packages/core/src/plugins/core-plugins/api-keys-plugin/index.ts
@@ -1,0 +1,77 @@
+/**
+ * API Keys Plugin — programmatic access tokens for headless REST access.
+ *
+ * Split, by necessity, across plugin + core:
+ *   - Plugin owns: the management surface — admin page + JSON API
+ *     (/admin/plugins/api-keys), settings (max keys per user, default expiry),
+ *     and the sidebar entry. Plus the ApiKeyService + the resolve middleware.
+ *   - Core owns: where the resolve middleware sits in the app-wide auth chain
+ *     (app.ts wires `apiKeyAuthMiddleware()` after the Better Auth session
+ *     middleware), and the `api_key` document type registration in the
+ *     document-type seed (so the q_apikey_* columns exist at boot). This mirrors
+ *     how the security-audit plugin's middleware + `security_event` type are
+ *     core-wired while the plugin owns its UX.
+ *
+ * The resolve middleware is always-on for the compiled core build (see
+ * middleware/api-key-auth.ts for why it isn't gated on a DB active-flag).
+ */
+
+import { definePlugin } from '../../sdk/define-plugin'
+import { apiKeysAdminRoutes } from './routes/admin'
+
+const KEY_ICON = `<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/></svg>`
+
+export const apiKeysPlugin = definePlugin({
+  id: 'api-keys',
+  version: '1.0.0-beta.1',
+  name: 'API Keys',
+  description: 'Programmatic API access keys for headless / server-to-server REST access.',
+  sonicjsVersionRange: '^3.0.0',
+  author: { name: 'SonicJS Team' },
+
+  register(app) {
+    app.route('/admin/plugins/api-keys', apiKeysAdminRoutes as any)
+  },
+
+  menu: [
+    { label: 'API Keys', path: '/admin/plugins/api-keys', icon: KEY_ICON, order: 86 },
+  ],
+
+  configSchema: {
+    maxKeysPerUser: {
+      type: 'number',
+      label: 'Max keys per user',
+      description: 'Hard cap on active keys a single user may hold.',
+      default: 50,
+    },
+    defaultExpiryDays: {
+      type: 'number',
+      label: 'Default expiry (days)',
+      description: 'Lifetime applied to new keys when no explicit expiry is given. 0 = never expires.',
+      default: 0,
+    },
+  },
+
+  activate: async () => console.log('[ApiKeys] Plugin activated'),
+  deactivate: async () => console.log('[ApiKeys] Plugin deactivated'),
+})
+
+export function createApiKeysPlugin() {
+  return apiKeysPlugin
+}
+
+export {
+  ApiKeyService,
+  API_KEY_QUERYABLE,
+  generateApiKeySecret,
+  hashApiKey,
+} from './services/api-key-service'
+export type {
+  CreatedApiKey,
+  ApiKeySummary,
+  ResolvedApiKeyUser,
+} from './services/api-key-service'
+export { apiKeyAuthMiddleware } from './middleware/api-key-auth'
+export { apiKeysAdminRoutes } from './routes/admin'
+export type { ApiKeysSettings } from './types'
+export default apiKeysPlugin

--- a/packages/core/src/plugins/core-plugins/api-keys-plugin/manifest.json
+++ b/packages/core/src/plugins/core-plugins/api-keys-plugin/manifest.json
@@ -1,0 +1,25 @@
+{
+  "id": "api-keys",
+  "name": "API Keys",
+  "version": "1.0.0-beta.1",
+  "description": "Programmatic API access keys for headless / server-to-server REST access. Long-lived per-user secrets, hashed at rest, managed from an admin page.",
+  "author": "SonicJS Team",
+  "category": "security",
+  "tags": ["security", "api", "auth", "api-keys", "headless"],
+  "dependencies": [],
+  "permissions": {
+    "api-keys:manage": "Create and revoke API keys"
+  },
+  "adminMenu": {
+    "label": "API Keys",
+    "icon": "key",
+    "path": "/admin/plugins/api-keys",
+    "order": 86
+  },
+  "iconEmoji": "🔑",
+  "is_core": false,
+  "defaultSettings": {
+    "maxKeysPerUser": 50,
+    "defaultExpiryDays": 0
+  }
+}

--- a/packages/core/src/plugins/core-plugins/api-keys-plugin/middleware/api-key-auth.ts
+++ b/packages/core/src/plugins/core-plugins/api-keys-plugin/middleware/api-key-auth.ts
@@ -1,0 +1,47 @@
+import type { Context, Next } from 'hono'
+import { ApiKeyService } from '../services/api-key-service'
+
+/**
+ * API-key authentication middleware.
+ *
+ * Runs app-wide, right after the Better Auth session middleware. If no session
+ * already resolved a user, it accepts a programmatic key from `x-api-key` or
+ * `Authorization: Bearer sk_…` and sets `c.get('user')` so the existing
+ * requireAuth/requireRole/requireRbac guards work unchanged.
+ *
+ * Wired in app.ts (like the security-audit middleware) rather than via a plugin
+ * hook, because app-wide middleware ordering is owned by core. It is always-on
+ * for the compiled core build — not gated on a DB plugin-active flag, since core
+ * plugins aren't seeded active on a fresh install and gating would silently break
+ * key auth out of the box. The lookup only runs when a request both lacks a
+ * session AND presents a key header, so normal traffic pays nothing.
+ */
+export function apiKeyAuthMiddleware() {
+  return async (c: Context, next: Next): Promise<void> => {
+    if (!c.get('user')) {
+      const authz = c.req.header('authorization') || ''
+      const bearer = authz.toLowerCase().startsWith('bearer ') ? authz.slice(7).trim() : ''
+      const presented = c.req.header('x-api-key') || (bearer.startsWith('sk_') ? bearer : '')
+      if (presented) {
+        try {
+          const tenantId = (c.get('tenantId') as string) || 'default'
+          const resolved = await new ApiKeyService(c.env.DB, tenantId).resolve(presented)
+          if (resolved) {
+            c.set('user', {
+              userId: resolved.userId,
+              email: resolved.email,
+              role: resolved.role,
+              isSuperAdmin: resolved.isSuperAdmin,
+              // API keys are stateless bearer creds — no session window.
+              exp: 0,
+              iat: 0,
+            })
+          }
+        } catch {
+          // Invalid/garbled key — leave unauthenticated.
+        }
+      }
+    }
+    await next()
+  }
+}

--- a/packages/core/src/plugins/core-plugins/api-keys-plugin/routes/admin.ts
+++ b/packages/core/src/plugins/core-plugins/api-keys-plugin/routes/admin.ts
@@ -1,0 +1,101 @@
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { requireAuth } from '../../../../middleware'
+import { PluginService } from '../../../../services'
+import { ApiKeyService } from '../services/api-key-service'
+import { renderApiKeysPage } from '../components/keys-page'
+import { DEFAULT_SETTINGS, type ApiKeysSettings } from '../types'
+import type { Bindings, Variables } from '../../../../app'
+
+const adminRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>()
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+const createSchema = z.object({
+  name: z.string().min(1).max(100),
+  // Optional lifetime in days; omitted/null → plugin default (which may be "never").
+  expiresInDays: z.number().int().positive().max(3650).nullish(),
+})
+
+async function getSettings(db: any): Promise<ApiKeysSettings> {
+  try {
+    const plugin = await new PluginService(db).getPlugin('api-keys')
+    if (plugin?.settings) {
+      const s = typeof plugin.settings === 'string' ? JSON.parse(plugin.settings) : plugin.settings
+      return { ...DEFAULT_SETTINGS, ...s }
+    }
+  } catch {
+    /* fall through to defaults */
+  }
+  return DEFAULT_SETTINGS
+}
+
+// Admin-only: only portal admins reach /admin/*, but guard explicitly so the
+// management API can never be hit by a lower role that slips past route mounting.
+adminRoutes.use('*', requireAuth())
+adminRoutes.use('*', async (c, next) => {
+  const user = c.get('user')
+  if (user?.role !== 'admin') {
+    return c.json({ error: 'Access denied' }, 403)
+  }
+  return next()
+})
+
+// ── Admin UI page ───────────────────────────────────────────────────────────
+adminRoutes.get('/', async (c) => {
+  const user = c.get('user')!
+  const tenantId = (c.get('tenantId') as string) || 'default'
+  const keys = await new ApiKeyService(c.env.DB, tenantId).list(user.userId)
+  return c.html(
+    renderApiKeysPage({
+      keys,
+      user: { name: user.email, email: user.email, role: user.role },
+      version: c.get('appVersion'),
+      dynamicMenuItems: c.get('pluginMenuItems'),
+    }),
+  )
+})
+
+// ── JSON management API (scoped to the current admin's own keys) ─────────────
+adminRoutes.get('/api/keys', async (c) => {
+  const user = c.get('user')!
+  const tenantId = (c.get('tenantId') as string) || 'default'
+  const keys = await new ApiKeyService(c.env.DB, tenantId).list(user.userId)
+  return c.json({ keys })
+})
+
+adminRoutes.post('/api/keys', async (c) => {
+  const user = c.get('user')!
+  const tenantId = (c.get('tenantId') as string) || 'default'
+  const body = await c.req.json().catch(() => ({}))
+  const parsed = createSchema.safeParse(body)
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid request', details: parsed.error.flatten() }, 400)
+  }
+
+  const settings = await getSettings(c.env.DB)
+  const svc = new ApiKeyService(c.env.DB, tenantId)
+
+  // Enforce the per-user cap.
+  if ((await svc.countForUser(user.userId)) >= settings.maxKeysPerUser) {
+    return c.json({ error: `API key limit reached (max ${settings.maxKeysPerUser})` }, 409)
+  }
+
+  // Explicit lifetime wins; else fall back to the plugin default (0 = never).
+  const days = parsed.data.expiresInDays ?? (settings.defaultExpiryDays > 0 ? settings.defaultExpiryDays : null)
+  const expiresAt = days ? Date.now() + days * DAY_MS : null
+
+  const created = await svc.create({ userId: user.userId, name: parsed.data.name, expiresAt })
+  // `key` is shown once here; clients must store it now.
+  return c.json({ apiKey: created }, 201)
+})
+
+adminRoutes.delete('/api/keys/:id', async (c) => {
+  const user = c.get('user')!
+  const tenantId = (c.get('tenantId') as string) || 'default'
+  const ok = await new ApiKeyService(c.env.DB, tenantId).revoke(c.req.param('id') ?? '', user.userId)
+  if (!ok) return c.json({ error: 'API key not found' }, 404)
+  return c.json({ success: true })
+})
+
+export { adminRoutes as apiKeysAdminRoutes }

--- a/packages/core/src/plugins/core-plugins/api-keys-plugin/services/api-key-service.sqlite.test.ts
+++ b/packages/core/src/plugins/core-plugins/api-keys-plugin/services/api-key-service.sqlite.test.ts
@@ -1,0 +1,192 @@
+// @ts-nocheck
+// Real-SQLite coverage for the programmatic API key feature (services/api-keys.ts).
+// Mock tests can't prove the q_apikey_* generated columns, the hash-only storage,
+// or the resolve predicates (revoked/expiry/active) — so this runs actual SQL via
+// the better-sqlite3 D1 shim (R10).
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createTestD1 } from '../../../../__tests__/utils/d1-sqlite'
+import { ApiKeyService, API_KEY_QUERYABLE, hashApiKey, generateApiKeySecret } from './api-key-service'
+
+async function seedUser(db, { id = 'user-1', email = 'owner@example.com', role = 'editor', active = 1 } = {}) {
+  db.raw
+    .prepare(
+      `INSERT INTO auth_user (id, name, email, email_verified, first_name, last_name, role, is_active, created_at, updated_at)
+       VALUES (?,?,?,?,?,?,?,?,?,?)`,
+    )
+    .run(id, 'Owner', email, 1, 'Owner', 'User', role, active, 1, 1)
+  return { id, email, role }
+}
+
+describe('ApiKeyService — real SQLite', () => {
+  let db
+  beforeEach(async () => {
+    db = createTestD1()
+    db.raw
+      .prepare(
+        `INSERT INTO document_types (id,name,display_name,schema,queryable_fields,settings,source,schema_version,is_system,is_active,created_at,updated_at)
+         VALUES ('api_key','api_key','API Key','{}','[]','{}','system',1,1,1,1,1)`,
+      )
+      .run()
+    await db.applyScalarSchema('api_key', API_KEY_QUERYABLE)
+  })
+  afterEach(() => db.close())
+
+  describe('create', () => {
+    it('returns a one-time sk_ secret and stores only its hash', async () => {
+      const user = await seedUser(db)
+      const svc = new ApiKeyService(db, 'default')
+      const created = await svc.create({ userId: user.id, name: 'CI token' })
+
+      expect(created.key).toMatch(/^sk_[0-9a-f]{48}$/)
+      expect(created.prefix).toBe(created.key.slice(0, 11))
+      expect(created.name).toBe('CI token')
+
+      const row = db.raw
+        .prepare('SELECT data, q_apikey_hash h, q_apikey_user_id u, q_apikey_revoked r FROM documents WHERE root_id=?')
+        .get(created.id)
+      // Plaintext secret never lands in the row; only its SHA-256 hash.
+      expect(row.data).not.toContain(created.key)
+      expect(row.h).toBe(await hashApiKey(created.key))
+      expect(row.u).toBe(user.id)
+      expect(row.r).toBe(0)
+    })
+
+    it('persists an explicit expiry', async () => {
+      const user = await seedUser(db)
+      const svc = new ApiKeyService(db, 'default')
+      const expiresAt = Date.now() + 60_000
+      const created = await svc.create({ userId: user.id, name: 'temp', expiresAt })
+      expect(created.expiresAt).toBe(expiresAt)
+    })
+  })
+
+  describe('resolve', () => {
+    it('resolves a valid secret to its owning user with role', async () => {
+      const user = await seedUser(db, { role: 'author' })
+      const svc = new ApiKeyService(db, 'default')
+      const { key } = await svc.create({ userId: user.id, name: 'k' })
+
+      const resolved = await svc.resolve(key)
+      expect(resolved).toEqual({
+        userId: user.id,
+        email: user.email,
+        role: 'author',
+        isSuperAdmin: false,
+      })
+    })
+
+    it('returns null for an unknown / malformed secret', async () => {
+      await seedUser(db)
+      const svc = new ApiKeyService(db, 'default')
+      expect(await svc.resolve('sk_deadbeef')).toBeNull()
+      expect(await svc.resolve('not-a-key')).toBeNull()
+      expect(await svc.resolve('')).toBeNull()
+    })
+
+    it('returns null for an expired key', async () => {
+      const user = await seedUser(db)
+      const svc = new ApiKeyService(db, 'default')
+      const { key } = await svc.create({ userId: user.id, name: 'expired', expiresAt: Date.now() - 1000 })
+      expect(await svc.resolve(key)).toBeNull()
+    })
+
+    it('returns null when the owning user is inactive', async () => {
+      const user = await seedUser(db, { active: 0 })
+      const svc = new ApiKeyService(db, 'default')
+      const { key } = await svc.create({ userId: user.id, name: 'k' })
+      expect(await svc.resolve(key)).toBeNull()
+    })
+
+    it('stamps lastUsedAt on a successful resolve', async () => {
+      const user = await seedUser(db)
+      const svc = new ApiKeyService(db, 'default')
+      const { key, id } = await svc.create({ userId: user.id, name: 'k' })
+
+      const before = db.raw.prepare('SELECT data FROM documents WHERE root_id=?').get(id)
+      expect(JSON.parse(before.data).lastUsedAt).toBeNull()
+
+      await svc.resolve(key)
+      const after = db.raw.prepare('SELECT data FROM documents WHERE root_id=?').get(id)
+      expect(typeof JSON.parse(after.data).lastUsedAt).toBe('number')
+    })
+
+    it('does not resolve a key minted for one tenant under another', async () => {
+      const user = await seedUser(db)
+      const { key } = await new ApiKeyService(db, 'default').create({ userId: user.id, name: 'k' })
+      expect(await new ApiKeyService(db, 'other').resolve(key)).toBeNull()
+    })
+  })
+
+  describe('list', () => {
+    it('returns metadata only (no secret, no hash) for the owner', async () => {
+      const user = await seedUser(db)
+      const svc = new ApiKeyService(db, 'default')
+      await svc.create({ userId: user.id, name: 'first' })
+      await svc.create({ userId: user.id, name: 'second' })
+
+      const keys = await svc.list(user.id)
+      expect(keys).toHaveLength(2)
+      for (const k of keys) {
+        expect(k).toHaveProperty('prefix')
+        expect(k).not.toHaveProperty('key')
+        expect(k).not.toHaveProperty('keyHash')
+        expect(JSON.stringify(k)).not.toMatch(/sk_[0-9a-f]{48}/)
+      }
+      expect(keys.map((k) => k.name).sort()).toEqual(['first', 'second'])
+    })
+
+    it('isolates keys by user', async () => {
+      const a = await seedUser(db, { id: 'ua', email: 'a@x.com' })
+      const b = await seedUser(db, { id: 'ub', email: 'b@x.com' })
+      const svc = new ApiKeyService(db, 'default')
+      await svc.create({ userId: a.id, name: 'a-key' })
+      await svc.create({ userId: b.id, name: 'b-key' })
+
+      expect((await svc.list(a.id)).map((k) => k.name)).toEqual(['a-key'])
+      expect((await svc.list(b.id)).map((k) => k.name)).toEqual(['b-key'])
+    })
+  })
+
+  describe('revoke', () => {
+    it('hard-deletes the key so it no longer resolves or lists', async () => {
+      const user = await seedUser(db)
+      const svc = new ApiKeyService(db, 'default')
+      const { key, id } = await svc.create({ userId: user.id, name: 'k' })
+
+      expect(await svc.revoke(id, user.id)).toBe(true)
+      expect(await svc.resolve(key)).toBeNull()
+      expect(await svc.list(user.id)).toHaveLength(0)
+      // Document row is gone (credential hard-erase, not soft-flag).
+      const row = db.raw.prepare('SELECT COUNT(*) c FROM documents WHERE root_id=?').get(id)
+      expect(row.c).toBe(0)
+    })
+
+    it('refuses to revoke a key owned by another user', async () => {
+      const a = await seedUser(db, { id: 'ua', email: 'a@x.com' })
+      const b = await seedUser(db, { id: 'ub', email: 'b@x.com' })
+      const svc = new ApiKeyService(db, 'default')
+      const { key, id } = await svc.create({ userId: a.id, name: 'a-key' })
+
+      expect(await svc.revoke(id, b.id)).toBe(false)
+      // Still valid for the real owner.
+      expect(await svc.resolve(key)).not.toBeNull()
+    })
+  })
+
+  describe('helpers', () => {
+    it('generateApiKeySecret produces unique sk_ secrets', () => {
+      const a = generateApiKeySecret()
+      const b = generateApiKeySecret()
+      expect(a).toMatch(/^sk_[0-9a-f]{48}$/)
+      expect(a).not.toBe(b)
+    })
+
+    it('hashApiKey is deterministic and not the input', async () => {
+      const h1 = await hashApiKey('sk_test')
+      const h2 = await hashApiKey('sk_test')
+      expect(h1).toBe(h2)
+      expect(h1).not.toBe('sk_test')
+      expect(h1).toMatch(/^[0-9a-f]{64}$/)
+    })
+  })
+})

--- a/packages/core/src/plugins/core-plugins/api-keys-plugin/services/api-key-service.ts
+++ b/packages/core/src/plugins/core-plugins/api-keys-plugin/services/api-key-service.ts
@@ -1,0 +1,238 @@
+import { D1Database } from '@cloudflare/workers-types'
+import type { Document, QueryableField } from '../../../../schemas/document'
+import { createDocumentSchema } from '../../../../schemas/document'
+import { DocumentsService } from '../../../../services/documents'
+
+/**
+ * Programmatic API keys, built on the document model (no new table — R-rules).
+ *
+ * better-auth 1.6.x ships no apiKey plugin, so SonicJS provides long-lived,
+ * per-user keys for headless / server-to-server REST access here. A key is one
+ * `api_key` document:
+ *   - the plaintext secret (`sk_<hex>`) is shown exactly once, at creation;
+ *   - only its SHA-256 hash is stored (`q_apikey_hash`), so a DB leak cannot
+ *     reconstruct usable keys;
+ *   - `q_apikey_user_id` powers per-user listing; `q_apikey_revoked` lets the
+ *     resolve query skip revoked keys with an indexed predicate.
+ *
+ * Resolution (an `x-api-key` / `Authorization: Bearer sk_…` header on an API
+ * request) looks up the hash, checks revoke + expiry, then loads the owning
+ * `auth_user` so the request runs as that user with their role.
+ *
+ * The `api_key` document type + its q_apikey_* generated columns are registered
+ * in the core document-type seed (document-types-seed.ts), so the columns exist
+ * at boot — before the resolve middleware can run.
+ */
+
+export const API_KEY_QUERYABLE: QueryableField[] = [
+  { name: 'keyHash', kind: 'scalar', type: 'text', column: 'q_apikey_hash' },
+  { name: 'userId', kind: 'scalar', type: 'text', column: 'q_apikey_user_id' },
+  { name: 'revoked', kind: 'scalar', type: 'integer', column: 'q_apikey_revoked' },
+]
+
+const KEY_PREFIX = 'sk_'
+/** Bytes of randomness in the secret (→ 48 hex chars after `sk_`). */
+const KEY_BYTES = 24
+/** Chars of the secret shown in listings, e.g. `sk_1a2b3c4d`. */
+const DISPLAY_PREFIX_LEN = KEY_PREFIX.length + 8
+
+export interface CreatedApiKey {
+  id: string
+  /** Full secret — returned ONCE, never persisted or retrievable again. */
+  key: string
+  name: string
+  prefix: string
+  expiresAt: number | null
+}
+
+export interface ApiKeySummary {
+  id: string
+  name: string
+  prefix: string
+  createdAt: number
+  lastUsedAt: number | null
+  expiresAt: number | null
+}
+
+export interface ResolvedApiKeyUser {
+  userId: string
+  email: string
+  role: string
+  isSuperAdmin: boolean
+}
+
+/** Generate a random `sk_<hex>` secret using Web Crypto (Workers + Node 18+). */
+export function generateApiKeySecret(): string {
+  const bytes = new Uint8Array(KEY_BYTES)
+  crypto.getRandomValues(bytes)
+  let hex = ''
+  for (const b of bytes) hex += b.toString(16).padStart(2, '0')
+  return KEY_PREFIX + hex
+}
+
+/** SHA-256 hex digest of the full secret. */
+export async function hashApiKey(secret: string): Promise<string> {
+  const data = new TextEncoder().encode(secret)
+  const digest = await crypto.subtle.digest('SHA-256', data)
+  const view = new Uint8Array(digest)
+  let hex = ''
+  for (const b of view) hex += b.toString(16).padStart(2, '0')
+  return hex
+}
+
+export class ApiKeyService {
+  constructor(private db: D1Database, private tenantId = 'default') {}
+
+  private docService(): DocumentsService {
+    return new DocumentsService(this.db, {
+      queryableFields: API_KEY_QUERYABLE,
+      tenantId: this.tenantId,
+      maxVersionsPerRoot: 1,
+    })
+  }
+
+  /** Count a user's active (non-revoked) keys — used to enforce the per-user cap. */
+  async countForUser(userId: string): Promise<number> {
+    const row = await this.db
+      .prepare(
+        `SELECT COUNT(*) AS c FROM documents
+         WHERE type_id = 'api_key' AND tenant_id = ? AND is_current_draft = 1
+           AND deleted_at IS NULL AND q_apikey_user_id = ? AND q_apikey_revoked = 0`,
+      )
+      .bind(this.tenantId, userId)
+      .first<{ c: number }>()
+    return row?.c ?? 0
+  }
+
+  /**
+   * Mint a new key for a user. The returned `key` is the only time the plaintext
+   * exists outside the caller — it is hashed before storage.
+   */
+  async create(input: { userId: string; name: string; expiresAt?: number | null }): Promise<CreatedApiKey> {
+    const name = input.name.trim() || 'API Key'
+    const secret = generateApiKeySecret()
+    const keyHash = await hashApiKey(secret)
+    const prefix = secret.slice(0, DISPLAY_PREFIX_LEN)
+    const expiresAt = input.expiresAt ?? null
+
+    const doc = await this.docService().create(
+      createDocumentSchema.parse({
+        typeId: 'api_key',
+        tenantId: this.tenantId,
+        title: name,
+        ownerId: input.userId,
+        publishOnCreate: true,
+        data: {
+          name,
+          userId: input.userId,
+          keyHash,
+          keyPrefix: prefix,
+          revoked: 0,
+          lastUsedAt: null,
+          expiresAt,
+        },
+      }),
+      input.userId,
+    )
+
+    return { id: doc.rootId, key: secret, name, prefix, expiresAt }
+  }
+
+  /** List a user's non-revoked keys (metadata only — never the secret or hash). */
+  async list(userId: string): Promise<ApiKeySummary[]> {
+    const res = await this.db
+      .prepare(
+        `SELECT root_id, data, created_at FROM documents
+         WHERE type_id = 'api_key' AND tenant_id = ? AND is_current_draft = 1
+           AND deleted_at IS NULL AND q_apikey_user_id = ? AND q_apikey_revoked = 0
+         ORDER BY created_at DESC`,
+      )
+      .bind(this.tenantId, userId)
+      .all<{ root_id: string; data: string; created_at: number }>()
+
+    return (res.results ?? []).map((row) => {
+      const d = JSON.parse(row.data) as Record<string, any>
+      return {
+        id: row.root_id,
+        name: d.name ?? 'API Key',
+        prefix: d.keyPrefix ?? '',
+        createdAt: row.created_at,
+        lastUsedAt: d.lastUsedAt ?? null,
+        expiresAt: d.expiresAt ?? null,
+      }
+    })
+  }
+
+  /**
+   * Revoke (hard-delete) a key owned by `userId`. Credentials are erased, not
+   * soft-flagged. Returns false if the key does not exist or is not owned by
+   * the caller (no information leak about other users' keys).
+   */
+  async revoke(rootId: string, userId: string): Promise<boolean> {
+    const row = await this.db
+      .prepare(
+        `SELECT q_apikey_user_id AS owner FROM documents
+         WHERE root_id = ? AND tenant_id = ? AND type_id = 'api_key' AND is_current_draft = 1 AND deleted_at IS NULL`,
+      )
+      .bind(rootId, this.tenantId)
+      .first<{ owner: string }>()
+    if (!row || row.owner !== userId) return false
+
+    await this.docService().erase(rootId, this.tenantId)
+    return true
+  }
+
+  /**
+   * Resolve a presented secret to its owning user, or null. Rejects unknown,
+   * revoked, expired keys and inactive users. Best-effort updates lastUsedAt.
+   */
+  async resolve(secret: string): Promise<ResolvedApiKeyUser | null> {
+    if (!secret || !secret.startsWith(KEY_PREFIX)) return null
+    const keyHash = await hashApiKey(secret)
+
+    const keyRow = await this.db
+      .prepare(
+        `SELECT root_id, data FROM documents
+         WHERE type_id = 'api_key' AND tenant_id = ? AND is_current_draft = 1 AND deleted_at IS NULL
+           AND q_apikey_hash = ? AND q_apikey_revoked = 0
+         LIMIT 1`,
+      )
+      .bind(this.tenantId, keyHash)
+      .first<{ root_id: string; data: string }>()
+    if (!keyRow) return null
+
+    const d = JSON.parse(keyRow.data) as Record<string, any>
+    if (d.expiresAt != null && Date.now() > Number(d.expiresAt)) return null
+
+    const user = await this.db
+      .prepare(`SELECT id, email, role, is_active, is_super_admin FROM auth_user WHERE id = ?`)
+      .bind(d.userId)
+      .first<{ id: string; email: string; role: string; is_active: number; is_super_admin: number }>()
+    if (!user || user.is_active !== 1) return null
+
+    // Best-effort usage stamp; never block auth on a write failure.
+    try {
+      await this.touchLastUsed(keyRow.root_id, d)
+    } catch {
+      /* non-fatal */
+    }
+
+    return {
+      userId: user.id,
+      email: user.email,
+      role: user.role ?? 'viewer',
+      isSuperAdmin: user.is_super_admin === 1,
+    }
+  }
+
+  /** Update lastUsedAt in-place (single-version type, no history churn). */
+  private async touchLastUsed(rootId: string, data: Record<string, any>): Promise<void> {
+    const next = JSON.stringify({ ...data, lastUsedAt: Date.now() })
+    await this.db
+      .prepare(
+        `UPDATE documents SET data = ? WHERE root_id = ? AND tenant_id = ? AND type_id = 'api_key' AND is_current_draft = 1`,
+      )
+      .bind(next, rootId, this.tenantId)
+      .run()
+  }
+}

--- a/packages/core/src/plugins/core-plugins/api-keys-plugin/types.ts
+++ b/packages/core/src/plugins/core-plugins/api-keys-plugin/types.ts
@@ -1,0 +1,11 @@
+export interface ApiKeysSettings {
+  /** Hard cap on active keys a single user may hold. Create is rejected beyond this. */
+  maxKeysPerUser: number
+  /** Default lifetime in days applied when a key is created without an explicit expiry. 0 = never expires. */
+  defaultExpiryDays: number
+}
+
+export const DEFAULT_SETTINGS: ApiKeysSettings = {
+  maxKeysPerUser: 50,
+  defaultExpiryDays: 0,
+}

--- a/packages/core/src/plugins/core-plugins/security-audit-plugin/services/brute-force-detector.test.ts
+++ b/packages/core/src/plugins/core-plugins/security-audit-plugin/services/brute-force-detector.test.ts
@@ -1,0 +1,189 @@
+/**
+ * BruteForceDetector unit tests.
+ *
+ * The detector is wired into the login path via the security-audit-plugin
+ * audit middleware, but had zero direct coverage. These tests mirror the
+ * account-lockout scenarios that Payload's auth suite covers:
+ *   - lock after N failed attempts (per-IP and per-email, independently)
+ *   - isLocked reflects an active lock and clears on unlock
+ *   - the sliding window expires stale attempts
+ *   - multi-email-from-one-IP is flagged suspicious
+ *   - alert threshold + active-lockout enumeration
+ *
+ * KV is the in-memory mock from test utils, so TTL expiry is real (it keys
+ * off Date.now()), letting us assert window/lockout expiration deterministically.
+ */
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { BruteForceDetector } from './brute-force-detector'
+import type { SecurityAuditSettings } from '../types'
+import { makeMockKVNamespace } from '../../../../__tests__/utils/mock-factories'
+
+const SETTINGS: SecurityAuditSettings['bruteForce'] = {
+  enabled: true,
+  maxFailedAttemptsPerIP: 4,
+  maxFailedAttemptsPerEmail: 3,
+  windowMinutes: 15,
+  lockoutDurationMinutes: 30,
+  alertThreshold: 6,
+}
+
+function makeDetector(overrides?: Partial<SecurityAuditSettings['bruteForce']>) {
+  const kv = makeMockKVNamespace()
+  const detector = new BruteForceDetector(kv as any, { ...SETTINGS, ...overrides })
+  return { kv, detector }
+}
+
+describe('BruteForceDetector', () => {
+  describe('recordFailedAttempt', () => {
+    it('locks the email after maxFailedAttemptsPerEmail failures', async () => {
+      const { detector } = makeDetector()
+      let result
+      for (let i = 0; i < SETTINGS.maxFailedAttemptsPerEmail; i++) {
+        result = await detector.recordFailedAttempt('1.1.1.1', 'victim@example.com')
+      }
+      expect(result!.emailCount).toBe(SETTINGS.maxFailedAttemptsPerEmail)
+      expect(result!.shouldLockEmail).toBe(true)
+      // IP threshold (4) is higher than email threshold (3), so not yet IP-locked.
+      expect(result!.shouldLockIP).toBe(false)
+    })
+
+    it('locks the IP after maxFailedAttemptsPerIP failures, independent of email', async () => {
+      const { detector } = makeDetector()
+      let result
+      // Different email each time so the per-email counter never trips first.
+      for (let i = 0; i < SETTINGS.maxFailedAttemptsPerIP; i++) {
+        result = await detector.recordFailedAttempt('2.2.2.2', `u${i}@example.com`)
+      }
+      expect(result!.ipCount).toBe(SETTINGS.maxFailedAttemptsPerIP)
+      expect(result!.shouldLockIP).toBe(true)
+    })
+
+    it('does not signal a lock below the threshold', async () => {
+      const { detector } = makeDetector()
+      const result = await detector.recordFailedAttempt('3.3.3.3', 'someone@example.com')
+      expect(result.shouldLockEmail).toBe(false)
+      expect(result.shouldLockIP).toBe(false)
+      expect(result.emailCount).toBe(1)
+    })
+
+    it('flags suspicious when >=5 distinct emails come from one IP', async () => {
+      const { detector } = makeDetector({ maxFailedAttemptsPerIP: 100 })
+      let result
+      for (let i = 0; i < 5; i++) {
+        result = await detector.recordFailedAttempt('4.4.4.4', `spray${i}@example.com`)
+      }
+      expect(result!.isSuspicious).toBe(true)
+    })
+
+    it('returns all-false / zero when the detector is disabled', async () => {
+      const { detector } = makeDetector({ enabled: false })
+      const result = await detector.recordFailedAttempt('5.5.5.5', 'x@example.com')
+      expect(result).toEqual({
+        ipCount: 0,
+        emailCount: 0,
+        shouldLockIP: false,
+        shouldLockEmail: false,
+        isSuspicious: false,
+      })
+    })
+  })
+
+  describe('sliding window', () => {
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
+    it('drops attempts older than windowMinutes so the count never trips', async () => {
+      vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+      const { detector } = makeDetector({ maxFailedAttemptsPerEmail: 3, windowMinutes: 15 })
+
+      // Two failures now.
+      await detector.recordFailedAttempt('6.6.6.6', 'slow@example.com')
+      await detector.recordFailedAttempt('6.6.6.6', 'slow@example.com')
+
+      // Advance past the window; the earlier two attempts expire.
+      vi.setSystemTime(new Date('2026-01-01T00:20:00Z'))
+      const result = await detector.recordFailedAttempt('6.6.6.6', 'slow@example.com')
+
+      // Only the most recent attempt survives the window filter.
+      expect(result.emailCount).toBe(1)
+      expect(result.shouldLockEmail).toBe(false)
+    })
+  })
+
+  describe('isLocked / lock / unlock', () => {
+    it('reports not locked when nothing is set', async () => {
+      const { detector } = makeDetector()
+      expect(await detector.isLocked('7.7.7.7', 'free@example.com')).toEqual({ locked: false })
+    })
+
+    it('reports locked with an email reason after lockEmail', async () => {
+      const { detector } = makeDetector()
+      await detector.lockEmail('locked@example.com')
+      const status = await detector.isLocked('7.7.7.7', 'locked@example.com')
+      expect(status.locked).toBe(true)
+      expect(status.reason).toMatch(/Account temporarily locked/)
+    })
+
+    it('reports locked with an IP reason after lockIP', async () => {
+      const { detector } = makeDetector()
+      await detector.lockIP('8.8.8.8')
+      const status = await detector.isLocked('8.8.8.8', 'whoever@example.com')
+      expect(status.locked).toBe(true)
+      expect(status.reason).toMatch(/IP address temporarily locked/)
+    })
+
+    it('clears the lock after unlockEmail / unlockIP', async () => {
+      const { detector } = makeDetector()
+      await detector.lockEmail('temp@example.com')
+      await detector.lockIP('9.9.9.9')
+      await detector.unlockEmail('temp@example.com')
+      await detector.unlockIP('9.9.9.9')
+      expect(await detector.isLocked('9.9.9.9', 'temp@example.com')).toEqual({ locked: false })
+    })
+
+    it('auto-expires the lock once lockoutDurationMinutes elapses (KV TTL)', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+      const { detector } = makeDetector({ lockoutDurationMinutes: 30 })
+      await detector.lockEmail('expire@example.com')
+      expect((await detector.isLocked('1.1.1.1', 'expire@example.com')).locked).toBe(true)
+
+      // Past the 30-minute lockout TTL.
+      vi.setSystemTime(new Date('2026-01-01T00:31:00Z'))
+      expect((await detector.isLocked('1.1.1.1', 'expire@example.com')).locked).toBe(false)
+      vi.useRealTimers()
+    })
+  })
+
+  describe('getActiveLockouts', () => {
+    it('enumerates active IP and email lockouts with type + value', async () => {
+      const { detector } = makeDetector()
+      await detector.lockIP('10.0.0.1')
+      await detector.lockEmail('a@example.com')
+
+      const lockouts = await detector.getActiveLockouts()
+      const byType = Object.fromEntries(lockouts.map((l) => [l.type, l.value]))
+      expect(lockouts).toHaveLength(2)
+      expect(byType.ip).toBe('10.0.0.1')
+      expect(byType.email).toBe('a@example.com')
+      for (const l of lockouts) expect(typeof l.lockedAt).toBe('number')
+    })
+
+    it('releaseLockout removes a specific lockout by key', async () => {
+      const { detector } = makeDetector()
+      await detector.lockIP('10.0.0.2')
+      const [lock] = await detector.getActiveLockouts()
+      await detector.releaseLockout(lock.key)
+      expect(await detector.getActiveLockouts()).toHaveLength(0)
+    })
+  })
+
+  describe('isAboveAlertThreshold', () => {
+    it('is true only at or above alertThreshold', () => {
+      const { detector } = makeDetector({ alertThreshold: 6 })
+      expect(detector.isAboveAlertThreshold(5)).toBe(false)
+      expect(detector.isAboveAlertThreshold(6)).toBe(true)
+      expect(detector.isAboveAlertThreshold(7)).toBe(true)
+    })
+  })
+})

--- a/packages/core/src/services/auth-validation.test.ts
+++ b/packages/core/src/services/auth-validation.test.ts
@@ -270,6 +270,36 @@ describe('authValidationService', () => {
       expect(result.success).toBe(false)
     })
 
+    // Email-format edge cases — mirrors Payload's `Email - format validation`
+    // suite. Confirms our registration schema rejects malformed addresses.
+    describe('email format edge cases', () => {
+      const accept = ['test@example.com', 'john.doe+tag@sub.example.co.uk', 'a_b@example.io']
+      const reject = [
+        'plainaddress',
+        'two"quotes"@example.com',
+        'has space@example.com',
+        'consecutive..dots@example.com',
+        '.leadingdot@example.com',
+        'comma,addr@example.com',
+        'no-at-sign.example.com',
+        'user@-example.com', // domain label starts with hyphen
+        'user@example-.com', // domain label ends with hyphen
+        'user@example..com', // empty domain label
+      ]
+
+      it.each(accept)('accepts %s', async (email) => {
+        const { authValidationService } = await import('./auth-validation')
+        const schema = await authValidationService.buildRegistrationSchema(createMockDb())
+        expect(schema.safeParse({ email, password: 'password123' }).success).toBe(true)
+      })
+
+      it.each(reject)('rejects %s', async (email) => {
+        const { authValidationService } = await import('./auth-validation')
+        const schema = await authValidationService.buildRegistrationSchema(createMockDb())
+        expect(schema.safeParse({ email, password: 'password123' }).success).toBe(false)
+      })
+    })
+
   })
 
   describe('generateDefaultValue', () => {

--- a/packages/core/src/services/auth-validation.ts
+++ b/packages/core/src/services/auth-validation.ts
@@ -119,8 +119,29 @@ export function resetAdminExistsCache(): void {
  * Auth Validation Service
  * Provides dynamic validation schemas for registration based on database settings
  */
+/**
+ * Email schema. Zod's `.email()` already rejects the common malformed shapes
+ * (spaces, double-quoted local parts, consecutive dots, leading dots, commas),
+ * but it *accepts* domain labels that begin or end with a hyphen (e.g.
+ * `user@example-.com`), which are invalid per RFC 1035. The refine closes that
+ * gap so registration validation matches stricter CMS auth suites.
+ */
+export const emailSchema = z
+  .string()
+  .email('Valid email is required')
+  .refine(
+    (value) => {
+      const at = value.lastIndexOf('@')
+      if (at < 0) return false
+      const domain = value.slice(at + 1)
+      // No domain label may start or end with a hyphen.
+      return domain.split('.').every((label) => label.length > 0 && !label.startsWith('-') && !label.endsWith('-'))
+    },
+    { message: 'Valid email is required' }
+  )
+
 const baseRegistrationSchema = z.object({
-  email: z.string().email('Valid email is required'),
+  email: emailSchema,
   password: z.string().min(8, 'Password must be at least 8 characters'),
   firstName: z.string().min(1, 'First name is required').optional(),
   lastName: z.string().min(1, 'Last name is required').optional()

--- a/packages/core/src/services/document-types-seed.ts
+++ b/packages/core/src/services/document-types-seed.ts
@@ -183,6 +183,30 @@ export async function bootstrapDocumentTypes(db: D1Database): Promise<void> {
     ],
   })
 
+  // API key (document-backed programmatic access tokens; auth-owned, one document per key).
+  // Stores only the SHA-256 hash of the secret (q_apikey_hash) — never the plaintext. PII/credential:
+  // revoke hard-erases. See services/api-keys.ts (ApiKeyService) for the write/resolve paths.
+  await registry.register({
+    id: 'api_key',
+    name: 'api_key',
+    displayName: 'API Key',
+    description: 'Programmatic API access key (auth-owned; only the secret hash is stored)',
+    source: 'system',
+    isAuth: true,
+    schema: anyObject,
+    settings: {
+      internal: true,
+      maxVersionsPerRoot: 1,
+      pii: true,
+      baseGrants: { admin: ['read', 'create', 'update', 'delete', 'manage'] },
+    },
+    queryableFields: [
+      { name: 'keyHash', kind: 'scalar', type: 'text',    column: 'q_apikey_hash' },
+      { name: 'userId',  kind: 'scalar', type: 'text',    column: 'q_apikey_user_id' },
+      { name: 'revoked', kind: 'scalar', type: 'integer', column: 'q_apikey_revoked' },
+    ],
+  })
+
   // Analytics event (document-backed; replaces legacy analytics_events table)
   await registry.register({
     id: 'analytics_event',

--- a/tests/e2e/86-api-key-auth.spec.ts
+++ b/tests/e2e/86-api-key-auth.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect } from '@playwright/test'
+import { ADMIN_CREDENTIALS } from './utils/test-helpers'
+
+/**
+ * Programmatic API keys — api-keys plugin (admin manage API at
+ * /admin/plugins/api-keys) + the core resolve middleware (x-api-key auth).
+ *
+ * Proves the headless-auth path end to end: a logged-in user mints a key, and a
+ * SEPARATE cookieless request context authenticates purely via the `x-api-key`
+ * (or `Authorization: Bearer sk_…`) header. Using a fresh context is essential —
+ * the shared `request` fixture carries the login session cookie, which would
+ * mask whether the header alone authenticated.
+ *
+ * The key-management calls (POST/DELETE) send `Authorization: Bearer <token>`.
+ * That token (returned by /auth/login) makes the request CSRF-exempt — the
+ * server skips CSRF when an Authorization header is present, since an attacker
+ * can't forge it cross-origin — while the session still authenticates the user.
+ */
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8787'
+
+async function loginToken(request: any): Promise<string> {
+  const res = await request.post('/auth/login', {
+    data: { email: ADMIN_CREDENTIALS.email, password: ADMIN_CREDENTIALS.password },
+  })
+  expect(res.ok()).toBe(true)
+  const { token } = await res.json()
+  expect(typeof token).toBe('string')
+  return token
+}
+
+async function createKey(request: any, token: string, name: string) {
+  const res = await request.post('/admin/plugins/api-keys/api/keys', {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { name },
+  })
+  expect(res.status()).toBe(201)
+  const body = await res.json()
+  return body.apiKey as { id: string; key: string; prefix: string; name: string }
+}
+
+test.describe('Programmatic API keys', () => {
+  test.beforeAll(async ({ request }) => {
+    await request.post('/auth/seed-admin').catch(() => {})
+  })
+
+  test('x-api-key authenticates an API request as the owning user', async ({ request, playwright }) => {
+    const token = await loginToken(request)
+    const key = await createKey(request, token, 'e2e-xapikey')
+    expect(key.key).toMatch(/^sk_[0-9a-f]{48}$/)
+    expect(key.prefix).toBe(key.key.slice(0, 11))
+
+    // Cookieless context: only the header can authenticate.
+    const clean = await playwright.request.newContext({ baseURL: BASE_URL })
+    const me = await clean.get('/auth/me', { headers: { 'x-api-key': key.key } })
+    expect(me.ok()).toBe(true)
+    const body = await me.json()
+    expect(body.user?.email).toBe(ADMIN_CREDENTIALS.email)
+    await clean.dispose()
+  })
+
+  test('Authorization: Bearer sk_ header also authenticates', async ({ request, playwright }) => {
+    const token = await loginToken(request)
+    const key = await createKey(request, token, 'e2e-bearer')
+
+    const clean = await playwright.request.newContext({ baseURL: BASE_URL })
+    const me = await clean.get('/auth/me', { headers: { Authorization: `Bearer ${key.key}` } })
+    expect(me.ok()).toBe(true)
+    await clean.dispose()
+  })
+
+  test('an invalid key is rejected with 401', async ({ playwright }) => {
+    const clean = await playwright.request.newContext({ baseURL: BASE_URL })
+    const me = await clean.get('/auth/me', {
+      headers: { 'x-api-key': 'sk_deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef', Accept: 'application/json' },
+    })
+    expect(me.status()).toBe(401)
+    await clean.dispose()
+  })
+
+  test('list returns metadata only — never the secret or hash', async ({ request }) => {
+    const token = await loginToken(request)
+    const created = await createKey(request, token, 'e2e-list')
+
+    const res = await request.get('/admin/plugins/api-keys/api/keys', { headers: { Authorization: `Bearer ${token}` } })
+    expect(res.ok()).toBe(true)
+    const { keys } = await res.json()
+    const mine = keys.find((k: any) => k.id === created.id)
+    expect(mine).toBeTruthy()
+    expect(mine.prefix).toBe(created.prefix)
+    expect(mine.key).toBeUndefined()
+    expect(mine.keyHash).toBeUndefined()
+    // No full secret anywhere in the listing payload.
+    expect(JSON.stringify(keys)).not.toMatch(/sk_[0-9a-f]{48}/)
+  })
+
+  test('revoking a key disables it immediately', async ({ request, playwright }) => {
+    const token = await loginToken(request)
+    const key = await createKey(request, token, 'e2e-revoke')
+
+    const clean = await playwright.request.newContext({ baseURL: BASE_URL })
+    // Works before revoke.
+    expect((await clean.get('/auth/me', { headers: { 'x-api-key': key.key } })).ok()).toBe(true)
+
+    const del = await request.delete(`/admin/plugins/api-keys/api/keys/${key.id}`, { headers: { Authorization: `Bearer ${token}` } })
+    expect(del.ok()).toBe(true)
+
+    // Rejected after revoke.
+    const after = await clean.get('/auth/me', { headers: { 'x-api-key': key.key, Accept: 'application/json' } })
+    expect(after.status()).toBe(401)
+    await clean.dispose()
+  })
+
+  test('creating a key requires authentication', async ({ playwright }) => {
+    const clean = await playwright.request.newContext({ baseURL: BASE_URL })
+    const res = await clean.post('/admin/plugins/api-keys/api/keys', { data: { name: 'nope' }, headers: { Accept: 'application/json' } })
+    expect(res.status()).toBe(401)
+    await clean.dispose()
+  })
+
+  test('admin manage page renders for an admin', async ({ request }) => {
+    await loginToken(request)
+    const res = await request.get('/admin/plugins/api-keys', { headers: { Accept: 'text/html' } })
+    expect(res.ok()).toBe(true)
+    const html = await res.text()
+    expect(html).toContain('API Keys')
+    expect(html).toContain('Create API key')
+  })
+})

--- a/tests/e2e/87-session-lifecycle.spec.ts
+++ b/tests/e2e/87-session-lifecycle.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test'
+import { ADMIN_CREDENTIALS } from './utils/test-helpers'
+
+/**
+ * Session lifecycle (Better Auth, app-wide session middleware).
+ *
+ * Mirrors Payload's auth Sessions suite: logging out destroys the session so a
+ * subsequent /auth/me is rejected, and logging out ONE session leaves other
+ * concurrent sessions for the same user untouched.
+ *
+ * Every test uses isolated request contexts so logging out here never disturbs
+ * the session cookies of parallel spec shards.
+ *
+ * Logout uses GET /auth/logout: it performs the same Better Auth server-side
+ * sign-out as the POST variant but, being a safe method, is exempt from CSRF
+ * validation — so a header-less request context can call it directly.
+ */
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8787'
+
+async function newSession(playwright: any) {
+  const ctx = await playwright.request.newContext({ baseURL: BASE_URL })
+  const res = await ctx.post('/auth/login', {
+    data: { email: ADMIN_CREDENTIALS.email, password: ADMIN_CREDENTIALS.password },
+  })
+  expect(res.ok()).toBe(true)
+  return ctx
+}
+
+// Force a JSON (not HTML-redirect) response from requireAuth, so an
+// unauthenticated /auth/me is a clean 401 rather than a 302 to the login page.
+function me(ctx: any) {
+  return ctx.get('/auth/me', { headers: { Accept: 'application/json' } })
+}
+
+test.describe('Session lifecycle', () => {
+  test.beforeAll(async ({ request }) => {
+    await request.post('/auth/seed-admin').catch(() => {})
+  })
+
+  test('logout destroys the session — /auth/me then rejects', async ({ playwright }) => {
+    const ctx = await newSession(playwright)
+
+    const before = await me(ctx)
+    expect(before.ok()).toBe(true)
+    expect((await before.json()).user?.email).toBe(ADMIN_CREDENTIALS.email)
+
+    const logout = await ctx.get('/auth/logout')
+    expect(logout.ok()).toBe(true)
+
+    const after = await me(ctx)
+    expect(after.status()).toBe(401)
+
+    await ctx.dispose()
+  })
+
+  test('logging out one session leaves a concurrent session alive', async ({ playwright }) => {
+    const a = await newSession(playwright)
+    const b = await newSession(playwright)
+
+    // Both sessions valid.
+    expect((await me(a)).ok()).toBe(true)
+    expect((await me(b)).ok()).toBe(true)
+
+    // Log out only session A.
+    expect((await a.get('/auth/logout')).ok()).toBe(true)
+
+    // A is dead, B is unaffected — sessions are independent rows.
+    expect((await me(a)).status()).toBe(401)
+    expect((await me(b)).ok()).toBe(true)
+
+    await a.dispose()
+    await b.dispose()
+  })
+
+  test('an unauthenticated context cannot reach /auth/me', async ({ playwright }) => {
+    const ctx = await playwright.request.newContext({ baseURL: BASE_URL })
+    const res = await me(ctx)
+    expect(res.status()).toBe(401)
+    await ctx.dispose()
+  })
+})


### PR DESCRIPTION
## Summary

Auth hardening review — added programmatic API keys (a genuine feature gap) and closed several test-coverage gaps on existing auth behavior.

## 🔑 API keys — new `api-keys-plugin`

`better-auth@1.6.x` ships **no** apiKey plugin (verified: has bearer/jwt/admin/two-factor, not apiKey), so this builds long-lived per-user keys on the **document model** (no new table — per the document-model rules).

- Plaintext `sk_` secret shown **once** at creation; only its SHA-256 hash is stored (`q_apikey_hash`). Tenant-scoped, expiry support, revoke = hard-erase, ownership-guarded.
- `x-api-key` / `Authorization: Bearer sk_…` resolved in the app-wide auth chain (core-wired in `app.ts`, right after the Better Auth session middleware), so existing `requireAuth`/`requireRole`/`requireRbac` guards work unchanged for headless/server-to-server clients.
- **Plugin owns the management surface:** admin manage UI + JSON API at `/admin/plugins/api-keys` (list/create/revoke, admin-scoped to the caller's own keys, enforces `maxKeysPerUser` + `defaultExpiryDays`), settings auto-form, sidebar menu. Mirrors the `security-audit-plugin` split (plugin owns UX; core wires the app-chain middleware + seeds the `api_key` doc type).

**Design note:** the resolve middleware is intentionally **not** gated on a DB `isPluginActive` flag — verified empirically that core plugins aren't seeded active on a fresh DB, so gating would silently break key-auth out of the box and add a per-request DB read. Always-on for the compiled core build; documented in the middleware.

## ✅ Test-gap closures (existing features)

- **brute-force lockout** — the detector was live in the login path with **zero coverage**. Added 14 unit tests (per-IP/email lock, sliding-window expiry, TTL auto-unlock, suspicious multi-email, alert threshold).
- **email validation** — found a real gap: Zod `.email()` *accepted* trailing-hyphen domains (`user@example-.com`). Tightened with a refine + format edge-case tests.
- **session lifecycle (e2e)** — logout destroys the session; logging out one session leaves a concurrent session alive; unauthenticated requests rejected.

## Verification

- `type-check` clean.
- **62** unit/integration tests pass (14 api-key real-SQLite, brute-force, email-validation).
- **10** e2e pass against a real wrangler server: `86-api-key-auth` (x-api-key + Bearer auth, invalid-key 401, list-hides-secret, revoke, auth-required, admin page renders) + `87-session-lifecycle`.
- Pre-existing failures in `email-plugin/on-cron-tick.test.ts` are unrelated (confirmed: fail with these changes stashed).

## Follow-ups
Remaining gaps from the review are tracked in #957–#962.

## Files

**New:** `api-keys-plugin/` (8 files incl. real-SQLite tests), `brute-force-detector.test.ts`, `tests/e2e/86-*`, `tests/e2e/87-*`.
**Modified:** `app.ts` (wire middleware + register plugin), `services/auth-validation.ts` (email refine), `services/document-types-seed.ts` (`api_key` type), `auth-validation.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)