### PR TITLE
fix(admin): content edit sidebar dates, author display name, and false Lexical warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sonicjs",
-  "version": "3.0.0-beta.22",
+  "version": "3.0.0-beta.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sonicjs",
-      "version": "3.0.0-beta.22",
+      "version": "3.0.0-beta.23",
       "workspaces": [
         "packages/*",
         "www",
@@ -22472,7 +22472,7 @@
     },
     "packages/create-app": {
       "name": "create-sonicjs",
-      "version": "3.0.0-beta.22",
+      "version": "3.0.0-beta.23",
       "license": "MIT",
       "dependencies": {
         "execa": "^9.6.0",

--- a/packages/core/src/routes/admin-content.ts
+++ b/packages/core/src/routes/admin-content.ts
@@ -985,6 +985,17 @@ adminContentRoutes.get('/:id/edit', async (c) => {
       if (docType && dcoll) {
         const fields = await getCollectionFields(db, dcoll.id)
         const flags = await loadContentEditorFlags(db)
+        let authorName: string | undefined
+        if (docRow.created_by) {
+          const authorRow = await db
+            .prepare("SELECT name, first_name, last_name, email FROM auth_user WHERE id = ?")
+            .bind(docRow.created_by).first() as any
+          if (authorRow) {
+            authorName = authorRow.name ||
+              [authorRow.first_name, authorRow.last_name].filter(Boolean).join(' ') ||
+              authorRow.email
+          }
+        }
         const formData: ContentFormData = {
           id: docRow.root_id,
           title: docRow.title,
@@ -999,6 +1010,7 @@ adminContentRoutes.get('/:id/edit', async (c) => {
           isEdit: true,
           referrerParams,
           versioningEnabled: docType?.settings?.versioning === true,
+          author_name: authorName,
           user: user ? { name: user.email, email: user.email, role: user.role } : undefined,
           version: c.get('appVersion'),
           ...flags,
@@ -1186,6 +1198,7 @@ adminContentRoutes.post('/', async (c) => {
 
     // Check for validation errors
     if (Object.keys(errors).length > 0) {
+      const flags = await loadContentEditorFlags(db)
       const formDataWithErrors: ContentFormData = {
         collection,
         fields,
@@ -1196,7 +1209,8 @@ adminContentRoutes.post('/', async (c) => {
           name: user.email,
           email: user.email,
           role: user.role
-        } : undefined
+        } : undefined,
+        ...flags,
       }
       if (c.req.header('HX-Request') === 'true') {
         c.header('HX-Retarget', '#content-form-page')
@@ -1428,6 +1442,7 @@ adminContentRoutes.put('/:id', async (c) => {
     const { data, errors } = extractFieldData(fields, formData)
 
     if (Object.keys(errors).length > 0) {
+      const flags = await loadContentEditorFlags(db)
       const formDataWithErrors: ContentFormData = {
         id,
         collection: collection!,
@@ -1440,7 +1455,8 @@ adminContentRoutes.put('/:id', async (c) => {
           name: user!.email,
           email: user!.email,
           role: user!.role
-        } : undefined
+        } : undefined,
+        ...flags,
       }
       if (c.req.header('HX-Request') === 'true') {
         c.header('HX-Retarget', '#content-form-page')

--- a/packages/core/src/templates/pages/admin-content-form.template.ts
+++ b/packages/core/src/templates/pages/admin-content-form.template.ts
@@ -71,6 +71,7 @@ export interface ContentFormData {
     role: string
   }
   version?: string
+  author_name?: string
 }
 
 export function renderContentFormPage(data: ContentFormData, opts?: { partialOnly?: boolean }): string {
@@ -288,20 +289,20 @@ export function renderContentFormPage(data: ContentFormData, opts?: { partialOnl
               <dl class="space-y-3 text-sm">
                 <div>
                   <dt class="text-zinc-500 dark:text-zinc-400">Created</dt>
-                  <dd class="mt-1 text-zinc-950 dark:text-white">${data.created_at ? new Date(data.created_at).toLocaleDateString() : 'Unknown'}</dd>
+                  <dd class="mt-1 text-zinc-950 dark:text-white">${data.created_at ? new Date(data.created_at * 1000).toLocaleDateString() : 'Unknown'}</dd>
                 </div>
                 <div>
                   <dt class="text-zinc-500 dark:text-zinc-400">Last Modified</dt>
-                  <dd class="mt-1 text-zinc-950 dark:text-white">${data.updated_at ? new Date(data.updated_at).toLocaleDateString() : 'Unknown'}</dd>
+                  <dd class="mt-1 text-zinc-950 dark:text-white">${data.updated_at ? new Date(data.updated_at * 1000).toLocaleDateString() : 'Unknown'}</dd>
                 </div>
                 <div>
                   <dt class="text-zinc-500 dark:text-zinc-400">Author</dt>
-                  <dd class="mt-1 text-zinc-950 dark:text-white">${data.data?.author || 'Unknown'}</dd>
+                  <dd class="mt-1 text-zinc-950 dark:text-white">${data.author_name || 'Unknown'}</dd>
                 </div>
                 ${data.published_at ? `
                   <div>
                     <dt class="text-zinc-500 dark:text-zinc-400">Published</dt>
-                    <dd class="mt-1 text-zinc-950 dark:text-white">${new Date(data.published_at).toLocaleDateString()}</dd>
+                    <dd class="mt-1 text-zinc-950 dark:text-white">${new Date(data.published_at * 1000).toLocaleDateString()}</dd>
                   </div>
                 ` : ''}
               </dl>

--- a/tests/e2e/94-content-edit-info-sidebar.spec.ts
+++ b/tests/e2e/94-content-edit-info-sidebar.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test'
+import { loginAsAdmin } from './utils/test-helpers'
+
+test.describe('Content edit - Content Info sidebar', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page)
+  })
+
+  test('dates show current year, not 1970', async ({ page }) => {
+    // Navigate to content list and open first document-backed item
+    await page.goto('/admin/content')
+    await page.waitForSelector('table tbody tr', { timeout: 10000 })
+
+    const firstEditLink = page.locator('table tbody tr a[href*="/edit"]').first()
+    await firstEditLink.click()
+    await page.waitForSelector('text=Content Info', { timeout: 10000 })
+
+    const currentYear = new Date().getFullYear().toString()
+
+    // All dates in the sidebar must show current year, not 1970
+    const createdDt = page.locator('dl dt:has-text("Created") + dd')
+    await expect(createdDt).not.toContainText('1970')
+    await expect(createdDt).toContainText(currentYear)
+
+    const modifiedDt = page.locator('dl dt:has-text("Last Modified") + dd')
+    await expect(modifiedDt).not.toContainText('1970')
+    await expect(modifiedDt).toContainText(currentYear)
+  })
+
+  test('author shows display name, not raw ID', async ({ page }) => {
+    await page.goto('/admin/content')
+    await page.waitForSelector('table tbody tr', { timeout: 10000 })
+
+    const firstEditLink = page.locator('table tbody tr a[href*="/edit"]').first()
+    await firstEditLink.click()
+    await page.waitForSelector('text=Content Info', { timeout: 10000 })
+
+    const authorDd = page.locator('dl dt:has-text("Author") + dd')
+    const authorText = await authorDd.textContent()
+
+    // Raw user IDs match pattern like "admin-<digits>-<alphanum>"
+    expect(authorText).not.toMatch(/^admin-\d+-\w+$/)
+    // Should show something meaningful (not empty, not "Unknown" if user exists)
+    expect(authorText?.trim().length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary

- Content Info sidebar was showing **1/21/1970** for Created/Modified/Published — documents store timestamps in seconds but `new Date()` expects ms; fixed by multiplying × 1000
- Author field displayed raw user ID (e.g. `admin-1782947377751-scpnsd5o3`) — now resolves display name from `auth_user` via `name` → `first_name + last_name` → `email` fallback chain
- False **"Lexical Editor plugin is inactive. Using textarea fallback."** warning appeared on validation re-render (e.g. submitting with blank Author field) — both create and legacy-edit POST validation paths were missing `loadContentEditorFlags(db)`, fixed to match the doc-backed edit path

## Changes

- `packages/core/src/routes/admin-content.ts` — fetch `auth_user` for author display name; add `loadContentEditorFlags` to create + legacy-edit validation error paths
- `packages/core/src/templates/pages/admin-content-form.template.ts` — add `author_name` to `ContentFormData`; multiply timestamps × 1000; render `author_name` instead of `data.data?.author`
- `tests/e2e/94-content-edit-info-sidebar.spec.ts` — new E2E spec verifying correct year in sidebar dates and no raw ID in author field

## Testing
- [x] Type-check passes
- [x] Lint passes (0 errors)
- [ ] E2E spec `94-content-edit-info-sidebar.spec.ts` validated by CI

## Checklist
- [x] Code follows project conventions
- [x] No new TypeScript errors introduced
- [x] E2E test added for new functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)