### PR TITLE
fix(plugins): remove non-functional sort dropdown

### DIFF
--- a/packages/core/src/templates/pages/admin-plugins-list.template.ts
+++ b/packages/core/src/templates/pages/admin-plugins-list.template.ts
@@ -232,15 +232,6 @@ export function renderPluginsListPage(data: PluginsListPageData): string {
             </div>
 
             <div class="flex items-center gap-3 w-full sm:w-auto">
-              <select id="sort-filter" onchange="filterAndSortPlugins()" class="block w-full sm:w-auto h-9 rounded-md border-0 py-1.5 pl-3 pr-8 text-zinc-900 ring-1 ring-inset ring-zinc-300 focus:ring-2 focus:ring-inset focus:ring-zinc-600 dark:bg-zinc-900 dark:text-white dark:ring-zinc-700 dark:focus:ring-zinc-500 sm:text-sm sm:leading-6">
-                <option value="name-asc">Name (A-Z)</option>
-                <option value="name-desc">Name (Z-A)</option>
-                <option value="newest">Newest Installed</option>
-                <option value="updated">Recently Updated</option>
-                <option value="popular">Popularity</option>
-                <option value="rating">Highest Rated</option>
-              </select>
-
               <button
                 onclick="location.reload()"
                 class="inline-flex items-center gap-x-1.5 rounded-md bg-white dark:bg-zinc-900 px-3 py-1.5 h-9 text-sm font-semibold text-zinc-900 dark:text-white shadow-sm ring-1 ring-inset ring-zinc-300 dark:ring-zinc-700 hover:bg-zinc-50 dark:hover:bg-zinc-800"
@@ -404,8 +395,6 @@ export function renderPluginsListPage(data: PluginsListPageData): string {
           .forEach(cb => params.append('status', cb.value));
         const search = document.getElementById('search-input').value;
         if (search) params.set('search', search);
-        const sort = document.getElementById('sort-filter').value;
-        if (sort && sort !== 'name-asc') params.set('sort', sort);
         const url = new URL(window.location.href);
         url.search = params.toString();
         history.replaceState(null, '', url.toString());
@@ -423,8 +412,6 @@ export function renderPluginsListPage(data: PluginsListPageData): string {
         });
         const search = params.get('search');
         if (search) document.getElementById('search-input').value = search;
-        const sort = params.get('sort');
-        if (sort) document.getElementById('sort-filter').value = sort;
         if (params.toString()) filterAndSortPlugins();
       }
 
@@ -440,7 +427,6 @@ export function renderPluginsListPage(data: PluginsListPageData): string {
           .map(cb => cb.value.toLowerCase());
 
         const searchInput = document.getElementById('search-input').value.toLowerCase();
-        const sortValue = document.getElementById('sort-filter').value;
 
         const pluginsGrid = document.getElementById('plugins-grid');
         const pluginCards = Array.from(pluginsGrid.querySelectorAll('.plugin-card'));
@@ -462,30 +448,6 @@ export function renderPluginsListPage(data: PluginsListPageData): string {
           if (searchInput && !name.includes(searchInput) && !description.includes(searchInput)) return false;
           
           return true;
-        });
-
-        // Sort
-        visibleCards.sort((a, b) => {
-          const aName = a.getAttribute('data-name') || '';
-          const bName = b.getAttribute('data-name') || '';
-          const aInstalled = parseInt(a.getAttribute('data-installed') || '0');
-          const bInstalled = parseInt(b.getAttribute('data-installed') || '0');
-          const aUpdated = parseInt(a.getAttribute('data-updated') || '0');
-          const bUpdated = parseInt(b.getAttribute('data-updated') || '0');
-          const aDownloads = parseInt(a.getAttribute('data-downloads') || '0');
-          const bDownloads = parseInt(b.getAttribute('data-downloads') || '0');
-          const aRating = parseFloat(a.getAttribute('data-rating') || '0');
-          const bRating = parseFloat(b.getAttribute('data-rating') || '0');
-
-          switch (sortValue) {
-            case 'name-desc': return bName.localeCompare(aName);
-            case 'newest': return bInstalled - aInstalled;
-            case 'updated': return bUpdated - aUpdated;
-            case 'popular': return bDownloads - aDownloads;
-            case 'rating': return bRating - aRating;
-            case 'name-asc':
-            default: return aName.localeCompare(bName);
-          }
         });
 
         // Re-append


### PR DESCRIPTION
## Summary
- Remove sort dropdown from plugins screen — sort options relied on `data-installed`/`data-updated` attributes that were never set on plugin cards, making all sort operations no-ops
- Clean up dead sort JS from `filterAndSortPlugins()`, `updateURL()`, and `initFiltersFromURL()`

## Changes
- `packages/core/src/templates/pages/admin-plugins-list.template.ts` — remove `<select id="sort-filter">` and all related JS (38 lines deleted)

## Testing
- [x] No new behavior — pure removal of broken UI element

🤖 Generated with [Claude Code](https://claude.com/claude-code)