### PR TITLE
fix(stats): fix dashboard data parsing and display issues

### DIFF
--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -383,7 +383,7 @@ export function createSonicJSApp(config: SonicJSConfig = {}): SonicJSApp {
   app.use('*', metricsMiddleware())
 
   // Bootstrap middleware - runs migrations, syncs collections, and initializes plugins
-  app.use('*', bootstrapMiddleware(config))
+  app.use('*', bootstrapMiddleware(config, [...corePluginsBeforeCatchAll, ...corePluginsAfterCatchAll, ...(config.plugins?.register ?? [])]))
 
   // bootIsolate — extracted from the wiring middleware so it can be called from
   // both HTTP requests AND cron-first cold isolates (scheduled() handlers) that

--- a/packages/core/src/middleware/bootstrap.ts
+++ b/packages/core/src/middleware/bootstrap.ts
@@ -82,7 +82,7 @@ export function verifySecurityConfig(env: Bindings): void {
  * Bootstrap middleware that ensures system initialization
  * Runs once per worker instance
  */
-export function bootstrapMiddleware(config: SonicJSConfig = {}) {
+export function bootstrapMiddleware(config: SonicJSConfig = {}, allPlugins?: Array<{ name?: string; id?: string }>) {
   return async (c: Context<{ Bindings: Bindings; Variables: { hookSystem?: unknown } }>, next: Next) => {
     // Attach the hook system to the request BEFORE any heavy bootstrap work
     // runs, so anything that emits a hook during bootstrap (cron cold starts,
@@ -233,8 +233,9 @@ export function bootstrapMiddleware(config: SonicJSConfig = {}) {
           }
         }
 
-        // Plugin names from config
-        const activePlugins = (config.plugins?.register ?? []).map((p: any) => p.name ?? 'unknown');
+        // Plugin names — use allPlugins (all registered, including core) when available
+        const pluginSource = allPlugins ?? (config.plugins?.register ?? []) as Array<{ name?: string; id?: string }>;
+        const activePlugins = pluginSource.map((p) => p.name ?? String(p.id ?? 'unknown'));
 
         // Stable installation ID via KV (generated once, persisted)
         let installationId = 'unknown';

--- a/packages/stats/src/plugins/stats-dashboard/routes/admin.ts
+++ b/packages/stats/src/plugins/stats-dashboard/routes/admin.ts
@@ -129,13 +129,14 @@ adminRoutes.get('/', async (c) => {
        FROM documents WHERE ${EVENTS_WHERE} AND json_extract(data,'$.event_type')='installation_started'
        GROUP BY t ORDER BY count DESC`
     ).all(),
-    // 9. Install failures by errorType
+    // 9. Install failures by errorType + step + version
     db.prepare(
       `SELECT COALESCE(json_extract(data,'$.properties.errorType'), json_extract(data,'$.error_code'),'unknown') AS err,
-              COALESCE(json_extract(data,'$.step'),'-') AS step,
+              COALESCE(json_extract(data,'$.properties.step'),'-') AS step,
+              COALESCE(json_extract(data,'$.properties.version'),'-') AS version,
               COUNT(*) AS count
        FROM documents WHERE ${EVENTS_WHERE} AND json_extract(data,'$.event_type')='installation_failed'
-       GROUP BY err, step ORDER BY count DESC LIMIT 25`
+       GROUP BY err, step, version ORDER BY count DESC LIMIT 25`
     ).all(),
     // 10. Runtime errors (error_occurred) by errorType + version
     db.prepare(
@@ -145,18 +146,34 @@ adminRoutes.get('/', async (c) => {
        FROM documents WHERE ${EVENTS_WHERE} AND json_extract(data,'$.event_type')='error_occurred'
        GROUP BY err, version ORDER BY count DESC LIMIT 25`
     ).all(),
-    // 11. Top collections from project_snapshot (aggregate doc counts across installations)
+    // 11. Top collections from project_snapshot — latest snapshot per installation to avoid boot-count inflation
     db.prepare(
-      `SELECT key AS collection, SUM(CAST(value AS INTEGER)) AS total_docs, COUNT(DISTINCT json_extract(data,'$.properties.installation_id')) AS installations
-       FROM documents, json_each(json(json_extract(data,'$.properties.collection_counts')))
-       WHERE ${EVENTS_WHERE} AND json_extract(data,'$.event_type')='project_snapshot'
+      `WITH latest AS (
+         SELECT json_extract(data,'$.properties.installation_id') AS installation_id,
+                json_extract(data,'$.properties.collection_counts') AS counts_json
+         FROM documents
+         WHERE ${EVENTS_WHERE} AND json_extract(data,'$.event_type')='project_snapshot'
+         GROUP BY json_extract(data,'$.properties.installation_id')
+         HAVING created_at = MAX(created_at)
+       )
+       SELECT key AS collection,
+              SUM(CAST(value AS INTEGER)) AS total_docs,
+              COUNT(DISTINCT installation_id) AS installations
+       FROM latest, json_each(json(counts_json))
        GROUP BY key ORDER BY total_docs DESC LIMIT 20`
     ).all(),
-    // 12. Top plugins from project_snapshot (count appearances across installations)
+    // 12. Top plugins from project_snapshot — latest snapshot per installation
     db.prepare(
-      `SELECT value AS plugin, COUNT(DISTINCT json_extract(data,'$.properties.installation_id')) AS installations
-       FROM documents, json_each(json(json_extract(data,'$.properties.active_plugins')))
-       WHERE ${EVENTS_WHERE} AND json_extract(data,'$.event_type')='project_snapshot'
+      `WITH latest AS (
+         SELECT json_extract(data,'$.properties.installation_id') AS installation_id,
+                json_extract(data,'$.properties.active_plugins') AS plugins_json
+         FROM documents
+         WHERE ${EVENTS_WHERE} AND json_extract(data,'$.event_type')='project_snapshot'
+         GROUP BY json_extract(data,'$.properties.installation_id')
+         HAVING created_at = MAX(created_at)
+       )
+       SELECT value AS plugin, COUNT(DISTINCT installation_id) AS installations
+       FROM latest, json_each(json(plugins_json))
        GROUP BY value ORDER BY installations DESC LIMIT 20`
     ).all(),
     // 13. Field type histogram aggregated across all snapshots
@@ -228,7 +245,7 @@ adminRoutes.get('/', async (c) => {
     const s = t.get('installation_started') ?? 0
     const comp = t.get('installation_completed') ?? 0
     const f = t.get('installation_failed') ?? 0
-    return { week: w, started: s, completed: comp, failed: f, rate: s > 0 ? Math.round((comp / s) * 100) : 0 }
+    return { week: w, started: s, completed: comp, failed: f, rate: s > 0 ? Math.round((comp / s) * 100) : 0, avgPerDay: (comp / 7).toFixed(1) }
   })
 
   // ── Totals / KPIs ──────────────────────────────────────────────────────
@@ -265,7 +282,7 @@ adminRoutes.get('/', async (c) => {
     count: Number(r.count),
   }))
   const templateRows = rowsOf(templateR) as { t: string; count: number }[]
-  const installFailRows = rowsOf(installFailR) as { err: string; step: string; count: number }[]
+  const installFailRows = rowsOf(installFailR) as { err: string; step: string; version: string; count: number }[]
   const runtimeErrRows = rowsOf(runtimeErrR) as { err: string; version: string; count: number }[]
 
   // ── Project snapshot breakdowns ─────────────────────────────────────────
@@ -378,6 +395,7 @@ adminRoutes.get('/', async (c) => {
           <th class="py-2 text-left font-medium">Week</th>
           <th class="py-2 text-right font-medium">Started</th>
           <th class="py-2 text-right font-medium">Completed</th>
+          <th class="py-2 text-right font-medium">Avg/day</th>
           <th class="py-2 text-right font-medium">Failed</th>
           <th class="py-2 text-right font-medium">Completion %</th>
         </tr>
@@ -387,6 +405,7 @@ adminRoutes.get('/', async (c) => {
         <td class="py-2 font-mono text-zinc-700 dark:text-zinc-300">${fmtWeekDate(r.week)}</td>
         <td class="py-2 text-right text-zinc-700 dark:text-zinc-300">${r.started.toLocaleString()}</td>
         <td class="py-2 text-right text-emerald-600 dark:text-emerald-400 font-medium">${r.completed.toLocaleString()}</td>
+        <td class="py-2 text-right text-zinc-500 dark:text-zinc-400">${r.avgPerDay}</td>
         <td class="py-2 text-right ${r.failed > 0 ? 'text-red-600 dark:text-red-400' : 'text-zinc-400'}">${r.failed.toLocaleString()}</td>
         <td class="py-2 text-right"><span class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${r.rate >= 70 ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400' : r.rate >= 40 ? 'bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400' : 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400'}">${r.rate}%</span></td>
       </tr>`).join('')}
@@ -394,7 +413,20 @@ adminRoutes.get('/', async (c) => {
 
   <!-- Errors -->
   <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
-    ${card('Install Failures', 'installation_failed grouped by error + step', errTable(installFailRows.map((r) => ({ err: r.err, sub: r.step, count: Number(r.count) })), 'Step', 'No failures recorded.'))}
+    ${card('Install Failures', 'installation_failed grouped by error + step + version', installFailRows.length === 0
+      ? '<div class="py-8 text-center text-sm text-zinc-500 dark:text-zinc-400">No failures recorded.</div>'
+      : `<div class="overflow-x-auto"><table class="w-full text-sm">
+          <thead class="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+            <tr><th class="py-2 text-left font-medium">Error</th><th class="py-2 text-left font-medium">Step</th><th class="py-2 text-left font-medium">Version</th><th class="py-2 text-right font-medium">Count</th></tr>
+          </thead>
+          <tbody class="divide-y divide-zinc-950/5 dark:divide-white/5">
+          ${installFailRows.map((r) => `<tr>
+            <td class="py-2 pr-4 text-zinc-700 dark:text-zinc-300 max-w-xs break-words">${esc(r.err)}</td>
+            <td class="py-2 pr-4 font-mono text-xs text-zinc-500 dark:text-zinc-400">${esc(r.step)}</td>
+            <td class="py-2 pr-4 font-mono text-xs text-zinc-500 dark:text-zinc-400">${esc(r.version)}</td>
+            <td class="py-2 text-right font-semibold text-red-600 dark:text-red-400">${Number(r.count).toLocaleString()}</td>
+          </tr>`).join('')}
+          </tbody></table></div>`)}
     ${card('Runtime Errors', 'error_occurred grouped by error + version', errTable(runtimeErrRows.map((r) => ({ err: r.err, sub: r.version, count: Number(r.count) })), 'Version', 'No runtime errors recorded.'))}
   </div>
 

--- a/tests/e2e/97-stats-dashboard-fixes.spec.ts
+++ b/tests/e2e/97-stats-dashboard-fixes.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test'
+import { loginAsAdmin } from './utils/test-helpers'
+
+test.describe('Stats dashboard data parsing', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page)
+  })
+
+  test('dashboard renders without JS errors', async ({ page }) => {
+    const errors: string[] = []
+    page.on('pageerror', (err) => errors.push(err.message))
+
+    await page.goto('/admin/dashboard')
+    await page.waitForLoadState('networkidle')
+
+    expect(errors.filter((e) => !e.includes('Chart'))).toHaveLength(0)
+  })
+
+  test('install failures table has Step and Version columns', async ({ page }) => {
+    await page.goto('/admin/dashboard')
+    await page.waitForLoadState('networkidle')
+
+    const failuresCard = page.locator('text=Install Failures').first()
+    await expect(failuresCard).toBeVisible()
+
+    const headers = page.locator('th')
+    const headerTexts = await headers.allTextContents()
+    const normalized = headerTexts.map((t) => t.toLowerCase())
+
+    // Table should have Step and Version columns (not just Error + Count)
+    expect(normalized.some((h) => h.includes('step'))).toBe(true)
+    expect(normalized.some((h) => h.includes('version'))).toBe(true)
+  })
+
+  test('What People Build section renders when snapshot data exists', async ({ page }) => {
+    await page.goto('/admin/dashboard')
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.locator('text=What People Build')).toBeVisible()
+    // Section header is always present; charts render if data exists
+    await expect(page.locator('text=Top Collections')).toBeVisible()
+    await expect(page.locator('text=Active Plugins')).toBeVisible()
+  })
+
+  test('/v1/events accepts project_snapshot payload', async ({ request }) => {
+    const res = await request.post('/v1/events', {
+      data: {
+        data: {
+          installation_id: 'test-e2e-install',
+          event_type: 'project_snapshot',
+          properties: {
+            installation_id: 'test-e2e-install',
+            collection_names: '["test_col"]',
+            collection_counts: '{"test_col":5}',
+            active_plugins: '["Test Plugin"]',
+            field_type_histogram: '{"string":3}',
+            doc_total: 5,
+            sonicjs_version: '3.0.0-test',
+          },
+        },
+      },
+    })
+    expect(res.status()).toBe(201)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+  })
+
+  test('/v1/events accepts installation_failed with step', async ({ request }) => {
+    const res = await request.post('/v1/events', {
+      data: {
+        data: {
+          installation_id: 'test-e2e-fail',
+          event_type: 'installation_failed',
+          properties: {
+            errorType: 'Command failed with exit code 1',
+            step: 'db_migrate',
+            version: '3.0.0-test',
+          },
+        },
+      },
+    })
+    expect(res.status()).toBe(201)
+  })
+})


### PR DESCRIPTION
## Summary
- Fix install failures `step` column — was reading `$.step` (always `-`), now reads `$.properties.step`
- Add `version` column to install failures table so we can see which SonicJS version is failing
- Fix top collections `total_docs` inflation — was SUMming across every boot, now uses CTE to take latest snapshot per installation
- Fix active plugins chart with same latest-snapshot dedup
- Fix bootstrap `project_snapshot` to capture all plugins (core + user), not just user-registered ones
- Add `Avg/day` column (based on completed installs) to Weekly Breakdown table

## Test plan
- [ ] `tests/e2e/97-stats-dashboard-fixes.spec.ts` covers dashboard render, failure table columns, `/v1/events` ingestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)