### PR TITLE
fix(plugins): example plugin settings not reflected in API output

### DIFF
--- a/my-sonicjs-app/src/plugins/example/index.ts
+++ b/my-sonicjs-app/src/plugins/example/index.ts
@@ -124,8 +124,8 @@ export const examplePlugin = definePlugin({
     //   c) POST to /api/forms or another dedicated catch-all (plugin-provided)
     //
     // The public API is at /hello-cruel-world/* (no /api/ prefix).
-    // Pass pluginOptions by reference — onBoot() mutates it after loading DB settings.
-    app.route('/example', createExampleApiRoutes(pluginOptions) as any)
+    // Settings read from DB per-request — no options needed.
+    app.route('/example', createExampleApiRoutes() as any)
 
     // Admin routes live under /admin/*, which also has a catch-all, but user
     // plugins are mounted BEFORE the /admin catch-all, so this works fine.

--- a/my-sonicjs-app/src/plugins/example/routes/api.ts
+++ b/my-sonicjs-app/src/plugins/example/routes/api.ts
@@ -16,9 +16,25 @@
  */
 
 import { Hono } from 'hono'
-import { DocumentRepository } from '@sonicjs-cms/core'
+import { DocumentRepository, PluginServiceClass as PluginService } from '@sonicjs-cms/core'
 
 const MOODS_TYPE_ID = 'example'
+
+async function getPluginSettings(db: any): Promise<{ greeting: string; defaultName: string }> {
+  const defaults = { greeting: 'Hello, Cruel World!', defaultName: 'Stranger' }
+  if (!db) return defaults
+  try {
+    const svc = new PluginService(db)
+    const plugin = await svc.getPlugin('example')
+    const s = (plugin?.settings ?? {}) as Record<string, unknown>
+    return {
+      greeting: typeof s.greeting === 'string' ? s.greeting : defaults.greeting,
+      defaultName: typeof s.defaultName === 'string' ? s.defaultName : defaults.defaultName,
+    }
+  } catch {
+    return defaults
+  }
+}
 
 /**
  * Pick a random published mood from the DB, or null if none exist yet.
@@ -40,11 +56,10 @@ async function getRandomMood(db: any): Promise<{ name: string; emoji: string; de
 /**
  * createExampleApiRoutes — factory that returns the public API router.
  *
- * Factory pattern (vs. a plain exported Hono instance) lets you pass config from
- * the plugin into the routes without module-level globals.
- * options is passed by reference — onBoot() mutates it so handlers see live values.
+ * Settings are read from the DB on each request so changes made via the admin UI
+ * take effect immediately without waiting for a Worker isolate restart.
  */
-export function createExampleApiRoutes(options: { greeting?: string; defaultName?: string } = {}): Hono {
+export function createExampleApiRoutes(): Hono {
   const router = new Hono()
 
   // ── GET /example ────────────────────────────────────────────────────────────
@@ -52,11 +67,14 @@ export function createExampleApiRoutes(options: { greeting?: string; defaultName
   // c.env holds Cloudflare bindings (DB, KV, etc.) — accessed per-request, not at setup.
   router.get('/', async (c) => {
     const db = (c.env as any)?.DB
-    const mood = db ? await getRandomMood(db) : null
-    const name = options.defaultName ?? 'Stranger'
+    const [mood, settings] = await Promise.all([
+      db ? getRandomMood(db) : Promise.resolve(null),
+      getPluginSettings(db),
+    ])
+    const name = settings.defaultName
 
     return c.json({
-      message: `Hello, ${name}! The world is still quite cruel.`,
+      message: `${settings.greeting} I am ${name}.`,
       mood: mood ? `${mood.emoji} ${mood.name}`.trim() : null,
       moodDescription: mood?.description ?? null,
       timestamp: new Date().toISOString(),
@@ -88,12 +106,14 @@ export function createExampleApiRoutes(options: { greeting?: string; defaultName
   // Registered AFTER /moods so the literal path wins.
   router.get('/:name', async (c) => {
     const db = (c.env as any)?.DB
-    const mood = db ? await getRandomMood(db) : null
-    // c.req.param() reads the :name capture from the URL path.
+    const [mood, settings] = await Promise.all([
+      db ? getRandomMood(db) : Promise.resolve(null),
+      getPluginSettings(db),
+    ])
     const name = c.req.param('name')
 
     return c.json({
-      message: `Hello, ${name}! The world is still quite cruel.`,
+      message: `${settings.greeting} I am ${name}.`,
       mood: mood ? `${mood.emoji} ${mood.name}`.trim() : null,
       moodDescription: mood?.description ?? null,
       timestamp: new Date().toISOString(),

--- a/packages/create-app/templates/starter/src/plugins/example/routes/api.ts
+++ b/packages/create-app/templates/starter/src/plugins/example/routes/api.ts
@@ -16,9 +16,25 @@
  */
 
 import { Hono } from 'hono'
-import { DocumentRepository } from '@sonicjs-cms/core'
+import { DocumentRepository, PluginServiceClass as PluginService } from '@sonicjs-cms/core'
 
 const MOODS_TYPE_ID = 'example'
+
+async function getPluginSettings(db: any): Promise<{ greeting: string; defaultName: string }> {
+  const defaults = { greeting: 'Hello, Cruel World!', defaultName: 'Stranger' }
+  if (!db) return defaults
+  try {
+    const svc = new PluginService(db)
+    const plugin = await svc.getPlugin('example')
+    const s = (plugin?.settings ?? {}) as Record<string, unknown>
+    return {
+      greeting: typeof s.greeting === 'string' ? s.greeting : defaults.greeting,
+      defaultName: typeof s.defaultName === 'string' ? s.defaultName : defaults.defaultName,
+    }
+  } catch {
+    return defaults
+  }
+}
 
 /**
  * Pick a random published mood from the DB, or null if none exist yet.
@@ -40,11 +56,10 @@ async function getRandomMood(db: any): Promise<{ name: string; emoji: string; de
 /**
  * createExampleApiRoutes — factory that returns the public API router.
  *
- * Factory pattern (vs. a plain exported Hono instance) lets you pass config from
- * the plugin into the routes without module-level globals.
- * options is passed by reference — onBoot() mutates it so handlers see live values.
+ * Settings are read from the DB on each request so changes made via the admin UI
+ * take effect immediately without waiting for a Worker isolate restart.
  */
-export function createExampleApiRoutes(options: { greeting?: string; defaultName?: string } = {}): Hono {
+export function createExampleApiRoutes(): Hono {
   const router = new Hono()
 
   // ── GET /example ────────────────────────────────────────────────────────────
@@ -52,11 +67,14 @@ export function createExampleApiRoutes(options: { greeting?: string; defaultName
   // c.env holds Cloudflare bindings (DB, KV, etc.) — accessed per-request, not at setup.
   router.get('/', async (c) => {
     const db = (c.env as any)?.DB
-    const mood = db ? await getRandomMood(db) : null
-    const name = options.defaultName ?? 'Stranger'
+    const [mood, settings] = await Promise.all([
+      db ? getRandomMood(db) : Promise.resolve(null),
+      getPluginSettings(db),
+    ])
+    const name = settings.defaultName
 
     return c.json({
-      message: `Hello, ${name}! The world is still quite cruel.`,
+      message: `${settings.greeting} I am ${name}.`,
       mood: mood ? `${mood.emoji} ${mood.name}`.trim() : null,
       moodDescription: mood?.description ?? null,
       timestamp: new Date().toISOString(),
@@ -88,12 +106,14 @@ export function createExampleApiRoutes(options: { greeting?: string; defaultName
   // Registered AFTER /moods so the literal path wins.
   router.get('/:name', async (c) => {
     const db = (c.env as any)?.DB
-    const mood = db ? await getRandomMood(db) : null
-    // c.req.param() reads the :name capture from the URL path.
+    const [mood, settings] = await Promise.all([
+      db ? getRandomMood(db) : Promise.resolve(null),
+      getPluginSettings(db),
+    ])
     const name = c.req.param('name')
 
     return c.json({
-      message: `Hello, ${name}! The world is still quite cruel.`,
+      message: `${settings.greeting} I am ${name}.`,
       mood: mood ? `${mood.emoji} ${mood.name}`.trim() : null,
       moodDescription: mood?.description ?? null,
       timestamp: new Date().toISOString(),

--- a/tests/e2e/68-example-plugin-settings.spec.ts
+++ b/tests/e2e/68-example-plugin-settings.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test'
+import { loginAsAdmin, TEST_ORIGIN } from './utils/test-helpers'
+
+test.describe('Example plugin — settings reflected in API', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page)
+  })
+
+  test('GET /example returns greeting and defaultName from DB settings', async ({ page }) => {
+    // Update settings via admin UI
+    await page.goto('/admin/plugins/example')
+    await page.waitForSelector('#settings', { timeout: 5000 }).catch(() => {})
+    await page.goto('/admin/plugins/example#settings')
+
+    const greetingInput = page.locator('input[name="greeting"]')
+    const nameInput = page.locator('input[name="defaultName"]')
+
+    await greetingInput.fill('Greetings from test!')
+    await nameInput.fill('TestUser')
+    await page.locator('button[type="submit"]').click()
+    await page.waitForResponse(r => r.url().includes('/admin') && r.status() < 400)
+
+    // Verify API reflects updated settings
+    const res = await page.request.get(`${TEST_ORIGIN}/example`)
+    expect(res.status()).toBe(200)
+    const body = await res.json()
+    expect(body.message).toContain('Greetings from test!')
+    expect(body.message).toContain('TestUser')
+    expect(body.plugin).toBe('example')
+  })
+
+  test('GET /example/:name uses updated greeting from settings', async ({ page }) => {
+    // Read current greeting from API (after previous test may have changed it)
+    const res = await page.request.get(`${TEST_ORIGIN}/example/traveller`)
+    expect(res.status()).toBe(200)
+    const body = await res.json()
+    expect(typeof body.message).toBe('string')
+    expect(body.message).toContain('traveller')
+    expect(body.plugin).toBe('example')
+  })
+
+  test('GET /example/moods returns published moods list', async ({ page }) => {
+    const res = await page.request.get(`${TEST_ORIGIN}/example/moods`)
+    expect(res.status()).toBe(200)
+    const body = await res.json()
+    expect(Array.isArray(body.moods)).toBe(true)
+    expect(typeof body.total).toBe('number')
+  })
+})


### PR DESCRIPTION
## Summary

- `onBoot` populated `pluginOptions` once at Worker isolate warm-up; settings saved via admin UI persisted to DB but the in-memory cache was never refreshed — `GET /example` always returned stale boot-time values
- Added `getPluginSettings(db)` helper in `routes/api.ts` that reads `greeting`/`defaultName` from DB per-request (via `PluginService.getPlugin`), parallel with `getRandomMood`
- Also fixed `greeting` being declared in `configSchema` but never used in the response (was hardcoded string); now uses `${settings.greeting}`
- Removed the now-unused `options` param from `createExampleApiRoutes`
- Applied the same fix to `packages/create-app/templates/starter` so new projects get the correct behavior

## Test plan

- [ ] `GET /example` — update `defaultName` in admin settings, verify response reflects new name without Worker restart
- [ ] `GET /example/:name` — verify `greeting` from settings appears in message
- [ ] `GET /example/moods` — still returns published moods list
- [ ] E2E spec `tests/e2e/68-example-plugin-settings.spec.ts` covers all three routes and settings reflection

🤖 Generated with [Claude Code](https://claude.com/claude-code)