### PR TITLE
fix(plugins): preserve _routes when saving settings via legacy tab

### DIFF
--- a/packages/core/src/routes/admin-plugins.ts
+++ b/packages/core/src/routes/admin-plugins.ts
@@ -471,7 +471,10 @@ adminPluginRoutes.post('/:id/settings', async (c) => {
     const settings = await c.req.json()
 
     const pluginService = new PluginService(db)
-    await pluginService.updatePluginSettings(pluginId, settings)
+    // Merge with existing settings so system keys (_routes, _adminPath, etc.) are preserved.
+    const existingPlugin = await pluginService.getPlugin(pluginId)
+    const existingSettings = (existingPlugin?.settings as Record<string, unknown>) ?? {}
+    await pluginService.updatePluginSettings(pluginId, { ...existingSettings, ...settings })
 
     // Clear auth validation cache if updating core-auth plugin
     if (pluginId === 'core-auth') {

--- a/tests/e2e/91-plugin-routes-tab-persistence.spec.ts
+++ b/tests/e2e/91-plugin-routes-tab-persistence.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test'
+import { loginAsAdmin } from './utils/test-helpers'
+
+test.describe('Plugin Information tab - routes persistence', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page)
+  })
+
+  test('routes remain visible after saving settings via legacy settings tab', async ({ page }) => {
+    // Navigate to example plugin info page
+    await page.goto('/admin/plugins/example')
+    await page.waitForLoadState('networkidle')
+
+    // Confirm Information tab shows routes before any save
+    const infoTab = page.getByText('Information', { exact: true }).first()
+    await infoTab.click()
+    await expect(page.getByText('Routes')).toBeVisible()
+    await expect(page.getByText('/example')).toBeVisible()
+
+    // Go to Settings tab and save without changing anything
+    const settingsTab = page.getByRole('tab', { name: /settings/i }).first()
+    await settingsTab.click()
+    const saveBtn = page.getByRole('button', { name: /save/i }).first()
+    await saveBtn.click()
+    await page.waitForLoadState('networkidle')
+
+    // Return to Information tab — routes must still be present
+    await infoTab.click()
+    await expect(page.getByText('Routes')).toBeVisible()
+    await expect(page.getByText('/example')).toBeVisible()
+  })
+
+  test('POST /:id/settings preserves _routes in response body', async ({ page }) => {
+    // Hit the API directly and confirm _routes survives a round-trip
+    await page.goto('/admin/plugins/example')
+    await page.waitForLoadState('networkidle')
+
+    const response = await page.evaluate(async () => {
+      // Save an empty settings payload — the handler must merge, not overwrite
+      const res = await fetch('/admin/plugins/example/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ greeting: 'Hello, Cruel World!', defaultName: 'Stranger' }),
+      })
+      return res.json()
+    })
+
+    expect(response.success).toBe(true)
+
+    // Reload and verify routes still rendered
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+
+    const infoTab = page.getByText('Information', { exact: true }).first()
+    await infoTab.click()
+    await expect(page.getByText('Routes')).toBeVisible()
+    await expect(page.getByText('/example')).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary
- `POST /admin/plugins/:id/settings` was overwriting the entire settings blob without merging, wiping `_routes` and `_adminPath` that `onBoot` stores on every settings save
- Fix: fetch existing settings first, spread them, then spread submitted values on top — same pattern already used in `POST /:id/configure`
- Adds E2E spec `91-plugin-routes-tab-persistence` that verifies routes survive a settings save round-trip

## Root Cause
`admin-plugins.ts:474` called `updatePluginSettings(pluginId, settings)` with only the form-submitted keys. The `updatePluginSettings` SQL does `json_set(data, '$.settings', json(?))` — a full replacement, not a merge.

## Changes
- `packages/core/src/routes/admin-plugins.ts` — merge existing settings before writing in `POST /:id/settings`
- `tests/e2e/91-plugin-routes-tab-persistence.spec.ts` — E2E coverage for route persistence

## Testing
- [x] Fix applies to all plugins that use `_routes` pattern (future-proof)
- [x] E2E spec added verifying routes visible after settings save

🤖 Generated with [Claude Code](https://claude.com/claude-code)