### PR TITLE
fix(bootstrap): reconcile collections on cached startup

### DIFF
--- a/packages/core/src/middleware/bootstrap.ts
+++ b/packages/core/src/middleware/bootstrap.ts
@@ -112,7 +112,10 @@ export function bootstrapMiddleware(config: SonicJSConfig = {}, allPlugins?: Arr
       if (cacheKv) {
         const kvDone = await cacheKv.get(BOOTSTRAP_KV_KEY())
         if (kvDone === '1') {
-          // Hydrate in-memory state without touching D1.
+          // Hydrate in-memory state, then reconcile code-defined collection document
+          // types. The KV marker can outlive a newly added collection while the
+          // SonicJS version stays the same, so skipping D1 entirely would leave that
+          // collection unable to use document-backed APIs such as slug checking.
           try {
             const kv = (c.env as any).CACHE_KV as KVNamespace
             const { setGlobalKVNamespace } = await import("../plugins/cache/services/cache")
@@ -124,6 +127,7 @@ export function bootstrapMiddleware(config: SonicJSConfig = {}, allPlugins?: Arr
           try {
             const configs = await loadCollectionConfigs()
             getCollectionRegistry().register(configs)
+            await autoRegisterCollectionDocumentTypes(c.env.DB)
           } catch { /* registry optional in fast-path */ }
           bootstrapComplete = true
           return next()


### PR DESCRIPTION
## Description
Reconciles code-defined collection document types when bootstrap is satisfied from the KV cache.

Fixes #1014 

## Changes
  - Register code-defined collection document types after hydrating the cached bootstrap state.
  - Restore document-backed operations, including slug availability checks, for collections added without a SonicJS version bump.

## Testing

### Unit Tests
  - [x] Existing document-type registration tests pass.
  - [x] `npm test --workspace=packages/core -- document-types-seed.test.ts`

### E2E Tests
  - [ ] Not added; this is a bootstrap-path fix with no UI changes.

## Screenshots/Videos
N/A

## Checklist
  - [x] Code follows project conventions
  - [x] Tests passing
  - [x] Type checking passes
  - [x] No console errors or warnings
  - [ ] Documentation updated (not needed)

---
Generated with Claude Code in Conductor
