### PR TITLE
fix: hide publish button when versioning plugin is disabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sonicjs",
-  "version": "3.0.0-beta.24",
+  "version": "3.0.0-beta.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sonicjs",
-      "version": "3.0.0-beta.24",
+      "version": "3.0.0-beta.23",
       "workspaces": [
         "packages/*",
         "www",
@@ -55,6 +55,8 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250620.0",
         "@types/node": "^20.19.1",
+        "drizzle-kit": "^0.30.0",
+        "drizzle-orm": "^0.45.2",
         "hono": "^4.12.26",
         "typescript": "^5.8.3",
         "vitest": "^4.1.9",
@@ -76,6 +78,23 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "my-sonicjs-app/node_modules/drizzle-kit": {
+      "version": "0.30.6",
+      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.30.6.tgz",
+      "integrity": "sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@drizzle-team/brocli": "^0.10.2",
+        "@esbuild-kit/esm-loader": "^2.5.5",
+        "esbuild": "^0.19.7",
+        "esbuild-register": "^3.5.0",
+        "gel": "^2.0.0"
+      },
+      "bin": {
+        "drizzle-kit": "bin.cjs"
       }
     },
     "my-sonicjs-app/node_modules/zod": {
@@ -5557,8 +5576,8 @@
       "version": "3.9.3",
       "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.3.tgz",
       "integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -5904,29 +5923,6 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -10655,8 +10651,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
       "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -10972,6 +10968,19 @@
         "@esbuild/win32-arm64": "0.19.12",
         "@esbuild/win32-ia32": "0.19.12",
         "@esbuild/win32-x64": "0.19.12"
+      }
+    },
+    "node_modules/esbuild-register": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.6.0.tgz",
+      "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.12 <1"
       }
     },
     "node_modules/escalade": {
@@ -12384,6 +12393,27 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gel": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/gel/-/gel-2.2.0.tgz",
+      "integrity": "sha512-q0ma7z2swmoamHQusey8ayo8+ilVdzDt4WTxSPzq/yRqvucWRfymRVMvNgmSC0XK7eNjjEZEcplxpgaNojKdmQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@petamoriken/float16": "^3.8.7",
+        "debug": "^4.3.4",
+        "env-paths": "^3.0.0",
+        "semver": "^7.6.2",
+        "shell-quote": "^1.8.1",
+        "which": "^4.0.0"
+      },
+      "bin": {
+        "gel": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
       }
     },
     "node_modules/generator-function": {
@@ -18045,8 +18075,8 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
       "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -22442,7 +22472,7 @@
     },
     "packages/create-app": {
       "name": "create-sonicjs",
-      "version": "3.0.0-beta.24",
+      "version": "3.0.0-beta.23",
       "license": "MIT",
       "dependencies": {
         "execa": "^9.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sonicjs",
-  "version": "3.0.0-beta.23",
+  "version": "3.0.0-beta.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sonicjs",
-      "version": "3.0.0-beta.23",
+      "version": "3.0.0-beta.24",
       "workspaces": [
         "packages/*",
         "www",
@@ -55,8 +55,6 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250620.0",
         "@types/node": "^20.19.1",
-        "drizzle-kit": "^0.30.0",
-        "drizzle-orm": "^0.45.2",
         "hono": "^4.12.26",
         "typescript": "^5.8.3",
         "vitest": "^4.1.9",
@@ -78,23 +76,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "my-sonicjs-app/node_modules/drizzle-kit": {
-      "version": "0.30.6",
-      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.30.6.tgz",
-      "integrity": "sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@drizzle-team/brocli": "^0.10.2",
-        "@esbuild-kit/esm-loader": "^2.5.5",
-        "esbuild": "^0.19.7",
-        "esbuild-register": "^3.5.0",
-        "gel": "^2.0.0"
-      },
-      "bin": {
-        "drizzle-kit": "bin.cjs"
       }
     },
     "my-sonicjs-app/node_modules/zod": {
@@ -5576,8 +5557,8 @@
       "version": "3.9.3",
       "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.3.tgz",
       "integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -5923,6 +5904,29 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -10651,8 +10655,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
       "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -10968,19 +10972,6 @@
         "@esbuild/win32-arm64": "0.19.12",
         "@esbuild/win32-ia32": "0.19.12",
         "@esbuild/win32-x64": "0.19.12"
-      }
-    },
-    "node_modules/esbuild-register": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.6.0.tgz",
-      "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "peerDependencies": {
-        "esbuild": ">=0.12 <1"
       }
     },
     "node_modules/escalade": {
@@ -12393,27 +12384,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gel": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/gel/-/gel-2.2.0.tgz",
-      "integrity": "sha512-q0ma7z2swmoamHQusey8ayo8+ilVdzDt4WTxSPzq/yRqvucWRfymRVMvNgmSC0XK7eNjjEZEcplxpgaNojKdmQ==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@petamoriken/float16": "^3.8.7",
-        "debug": "^4.3.4",
-        "env-paths": "^3.0.0",
-        "semver": "^7.6.2",
-        "shell-quote": "^1.8.1",
-        "which": "^4.0.0"
-      },
-      "bin": {
-        "gel": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
       }
     },
     "node_modules/generator-function": {
@@ -18075,8 +18045,8 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
       "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -22472,7 +22442,7 @@
     },
     "packages/create-app": {
       "name": "create-sonicjs",
-      "version": "3.0.0-beta.23",
+      "version": "3.0.0-beta.24",
       "license": "MIT",
       "dependencies": {
         "execa": "^9.6.0",

--- a/packages/core/src/templates/pages/admin-content-form.template.ts
+++ b/packages/core/src/templates/pages/admin-content-form.template.ts
@@ -403,7 +403,7 @@ export function renderContentFormPage(data: ContentFormData, opts?: { partialOnl
               Save & close
             </button>
 
-            ${data.user?.role !== 'viewer' ? `
+            ${data.user?.role !== 'viewer' && data.versioningEnabled ? `
               <button
                 type="submit"
                 form="content-form"


### PR DESCRIPTION
## Summary
- Publish button on content form now only renders when versioning plugin is enabled (`versioningEnabled === true`)
- Previously visible to all non-viewer roles regardless of plugin state

## Changes
- `packages/core/src/templates/pages/admin-content-form.template.ts` — added `&& data.versioningEnabled` guard to publish button condition

## Testing
- [ ] Verify publish button hidden when versioning plugin disabled
- [ ] Verify publish button visible when versioning plugin enabled and user is not viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)