### PR TITLE
feat(plugins): add API Documentation plugin (endpoint catalog + Scalar explorer + live OpenAPI spec)

### DIFF
--- a/packages/core/src/__tests__/middleware/bootstrap-fk-ordering.test.ts
+++ b/packages/core/src/__tests__/middleware/bootstrap-fk-ordering.test.ts
@@ -1,0 +1,77 @@
+// @ts-nocheck
+// Regression: the bootstrap FK-ordering guarantee (first-boot race).
+//
+// bootstrap.ts seeds system data on a fresh DB. Two kinds of step run there:
+//   PRODUCERS — bootstrapDocumentTypes / autoRegisterCollectionDocumentTypes — create
+//               `document_types` rows.
+//   CONSUMERS — RBAC seed / core-plugin bootstrap — `INSERT INTO documents`, whose
+//               `type_id` FK-references those `document_types` rows (0002_documents.sql:30).
+// The pre-fix code ran all of them in one Promise.all, so on a cold DB a consumer insert
+// could win the race against its producer and hit `FOREIGN KEY constraint failed` (each
+// step's error was caught+swallowed, leaving RBAC roles / plugins unseeded — then a KV
+// marker latched the partial state for 24h).
+//
+// The shared d1-sqlite harness disables FK enforcement (D1 doesn't reliably enforce it and
+// services delete derived rows explicitly). Here the FK IS the subject, so we turn it back
+// ON for the DB under test — it is exactly what production D1 enforced when it threw.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createTestD1 } from '../utils/d1-sqlite'
+import { DocumentsService } from '../../services/documents'
+import { bootstrapDocumentTypes } from '../../services/document-types-seed'
+
+function fkOnDb() {
+  const db = createTestD1()
+  db.raw.pragma('foreign_keys = ON') // re-enable for this test (harness default is OFF)
+  return db
+}
+
+describe('bootstrap FK ordering (first-boot race regression)', () => {
+  let db
+  beforeEach(() => { db = fkOnDb() })
+  afterEach(() => db.close())
+
+  it('reproduces the race failure: inserting a document before its type exists throws FK', async () => {
+    // CONSUMER before PRODUCER — what the pre-fix parallel batch allowed on a cold DB.
+    const svc = new DocumentsService(db, { tenantId: 'default' })
+    await expect(
+      svc.create({ typeId: 'rbac_role', data: { name: 'admin' }, publishOnCreate: true }),
+    ).rejects.toThrow(/FOREIGN KEY constraint failed/i)
+
+    // Nothing was written — this is the "roles missing after boot" symptom.
+    const n = db.raw.prepare("SELECT COUNT(*) AS n FROM documents WHERE type_id = 'rbac_role'").get().n
+    expect(n).toBe(0)
+  })
+
+  it('the fixed ordering succeeds: register document types FIRST, then insert documents', async () => {
+    // PRODUCER first (bootstrap Phase A) …
+    await bootstrapDocumentTypes(db)
+    const typeCount = db.raw
+      .prepare("SELECT COUNT(*) AS n FROM document_types WHERE id IN ('rbac_role','plugin')").get().n
+    expect(typeCount).toBe(2)
+
+    // … then the CONSUMER insert (bootstrap Phase B) no longer violates the FK.
+    const svc = new DocumentsService(db, { tenantId: 'default' })
+    const doc = await svc.create({ typeId: 'rbac_role', data: { name: 'admin' }, publishOnCreate: true })
+    expect(doc.typeId).toBe('rbac_role')
+
+    const n = db.raw.prepare("SELECT COUNT(*) AS n FROM documents WHERE type_id = 'rbac_role'").get().n
+    expect(n).toBe(1)
+  })
+
+  it('registering all producer types up front lets many document inserts land under FK enforcement', async () => {
+    await bootstrapDocumentTypes(db)
+    const svc = new DocumentsService(db, { tenantId: 'default' })
+    // A spread of system types real consumers (RBAC seed, plugin bootstrap) write.
+    for (const [typeId, data] of [
+      ['rbac_role', { name: 'editor' }],
+      ['rbac_verb', { name: 'read' }],
+      ['plugin', { name: 'core-auth' }],
+    ]) {
+      const d = await svc.create({ typeId, data, publishOnCreate: true })
+      expect(d.typeId).toBe(typeId)
+    }
+    const total = db.raw
+      .prepare("SELECT COUNT(*) AS n FROM documents WHERE type_id IN ('rbac_role','rbac_verb','plugin')").get().n
+    expect(total).toBe(3)
+  })
+})

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -41,6 +41,7 @@ import { userProfilesPlugin } from './plugins/core-plugins/user-profiles'
 import { aiSearchPlugin } from './plugins/core-plugins/ai-search-plugin'
 import { securityAuditPlugin } from './plugins/core-plugins/security-audit-plugin'
 import { securityAuditMiddleware, securityAuditApiRoutes, securityAuditAdminRoutes } from './plugins/core-plugins/security-audit-plugin'
+import { apiDocsPlugin } from './plugins/core-plugins/api-docs-plugin'
 import { apiKeysPlugin, apiKeyAuthMiddleware } from './plugins/core-plugins/api-keys-plugin'
 import { stripePlugin } from './plugins/core-plugins/stripe-plugin'
 import { formsPlugin } from './plugins/core-plugins/forms-plugin'
@@ -283,6 +284,7 @@ export function createSonicJSApp(config: SonicJSConfig = {}): SonicJSApp {
   const magicLinkPlugin = createMagicLinkAuthPlugin()
   const corePluginsBeforeCatchAll = [
     securityAuditPlugin,
+    apiDocsPlugin,
     apiKeysPlugin,
     aiSearchPlugin,
     oauthProvidersPlugin,

--- a/packages/core/src/middleware/bootstrap.ts
+++ b/packages/core/src/middleware/bootstrap.ts
@@ -20,6 +20,13 @@ type Bindings = {
 
 // Track if bootstrap has been run in this worker instance
 let bootstrapComplete = false;
+// Single-flight latch: the in-progress bootstrap promise for THIS isolate, or null.
+// `bootstrapComplete` only flips at the END of a successful run, so without this a
+// second request arriving on a cold isolate mid-bootstrap passes the completion/KV
+// checks and starts a SECOND concurrent seed — re-opening the document_types-vs-
+// documents FK window across the two runs and duplicating writes. Concurrent callers
+// await this instead.
+let bootstrapInFlight: Promise<void> | null = null;
 
 // KV key for cross-isolate bootstrap state. Version-keyed so a code deployment
 // (SONICJS_VERSION bump) automatically invalidates the cached flag and forces
@@ -152,6 +159,17 @@ export function bootstrapMiddleware(config: SonicJSConfig = {}, allPlugins?: Arr
     const gitBranch = (c.env as any).GIT_BRANCH as string | undefined;
     setBranchLabel(isLocalhost && gitBranch ? gitBranch : undefined);
 
+    // Single-flight: if another request on this cold isolate is already running the
+    // full bootstrap, await THAT run and proceed — never start a second concurrent
+    // seed. The check-and-set below is synchronous (no await between), so exactly one
+    // request wins the latch. Cleared in the `finally` at the end of the run.
+    if (bootstrapInFlight) {
+      await bootstrapInFlight;
+      return next();
+    }
+    let releaseInFlight: () => void = () => {};
+    bootstrapInFlight = new Promise<void>((resolve) => { releaseInFlight = resolve; });
+
     try {
       console.log("[Bootstrap] Starting system initialization...");
 
@@ -193,60 +211,76 @@ export function bootstrapMiddleware(config: SonicJSConfig = {}, allPlugins?: Arr
         console.error("[Bootstrap] Error populating collection registry:", error);
       }
 
-      // 3–4. Independent D1 operations — run in parallel to minimise cold-start latency.
-      // Each step has its own error handling so one failure doesn't block the others.
+      // 3–4. System-data seeding. Ordered in two phases because of a foreign-key
+      // dependency that a flat parallel batch violates on a fresh DB:
+      //   - PRODUCERS create `document_types` rows.
+      //   - CONSUMERS `INSERT INTO documents`, whose `type_id` FK-references those rows.
+      // Running all five in one Promise.all let a consumer insert win the race against
+      // its producer on a cold DB → `FOREIGN KEY constraint failed`, caught+swallowed
+      // per step, leaving RBAC roles / core plugins unseeded (see the header note).
       console.log("[Bootstrap] Registering document types and seeding system data...");
       const { RbacService } = await import("../services/rbac");
       const rbacService = new RbacService(c.env.DB, (c.env as any).CACHE_KV);
 
-      await Promise.all([
-        // 3. Register document types (idempotent)
-        bootstrapDocumentTypes(c.env.DB).catch((e) =>
-          console.error("[Bootstrap] Error registering document types:", e)
-        ),
-
-        // 3b. Make every content collection document-backed.
-        autoRegisterCollectionDocumentTypes(c.env.DB)
-          .then((auto) => {
-            if (auto.length) console.log(`[Bootstrap] Document-backed collections registered: ${auto.join(", ")}`)
-          })
-          .catch((e) => console.error("[Bootstrap] Error auto-registering collection document types:", e)),
-
-        // 2c. Repair legacy credential accounts.
-        repairMissingCredentialAccounts(c.env.DB).catch((e) =>
-          console.error("[Bootstrap] Error repairing credential accounts:", e)
-        ),
-
-        // 3a. Seed system RBAC roles/verbs/grants.
-        rbacService.ensureSystemRbacSeed().catch((e) =>
-          console.error("[Bootstrap] Error seeding RBAC documents:", e)
-        ),
-
-        // 4. Bootstrap core plugins.
-        config.plugins?.disableAll
-          ? Promise.resolve()
-          : (async () => {
-              const bootstrapService = new PluginBootstrapService(c.env.DB)
-              const needsBootstrap = await bootstrapService.isBootstrapNeeded()
-              if (needsBootstrap) {
-                console.log("[Bootstrap] Bootstrapping core plugins...")
-                await bootstrapService.bootstrapCorePlugins()
-              }
-            })().catch((e) => console.error("[Bootstrap] Error bootstrapping plugins:", e)),
-      ])
-
-      // Mark bootstrap as complete for this worker instance and persist to KV
-      // so subsequent cold-start isolates can skip the D1 work entirely.
-      bootstrapComplete = true;
-      console.log("[Bootstrap] System initialization completed");
-      try {
-        const cacheKv = (c.env as any).CACHE_KV as KVNamespace | undefined
-        if (cacheKv) {
-          // 24h TTL — long enough that hot instances never re-bootstrap, short
-          // enough that a DB reset auto-heals within a day.
-          await cacheKv.put(BOOTSTRAP_KV_KEY(), '1', { expirationTtl: 86400 })
+      // Track step failures so we never cache a PARTIAL bootstrap as "done" (below).
+      let bootstrapOk = true;
+      const runStep = async (label: string, fn: () => Promise<unknown>) => {
+        try {
+          await fn();
+        } catch (e) {
+          bootstrapOk = false;
+          console.error(`[Bootstrap] Error ${label}:`, e);
         }
-      } catch { /* KV write failure is non-fatal */ }
+      };
+
+      // Phase A — PRODUCERS: register every document type FIRST and await them, so the
+      // `document_types` rows are committed before any `documents` insert references them.
+      await runStep("registering document types", () => bootstrapDocumentTypes(c.env.DB));
+      await runStep("auto-registering collection document types", async () => {
+        const auto = await autoRegisterCollectionDocumentTypes(c.env.DB);
+        if (auto.length) console.log(`[Bootstrap] Document-backed collections registered: ${auto.join(", ")}`);
+      });
+
+      // Phase B — CONSUMERS (+ the independent credential-account repair): the types now
+      // exist, so these can safely run in parallel to keep cold-start latency low.
+      await Promise.all([
+        // Independent of document types (operates on auth `account` rows).
+        runStep("repairing credential accounts", () => repairMissingCredentialAccounts(c.env.DB)),
+
+        // Seeds system RBAC roles/verbs/grants as `documents` (FK → document_types).
+        runStep("seeding RBAC documents", () => rbacService.ensureSystemRbacSeed()),
+
+        // Bootstraps core plugins; installPlugin writes plugin `documents` (FK → document_types).
+        runStep("bootstrapping plugins", async () => {
+          if (config.plugins?.disableAll) return;
+          const bootstrapService = new PluginBootstrapService(c.env.DB);
+          if (await bootstrapService.isBootstrapNeeded()) {
+            console.log("[Bootstrap] Bootstrapping core plugins...");
+            await bootstrapService.bootstrapCorePlugins();
+          }
+        }),
+      ]);
+
+      // Mark bootstrap complete ONLY when every step succeeded. A partial bootstrap must
+      // not latch the in-memory flag or persist the KV skip marker: doing so would cache
+      // the broken state for the isolate's lifetime AND for the KV TTL (24h), so every
+      // later request/isolate skips the D1 work while roles/plugins stay missing. Leaving
+      // both unset lets the next request retry the (idempotent) bootstrap and converge
+      // once the transient condition clears.
+      if (bootstrapOk) {
+        bootstrapComplete = true;
+        console.log("[Bootstrap] System initialization completed");
+        try {
+          const cacheKv = (c.env as any).CACHE_KV as KVNamespace | undefined
+          if (cacheKv) {
+            // 24h TTL — long enough that hot instances never re-bootstrap, short
+            // enough that a DB reset auto-heals within a day.
+            await cacheKv.put(BOOTSTRAP_KV_KEY(), '1', { expirationTtl: 86400 })
+          }
+        } catch { /* KV write failure is non-fatal */ }
+      } else {
+        console.warn("[Bootstrap] System initialization completed WITH ERRORS — not caching the skip marker; the next request will retry.");
+      }
 
       // Fire project snapshot telemetry (fire-and-forget, never blocks boot)
       try {
@@ -306,6 +340,11 @@ export function bootstrapMiddleware(config: SonicJSConfig = {}, allPlugins?: Arr
     } catch (error) {
       console.error("[Bootstrap] Error during system initialization:", error);
       // Don't prevent the app from starting, but log the error
+    } finally {
+      // Release the single-flight latch so a later request can retry if this run
+      // did not mark bootstrap complete (transient failure self-heal).
+      bootstrapInFlight = null;
+      releaseInFlight();
     }
 
     // 4. Verify security configuration (outside try/catch so critical
@@ -321,6 +360,7 @@ export function bootstrapMiddleware(config: SonicJSConfig = {}, allPlugins?: Arr
  */
 export function resetBootstrap() {
   bootstrapComplete = false;
+  bootstrapInFlight = null;
 }
 
 /**

--- a/packages/core/src/plugins/core-plugins/api-docs-plugin/__tests__/admin-gate.test.ts
+++ b/packages/core/src/plugins/core-plugins/api-docs-plugin/__tests__/admin-gate.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Assembled gate tests — the plugin's security controls against a real (SQLite)
+ * D1 and live requests through the actual admin sub-app.
+ *
+ * Proves the B3 deactivate→404 gate in BOTH directions, the auth gate, and that
+ * the spec endpoint inherits both gates.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { Hono } from 'hono'
+import { apiDocsAdminRoutes, API_DOCS_PLUGIN_ID } from '../routes/admin'
+import { invalidatePluginStatusCache } from '../../../../middleware/plugin-middleware'
+import { createTestD1, type TestD1 } from '../../../../__tests__/utils/d1-sqlite'
+
+let db: TestD1
+
+const ADMIN = { userId: 'u1', email: 'admin@test.local', role: 'admin' }
+
+/** Seed the plugin's `documents` row with a given active/inactive status. */
+function seedStatus(status: 'active' | 'inactive') {
+  db.raw
+    .prepare(
+      `INSERT INTO documents (id, root_id, type_id, slug, tenant_id, is_current_draft, data)
+       VALUES (?, ?, 'plugin', ?, 'default', 1, ?)`,
+    )
+    .run('doc-apidocs', 'root-apidocs', API_DOCS_PLUGIN_ID, JSON.stringify({ status }))
+}
+
+/** Build the sub-app with an optional injected user, and make one request. */
+function request(path: string, opts: { user?: typeof ADMIN; accept?: string } = {}) {
+  const app = new Hono<{ Bindings: { DB: unknown }; Variables: { user?: typeof ADMIN } }>()
+  app.use('*', async (c, next) => {
+    if (opts.user) c.set('user', opts.user)
+    await next()
+  })
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test env binding
+  app.route('/admin/plugins/api-docs', apiDocsAdminRoutes as any)
+  return app.request(path, { headers: opts.accept ? { Accept: opts.accept } : {} }, { DB: db })
+}
+
+beforeEach(() => {
+  db = createTestD1()
+  // The per-isolate status cache is module-level; clear it so each test's seed
+  // is authoritative (the exact caveat documented on the gate).
+  invalidatePluginStatusCache(API_DOCS_PLUGIN_ID)
+})
+
+afterEach(() => {
+  db.close()
+  invalidatePluginStatusCache(API_DOCS_PLUGIN_ID)
+})
+
+describe('api-docs admin gate', () => {
+  it('404s the page when the plugin is deactivated (no active row)', async () => {
+    // no seed → not active
+    const res = await request('/admin/plugins/api-docs', { user: ADMIN })
+    expect(res.status).toBe(404)
+  })
+
+  it('404s the page when the plugin row is explicitly inactive', async () => {
+    seedStatus('inactive')
+    const res = await request('/admin/plugins/api-docs', { user: ADMIN })
+    expect(res.status).toBe(404)
+  })
+
+  it('serves the page (200) when active + authenticated', async () => {
+    seedStatus('active')
+    const res = await request('/admin/plugins/api-docs', { user: ADMIN })
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain('API Reference')
+  })
+
+  it('401s an unauthenticated request (auth gate runs first)', async () => {
+    seedStatus('active')
+    const res = await request('/admin/plugins/api-docs', { accept: 'application/json' })
+    expect(res.status).toBe(401)
+    expect(await res.json()).toMatchObject({ error: 'Authentication required' })
+  })
+
+  it('serves the OpenAPI spec (200 JSON) when active + authed', async () => {
+    seedStatus('active')
+    const res = await request('/admin/plugins/api-docs/openapi.json', { user: ADMIN })
+    expect(res.status).toBe(200)
+    const spec = (await res.json()) as { openapi: string; info: { title: string } }
+    expect(spec.openapi).toBe('3.0.0')
+    expect(spec.info.title).toBe('SonicJS AI API')
+  })
+
+  it('404s the spec when deactivated (spec inherits the gate)', async () => {
+    const res = await request('/admin/plugins/api-docs/openapi.json', { user: ADMIN })
+    expect(res.status).toBe(404)
+  })
+})

--- a/packages/core/src/plugins/core-plugins/api-docs-plugin/__tests__/api-docs-page.test.ts
+++ b/packages/core/src/plugins/core-plugins/api-docs-plugin/__tests__/api-docs-page.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { renderApiDocsPage } from '../components/api-docs-page'
+import type { RouteMetadata } from '../../../../services'
+
+const routes: RouteMetadata[] = [
+  { method: 'GET', path: '/api/content', description: 'List content', authentication: false, category: 'Content', documented: true },
+  { method: 'POST', path: '/api/content/:collection', description: 'Create', authentication: true, category: 'Content', documented: false },
+]
+
+describe('renderApiDocsPage', () => {
+  it('renders both tabs and the endpoint catalog', () => {
+    const html = renderApiDocsPage({ endpoints: routes, version: '3.0.0' })
+    expect(html).toContain('API Reference')
+    expect(html).toContain('tab-endpoints')
+    expect(html).toContain('tab-interactive')
+    expect(html).toContain('/api/content')
+    // stats: 2 total, 1 public, 1 protected
+    expect(html).toContain('Total Endpoints')
+  })
+
+  it('ESCAPES route-derived strings (N2 — no stored XSS)', () => {
+    const evil: RouteMetadata[] = [
+      { method: 'GET', path: '/api/<img src=x onerror=alert(1)>', description: '<script>alert(1)</script>', authentication: false, category: 'Content', documented: true },
+    ]
+    const html = renderApiDocsPage({ endpoints: evil })
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(html).not.toContain('<script>alert(1)</script>')
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;')
+    expect(html).not.toContain('<img src=x onerror=alert(1)>')
+  })
+
+  it('loads Scalar pinned + SRI (N1) and points it at the auth-gated spec', () => {
+    const html = renderApiDocsPage({ endpoints: routes })
+    expect(html).toContain('@scalar/api-reference@1.63.0')
+    expect(html).toContain('sha384-bnRzGcRYqM9jbXxeIbNDWWD8mNMY0p8qvmfAyfcT5S7/I6E7bsyLprA0uIP2gUu7')
+    expect(html).toContain('crossOrigin')
+    expect(html).toContain('/admin/plugins/api-docs/openapi.json')
+    // never the public core /api spec
+    expect(html).not.toContain("data-url', '/api'")
+  })
+
+  it('renders inside the shared admin chrome', () => {
+    const html = renderApiDocsPage({ endpoints: routes, user: { name: 'a@test', email: 'a@test', role: 'admin' } })
+    expect(html).toContain('<!DOCTYPE html>')
+    expect(html).toContain('SonicJS')
+  })
+
+  it('keeps data-description a well-formed attribute for undocumented routes', () => {
+    // An empty description falls back to a styled <em> in the VISIBLE <p>, but the
+    // data-description ATTRIBUTE (read by the search filter) must stay plain text —
+    // the <em class="…"> quotes would otherwise break the double-quoted attribute.
+    const undoc: RouteMetadata[] = [
+      { method: 'GET', path: '/api/x', description: '', authentication: false, category: 'Content', documented: false },
+    ]
+    const html = renderApiDocsPage({ endpoints: undoc })
+    // attribute is empty, not the <em> markup
+    expect(html).toContain('data-description=""')
+    expect(html).not.toContain('data-description="<em')
+    // the styled fallback still appears in the visible paragraph
+    expect(html).toContain('No description available')
+  })
+})

--- a/packages/core/src/plugins/core-plugins/api-docs-plugin/__tests__/openapi-builder.test.ts
+++ b/packages/core/src/plugins/core-plugins/api-docs-plugin/__tests__/openapi-builder.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { buildApiDocsOpenApiSpec } from '../services/openapi-builder'
+import type { RouteMetadata } from '../../../../services'
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const routes: RouteMetadata[] = [
+  { method: 'GET', path: '/api/content', description: 'List content', authentication: false, category: 'Content', documented: true },
+  { method: 'POST', path: '/api/content/:collection', description: 'Create in collection', authentication: true, category: 'Content', documented: true },
+  { method: 'GET', path: '/api/content/:collection/:id', description: 'Get one', authentication: 'unknown', category: 'Content', documented: true },
+  { method: 'GET', path: '/files/*', description: 'Serve file', authentication: false, category: 'Media', documented: true },
+]
+
+function spec() {
+  return buildApiDocsOpenApiSpec(routes, 'https://example.test', '3.0.0-test') as any
+}
+
+describe('buildApiDocsOpenApiSpec', () => {
+  it('produces an OpenAPI 3.0 document with SonicJS branding (de-branded)', () => {
+    const s = spec()
+    expect(s.openapi).toBe('3.0.0')
+    expect(s.info.title).toBe('SonicJS AI API')
+    expect(s.info.version).toBe('3.0.0-test')
+    expect(JSON.stringify(s)).not.toContain('Infowall')
+    expect(s.servers[0].url).toBe('https://example.test')
+    expect(s.components.securitySchemes.bearerAuth).toBeDefined()
+  })
+
+  it('converts :param to {param} and trailing /* to /{path}', () => {
+    const s = spec()
+    expect(s.paths['/api/content/{collection}']).toBeDefined()
+    expect(s.paths['/api/content/{collection}/{id}']).toBeDefined()
+    expect(s.paths['/files/{path}']).toBeDefined()
+    expect(s.paths['/api/content/:collection']).toBeUndefined()
+  })
+
+  it('attaches bearer security only to authenticated routes', () => {
+    const s = spec()
+    expect(s.paths['/api/content/{collection}'].post.security).toEqual([{ bearerAuth: [] }])
+    // public and unknown do NOT advertise auth
+    expect(s.paths['/api/content'].get.security).toBeUndefined()
+    expect(s.paths['/api/content/{collection}/{id}'].get.security).toBeUndefined()
+  })
+
+  it('adds a requestBody for POST/PUT/PATCH only', () => {
+    const s = spec()
+    expect(s.paths['/api/content/{collection}'].post.requestBody).toBeDefined()
+    expect(s.paths['/api/content'].get.requestBody).toBeUndefined()
+  })
+
+  it('declares path parameters for :param and wildcard routes', () => {
+    const s = spec()
+    const params = s.paths['/api/content/{collection}/{id}'].get.parameters
+    expect(params.map((p: any) => p.name).sort()).toEqual(['collection', 'id'])
+    expect(s.paths['/files/{path}'].get.parameters[0]).toMatchObject({ name: 'path', in: 'path', required: true })
+  })
+
+  it('builds tags from the categories in use', () => {
+    const s = spec()
+    const names = s.tags.map((t: any) => t.name)
+    expect(names).toContain('Content')
+    expect(names).toContain('Media')
+  })
+})

--- a/packages/core/src/plugins/core-plugins/api-docs-plugin/__tests__/registration.test.ts
+++ b/packages/core/src/plugins/core-plugins/api-docs-plugin/__tests__/registration.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { createSonicJSApp } from '../../../../app'
+import { apiDocsPlugin } from '../index'
+
+/**
+ * Boot-wiring regression: the plugin must be mounted into the REAL assembled
+ * app (not just unit-mountable), and its manifest must keep it active-by-default.
+ */
+describe('api-docs plugin registration', () => {
+  it('mounts /admin/plugins/api-docs into the assembled app', () => {
+    const app = createSonicJSApp()
+    const mounted = app.routes.some((r) => r.path.startsWith('/admin/plugins/api-docs'))
+    expect(mounted).toBe(true)
+  })
+
+  it('declares the definePlugin contract (id, register, menu)', () => {
+    expect(apiDocsPlugin.id).toBe('api-docs')
+    expect(typeof apiDocsPlugin.register).toBe('function')
+    expect(apiDocsPlugin.menu?.[0]?.path).toBe('/admin/plugins/api-docs')
+  })
+})

--- a/packages/core/src/plugins/core-plugins/api-docs-plugin/components/api-docs-page.ts
+++ b/packages/core/src/plugins/core-plugins/api-docs-plugin/components/api-docs-page.ts
@@ -1,0 +1,297 @@
+/**
+ * API Docs — page renderer (inside the shared admin chrome).
+ *
+ * Two tabs:
+ *   - Endpoints: the auto-discovered catalog from the core route-metadata
+ *     service (buildRouteList), grouped by category. All route-derived strings
+ *     are escaped (see SECURITY note below).
+ *   - Interactive: a Scalar explorer pointed at the plugin's own auth-gated
+ *     OpenAPI spec (/admin/plugins/api-docs/openapi.json).
+ *
+ * SECURITY (N2): route path/description/method/category are rendered ESCAPED
+ * via the core `escapeHtml`. Today these come from code-defined route patterns
+ * and the maintainer-authored registry, but escaping is unconditional so a
+ * route whose metadata ever derives from user/admin data (e.g. collection
+ * names) can never inject markup. Category titles/descriptions/icons come from
+ * CATEGORY_INFO (trusted, may contain intentional HTML entities) and are left
+ * as-is.
+ */
+import {
+  renderAdminLayoutCatalyst,
+  type AdminLayoutCatalystData,
+} from '../../../../templates/layouts/admin-layout-catalyst.template'
+import { CATEGORY_INFO, type RouteMetadata } from '../../../../services'
+import { escapeHtml } from '../../../../utils/sanitize'
+
+interface BaseUser {
+  name: string
+  email: string
+  role: string
+}
+
+export interface ApiDocsPageData {
+  endpoints: RouteMetadata[]
+  user?: BaseUser
+  version?: string
+  dynamicMenuItems?: Array<{ label: string; path: string; icon: string }>
+}
+
+const CURRENT_PATH = '/admin/plugins/api-docs'
+const SPEC_URL = '/admin/plugins/api-docs/openapi.json'
+
+// Pinned Scalar release + SRI hash (N1). Unpinned `latest` is a supply-chain
+// risk; this pins exact bytes. Self-hosting/bundling is the committed follow-up
+// (plan F1) — his app sets no CSP, so a CDN script runs unconstrained in the
+// admin session; pin+SRI is the interim floor, not the end state.
+const SCALAR_VERSION = '1.63.0'
+const SCALAR_SRC = `https://cdn.jsdelivr.net/npm/@scalar/api-reference@${SCALAR_VERSION}`
+const SCALAR_SRI = 'sha384-bnRzGcRYqM9jbXxeIbNDWWD8mNMY0p8qvmfAyfcT5S7/I6E7bsyLprA0uIP2gUu7'
+
+function renderAuthBadge(auth: boolean | 'unknown'): string {
+  if (auth === true) {
+    return `<span class="shrink-0 inline-flex items-center gap-x-1 rounded-md bg-amber-50 dark:bg-amber-500/10 px-2 py-1 text-xs font-medium text-amber-700 dark:text-amber-300 ring-1 ring-inset ring-amber-700/10 dark:ring-amber-400/20">Auth</span>`
+  }
+  if (auth === false) {
+    return `<span class="shrink-0 inline-flex items-center gap-x-1 rounded-md bg-lime-50 dark:bg-lime-500/10 px-2 py-1 text-xs font-medium text-lime-700 dark:text-lime-300 ring-1 ring-inset ring-lime-700/10 dark:ring-lime-400/20">Public</span>`
+  }
+  return `<span class="shrink-0 inline-flex items-center gap-x-1 rounded-md bg-zinc-50 dark:bg-zinc-500/10 px-2 py-1 text-xs font-medium text-zinc-500 dark:text-zinc-400 ring-1 ring-inset ring-zinc-500/10 dark:ring-zinc-400/20">Unknown</span>`
+}
+
+function renderEndpointRow(e: RouteMetadata): string {
+  const method = escapeHtml(e.method)
+  const methodClass = e.method.toLowerCase().replace(/[^a-z]/g, '')
+  const path = escapeHtml(e.path)
+  // descAttr: plain escaped text for the data-description attribute (read by the
+  // client-side search filter). descHtml: same, but with a styled <em> fallback
+  // for the visible <p>. Keep them separate — the <em class="…"> fallback's own
+  // quotes would break the double-quoted attribute if reused there.
+  const descAttr = escapeHtml(e.description)
+  const descHtml = e.description
+    ? descAttr
+    : '<em class="text-zinc-400 dark:text-zinc-500">No description available</em>'
+  return `
+    <div class="api-endpoint p-6 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors"
+         data-method="${method}"
+         data-path="${path}"
+         data-description="${descAttr}">
+      <div class="flex items-start gap-x-4">
+        <span class="method-badge method-${methodClass} shrink-0 px-3 py-1 rounded-md text-xs font-mono font-bold uppercase">${method}</span>
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-x-2 mb-2">
+            <code class="text-zinc-950 dark:text-white text-sm font-mono font-medium break-all">${path}</code>
+            ${renderAuthBadge(e.authentication)}
+            ${
+              e.documented === false
+                ? `<span class="shrink-0 inline-flex items-center rounded-md bg-zinc-50 dark:bg-zinc-800 px-2 py-1 text-xs font-medium text-zinc-400 dark:text-zinc-500 ring-1 ring-inset ring-zinc-200 dark:ring-zinc-700">Auto-discovered</span>`
+                : ''
+            }
+          </div>
+          <p class="text-zinc-600 dark:text-zinc-400 text-sm leading-6">${descHtml}</p>
+        </div>
+      </div>
+    </div>`
+}
+
+export function renderApiDocsPage(data: ApiDocsPageData): string {
+  const endpointsByCategory = data.endpoints.reduce((acc, e) => {
+    ;(acc[e.category] ??= []).push(e)
+    return acc
+  }, {} as Record<string, RouteMetadata[]>)
+  const categories = Object.keys(endpointsByCategory).sort()
+
+  const total = data.endpoints.length
+  const publicCount = data.endpoints.filter((e) => e.authentication === false).length
+  const protectedCount = data.endpoints.filter((e) => e.authentication === true).length
+  const undocumented = data.endpoints.filter((e) => e.documented === false).length
+
+  const statCard = (label: string, value: number | string, valueClass = 'text-zinc-950 dark:text-white') => `
+    <div class="rounded-lg bg-white dark:bg-zinc-900 shadow-sm ring-1 ring-zinc-950/5 dark:ring-white/10 px-6 py-5">
+      <dt class="text-sm/6 font-medium text-zinc-500 dark:text-zinc-400">${label}</dt>
+      <dd class="mt-2 flex items-baseline gap-x-2"><span class="text-4xl font-semibold tracking-tight ${valueClass}">${value}</span></dd>
+    </div>`
+
+  const content = `
+    <div class="space-y-6">
+      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 class="text-2xl/8 font-semibold text-zinc-950 dark:text-white">API Reference</h1>
+          <p class="mt-2 text-sm/6 text-zinc-500 dark:text-zinc-400">Auto-discovered documentation of all registered API endpoints, generated from the live route table.</p>
+        </div>
+        <div class="mt-4 sm:mt-0 sm:flex-none">
+          <a href="${SPEC_URL}" target="_blank" rel="noopener" class="inline-flex items-center justify-center gap-x-1.5 rounded-lg bg-zinc-950 dark:bg-white px-3.5 py-2.5 text-sm font-semibold text-white dark:text-zinc-950 hover:bg-zinc-800 dark:hover:bg-zinc-100 transition-colors shadow-sm">OpenAPI Spec</a>
+        </div>
+      </div>
+
+      <div class="border-b border-zinc-950/10 dark:border-white/10">
+        <nav class="-mb-px flex gap-x-6" aria-label="Tabs">
+          <button id="tab-endpoints" onclick="apiDocsSwitchTab('endpoints')" class="tab-btn border-b-2 border-zinc-950 dark:border-white px-1 pb-3 text-sm font-semibold text-zinc-950 dark:text-white">Endpoints</button>
+          <button id="tab-interactive" onclick="apiDocsSwitchTab('interactive')" class="tab-btn border-b-2 border-transparent px-1 pb-3 text-sm font-medium text-zinc-500 dark:text-zinc-400 hover:border-zinc-300 dark:hover:border-zinc-600 hover:text-zinc-700 dark:hover:text-zinc-300">Interactive</button>
+        </nav>
+      </div>
+
+      <div id="content-endpoints">
+        <dl class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+          ${statCard('Total Endpoints', total)}
+          ${statCard('Public', publicCount, 'text-lime-600 dark:text-lime-400')}
+          ${statCard('Protected', protectedCount, 'text-amber-600 dark:text-amber-400')}
+          ${statCard('Categories', categories.length, 'text-cyan-600 dark:text-cyan-400')}
+          ${statCard('Undocumented', undocumented, undocumented > 0 ? 'text-zinc-400 dark:text-zinc-500' : 'text-lime-600 dark:text-lime-400')}
+        </dl>
+
+        <div class="mt-6 rounded-lg bg-white dark:bg-zinc-900 shadow-sm ring-1 ring-zinc-950/5 dark:ring-white/10 px-6 py-5">
+          <div class="flex flex-col sm:flex-row sm:items-end gap-4">
+            <div class="flex-1">
+              <label class="block text-sm/6 font-medium text-zinc-950 dark:text-white mb-2">Search</label>
+              <input type="text" id="endpoint-search" placeholder="Search by path or description..." class="w-full rounded-lg bg-white dark:bg-zinc-800 px-3 py-2 text-sm text-zinc-950 dark:text-white shadow-sm ring-1 ring-inset ring-zinc-950/10 dark:ring-white/10 placeholder:text-zinc-400 dark:placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-950 dark:focus:ring-white transition-shadow" />
+            </div>
+            <div>
+              <label class="block text-sm/6 font-medium text-zinc-950 dark:text-white mb-2">Category</label>
+              <select id="category-filter" class="w-full appearance-none rounded-lg bg-white dark:bg-zinc-800 py-2 pl-3 pr-8 text-sm text-zinc-950 dark:text-white outline outline-1 -outline-offset-1 outline-zinc-950/10 dark:outline-white/10 min-w-[200px]">
+                <option value="">All Categories</option>
+                ${categories
+                  .map((c) => `<option value="${escapeHtml(c)}">${CATEGORY_INFO[c]?.title ?? escapeHtml(c)}</option>`)
+                  .join('')}
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-6 space-y-6">
+          ${categories
+            .map((category) => {
+              const info = CATEGORY_INFO[category] || { title: escapeHtml(category), description: '', icon: '&#x1f4cb;' }
+              const rows = endpointsByCategory[category]!
+              return `
+              <div class="api-category" data-category="${escapeHtml(category)}">
+                <div class="rounded-lg bg-white dark:bg-zinc-900 shadow-sm ring-1 ring-zinc-950/5 dark:ring-white/10 overflow-hidden">
+                  <div class="bg-zinc-50 dark:bg-zinc-800/50 px-6 py-4 border-b border-zinc-950/5 dark:border-white/10">
+                    <div class="flex items-center">
+                      <span class="text-2xl mr-3">${info.icon}</span>
+                      <div>
+                        <h2 class="text-lg font-semibold text-zinc-950 dark:text-white">${info.title}</h2>
+                        <p class="text-sm text-zinc-500 dark:text-zinc-400">${info.description}</p>
+                      </div>
+                      <div class="ml-auto">
+                        <span class="inline-flex items-center rounded-md bg-cyan-50 dark:bg-cyan-500/10 px-2.5 py-1 text-sm font-medium text-cyan-700 dark:text-cyan-300 ring-1 ring-inset ring-cyan-700/10 dark:ring-cyan-400/20">${rows.length} endpoint${rows.length !== 1 ? 's' : ''}</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="divide-y divide-zinc-950/5 dark:divide-white/10">
+                    ${rows.map(renderEndpointRow).join('')}
+                  </div>
+                </div>
+              </div>`
+            })
+            .join('')}
+        </div>
+
+        <div id="no-results" class="hidden mt-6 rounded-lg bg-white dark:bg-zinc-900 shadow-sm ring-1 ring-zinc-950/5 dark:ring-white/10 p-12 text-center">
+          <h3 class="text-base/7 font-semibold text-zinc-950 dark:text-white">No endpoints found</h3>
+          <p class="mt-2 text-sm/6 text-zinc-500 dark:text-zinc-400">Try adjusting your search or filter.</p>
+        </div>
+      </div>
+
+      <div id="content-interactive" class="hidden">
+        <div class="rounded-lg bg-white dark:bg-zinc-900 shadow-sm ring-1 ring-zinc-950/5 dark:ring-white/10 overflow-hidden" style="min-height: 600px;">
+          <div id="scalar-loading" class="flex items-center justify-center py-20">
+            <p class="text-sm text-zinc-500 dark:text-zinc-400">Loading interactive API explorer…</p>
+          </div>
+          <div id="scalar-container"></div>
+        </div>
+      </div>
+    </div>
+
+    <style>
+      .method-badge { min-width: 60px; text-align: center; }
+      .method-get { background-color: rgb(34 197 94); color: white; }
+      .method-post { background-color: rgb(59 130 246); color: white; }
+      .method-put { background-color: rgb(251 146 60); color: white; }
+      .method-patch { background-color: rgb(168 85 247); color: white; }
+      .method-delete { background-color: rgb(244 63 94); color: white; }
+    </style>
+
+    <script>
+      (function () {
+        var searchInput = document.getElementById('endpoint-search');
+        var categoryFilter = document.getElementById('category-filter');
+        var noResults = document.getElementById('no-results');
+
+        function filterEndpoints() {
+          var term = (searchInput.value || '').toLowerCase();
+          var selectedCategory = categoryFilter.value;
+          var cats = document.querySelectorAll('.api-category');
+          var visible = 0;
+          cats.forEach(function (cat) {
+            var catVisible = !selectedCategory || cat.dataset.category === selectedCategory;
+            var inCat = 0;
+            cat.querySelectorAll('.api-endpoint').forEach(function (ep) {
+              var hay = (ep.dataset.path + ' ' + ep.dataset.description).toLowerCase();
+              var match = catVisible && (!term || hay.indexOf(term) !== -1);
+              ep.style.display = match ? 'block' : 'none';
+              if (match) { inCat++; visible++; }
+            });
+            cat.style.display = (catVisible && inCat > 0) ? 'block' : 'none';
+          });
+          noResults.style.display = visible === 0 ? 'block' : 'none';
+        }
+        searchInput.addEventListener('input', filterEndpoints);
+        categoryFilter.addEventListener('change', filterEndpoints);
+
+        var scalarLoaded = false;
+        window.apiDocsSwitchTab = function (tab) {
+          var endpoints = document.getElementById('content-endpoints');
+          var interactive = document.getElementById('content-interactive');
+          var tabE = document.getElementById('tab-endpoints');
+          var tabI = document.getElementById('tab-interactive');
+          var active = 'tab-btn border-b-2 border-zinc-950 dark:border-white px-1 pb-3 text-sm font-semibold text-zinc-950 dark:text-white';
+          var inactive = 'tab-btn border-b-2 border-transparent px-1 pb-3 text-sm font-medium text-zinc-500 dark:text-zinc-400 hover:border-zinc-300 dark:hover:border-zinc-600 hover:text-zinc-700 dark:hover:text-zinc-300';
+          if (tab === 'endpoints') {
+            endpoints.classList.remove('hidden'); interactive.classList.add('hidden');
+            tabE.className = active; tabI.className = inactive;
+          } else {
+            endpoints.classList.add('hidden'); interactive.classList.remove('hidden');
+            tabE.className = inactive; tabI.className = active;
+            if (!scalarLoaded) loadScalar();
+          }
+        };
+
+        function loadScalar() {
+          scalarLoaded = true;
+          var container = document.getElementById('scalar-container');
+          var loading = document.getElementById('scalar-loading');
+          var el = document.createElement('div');
+          el.id = 'api-reference';
+          el.setAttribute('data-url', ${JSON.stringify(SPEC_URL)});
+          el.setAttribute('data-configuration', JSON.stringify({
+            theme: 'kepler',
+            darkMode: document.documentElement.classList.contains('dark'),
+            hideDownloadButton: false,
+            hideTestRequestButton: true,
+          }));
+          container.appendChild(el);
+          var script = document.createElement('script');
+          script.src = ${JSON.stringify(SCALAR_SRC)};
+          script.integrity = ${JSON.stringify(SCALAR_SRI)};
+          script.crossOrigin = 'anonymous';
+          script.onload = function () { if (loading) loading.style.display = 'none'; };
+          script.onerror = function () {
+            if (loading) loading.innerHTML = '<div class="text-center py-12"><p class="text-sm text-red-500">Failed to load the interactive explorer (network or integrity check).</p></div>';
+          };
+          document.head.appendChild(script);
+        }
+      })();
+    </script>
+  `
+
+  const layoutData: AdminLayoutCatalystData = {
+    title: 'API Reference',
+    pageTitle: 'API Reference',
+    currentPath: CURRENT_PATH,
+    user: data.user,
+    content,
+    version: data.version,
+    dynamicMenuItems: data.dynamicMenuItems,
+  }
+
+  return renderAdminLayoutCatalyst(layoutData)
+}

--- a/packages/core/src/plugins/core-plugins/api-docs-plugin/index.ts
+++ b/packages/core/src/plugins/core-plugins/api-docs-plugin/index.ts
@@ -1,0 +1,49 @@
+/**
+ * API Documentation Plugin
+ *
+ * Adds an interactive API reference to the admin panel:
+ *   - an auto-discovered endpoint catalog (reuses the core route-metadata
+ *     service — `buildRouteList(getAppInstance())`, the same machinery that
+ *     already backs `/admin/api-reference`);
+ *   - a Scalar API explorer;
+ *   - a live OpenAPI 3.0 spec generated from the running route table.
+ *
+ * Read-only. All routes live under `/admin/plugins/api-docs`, so they inherit
+ * the global admin gate (`requireAuth` + `requireRbac('portal','access')`);
+ * the sub-app additionally asserts auth + a deactivate→404 gate for
+ * defense-in-depth (see routes/admin.ts).
+ */
+
+import { definePlugin } from '../../sdk/define-plugin'
+import { apiDocsAdminRoutes } from './routes/admin'
+
+// Heroicons "book-open" (matches the manifest adminMenu icon).
+const API_DOCS_ICON = `<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/></svg>`
+
+export const apiDocsPlugin = definePlugin({
+  id: 'api-docs',
+  version: '1.0.0-beta.1',
+  name: 'API Documentation',
+  description:
+    'Interactive API reference — endpoint catalog, Scalar explorer, and a live OpenAPI 3.0 spec generated from the running route table.',
+  sonicjsVersionRange: '^3.0.0',
+  author: { name: 'SonicJS Team' },
+
+  register(app) {
+    app.route('/admin/plugins/api-docs', apiDocsAdminRoutes)
+  },
+
+  menu: [
+    { label: 'API Reference', path: '/admin/plugins/api-docs', icon: API_DOCS_ICON, order: 90 },
+  ],
+
+  activate: async () => console.log('[ApiDocs] Plugin activated'),
+  deactivate: async () => console.log('[ApiDocs] Plugin deactivated'),
+})
+
+export function createApiDocsPlugin() {
+  return apiDocsPlugin
+}
+
+export { apiDocsAdminRoutes } from './routes/admin'
+export default apiDocsPlugin

--- a/packages/core/src/plugins/core-plugins/api-docs-plugin/manifest.json
+++ b/packages/core/src/plugins/core-plugins/api-docs-plugin/manifest.json
@@ -1,0 +1,29 @@
+{
+  "id": "api-docs",
+  "name": "API Documentation",
+  "version": "1.0.0-beta.1",
+  "description": "Interactive API reference — an auto-discovered endpoint catalog, a Scalar API explorer, and a live OpenAPI 3.0 spec generated from the running route table.",
+  "author": "SonicJS Team",
+  "category": "developer-tools",
+  "tags": [
+    "api",
+    "docs",
+    "openapi",
+    "scalar",
+    "reference",
+    "developer-experience"
+  ],
+  "dependencies": [],
+  "permissions": {
+    "api-docs:view": "View the API reference and interactive explorer"
+  },
+  "adminMenu": {
+    "label": "API Reference",
+    "icon": "book-open",
+    "path": "/admin/plugins/api-docs",
+    "order": 90
+  },
+  "iconEmoji": "📖",
+  "is_core": true,
+  "defaultActive": true
+}

--- a/packages/core/src/plugins/core-plugins/api-docs-plugin/routes/admin.ts
+++ b/packages/core/src/plugins/core-plugins/api-docs-plugin/routes/admin.ts
@@ -1,0 +1,84 @@
+/**
+ * API Docs — admin routes (/admin/plugins/api-docs)
+ *
+ * P1 scaffold: the page shell + the security gates. The Endpoints and
+ * Interactive tabs (and the generated OpenAPI spec route) land in P2/P3.
+ */
+import { Hono } from 'hono'
+import { requireAuth } from '../../../../middleware'
+// Imported from its defining module rather than the middleware barrel, for
+// symmetry with invalidatePluginStatusCache — its cache companion, which the
+// barrel does NOT re-export. In a production bundle this resolves to the same
+// module singleton as the barrel export, so it's purely a sourcing choice; it
+// also keeps the status cache and its invalidator coherent under the test
+// runner's module resolution.
+import { isPluginActive } from '../../../../middleware/plugin-middleware'
+import { buildRouteList, getAppInstance } from '../../../../services'
+import { getCoreVersion } from '../../../../utils/version'
+import type { Bindings, Variables } from '../../../../app'
+import { renderApiDocsPage } from '../components/api-docs-page'
+import { buildApiDocsOpenApiSpec } from '../services/openapi-builder'
+
+/** Plugin id — must match manifest.json `id` and the plugins table slug. */
+export const API_DOCS_PLUGIN_ID = 'api-docs'
+
+const adminRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>()
+
+// Defense-in-depth: `/admin/*` is already globally gated by requireAuth +
+// requireRbac('portal','access'), but assert auth locally so the sub-app is
+// safe even if remounted, and so the intent is explicit at the plugin boundary.
+adminRoutes.use('*', requireAuth())
+
+// Deactivate→404 gate.
+//
+// SonicJS mounts plugin routes unconditionally and only hides the sidebar entry
+// when a plugin is deactivated (middleware/plugin-menu.ts) — the routes stay
+// reachable by direct URL. So we gate here explicitly, returning 404 (not 403)
+// to match the v3 "deactivated plugin looks absent" intent.
+//
+// Use the BOOLEAN isPluginActive(db, id) — NOT requireActivePlugin(), which
+// throws and the global onError turns into a 500.
+//
+// Caveat: isPluginActive caches plugin status per-isolate with no TTL, and
+// cache invalidation only clears the isolate that performed the toggle. So this
+// gate is best-effort across warm isolates — a toggle takes effect on new
+// isolates immediately and on a warm one when it recycles. Acceptable for a
+// read-only docs surface.
+adminRoutes.use('*', async (c, next) => {
+  if (!(await isPluginActive(c.env.DB, API_DOCS_PLUGIN_ID))) {
+    return c.notFound()
+  }
+  return next()
+})
+
+adminRoutes.get('/', (c) => {
+  const user = c.get('user')
+  const endpoints = buildRouteList(getAppInstance())
+  return c.html(
+    renderApiDocsPage({
+      endpoints,
+      user: user ? { name: user.email, email: user.email, role: user.role } : undefined,
+      version: c.get('appVersion'),
+      dynamicMenuItems: c.get('pluginMenuItems'),
+    }),
+  )
+})
+
+/**
+ * GET /admin/plugins/api-docs/openapi.json
+ *
+ * The live OpenAPI 3.0 spec, auto-generated from the running route table. Mounted
+ * on THIS sub-app deliberately, so it inherits the requireAuth + deactivate→404
+ * gates above (and the global /admin/* RBAC gate) — the spec enumerates the full
+ * admin surface, so it must never be reachable unauthenticated (cf. the core
+ * `GET /api` auth-gating decision). It also feeds the Interactive (Scalar) tab.
+ */
+adminRoutes.get('/openapi.json', (c) => {
+  const url = new URL(c.req.url)
+  const serverUrl = `${url.protocol}//${url.host}`
+  const routes = buildRouteList(getAppInstance())
+  const spec = buildApiDocsOpenApiSpec(routes, serverUrl, getCoreVersion())
+  return c.json(spec)
+})
+
+export { adminRoutes as apiDocsAdminRoutes }

--- a/packages/core/src/plugins/core-plugins/api-docs-plugin/services/openapi-builder.ts
+++ b/packages/core/src/plugins/core-plugins/api-docs-plugin/services/openapi-builder.ts
@@ -1,0 +1,135 @@
+/**
+ * OpenAPI 3.0 spec builder.
+ *
+ * The one piece SonicJS core is missing: a transform from the live route list
+ * (the core `buildRouteList(getAppInstance())` output) into an OpenAPI 3.0
+ * document. Everything upstream — route auto-discovery, the metadata registry,
+ * category + auth inference — is reused from `services/route-metadata`; this
+ * file only shapes that `RouteMetadata[]` into a spec.
+ *
+ * Pure and app-free by design (takes the already-built route list), so it can
+ * be unit-tested without an assembled app. The admin route calls
+ * `buildRouteList(getAppInstance())` and hands the result here.
+ *
+ * NOTE: this is the "thin" spec — operations carry summaries, tags, path
+ * params, a generic JSON request/response body, and per-route security. It does
+ * NOT (yet) inject per-collection field schemas from D1; that enrichment is a
+ * deliberate follow-up (see the plugin's delivery plan, F2).
+ */
+import { CATEGORY_INFO, type RouteMetadata } from '../../../../services'
+
+/** OpenAPI operation object (only the fields this builder emits). */
+interface OpenApiOperation {
+  summary: string
+  tags: string[]
+  responses: Record<string, unknown>
+  security?: Array<Record<string, string[]>>
+  parameters?: Array<Record<string, unknown>>
+  requestBody?: Record<string, unknown>
+}
+
+const BODY_METHODS = new Set(['post', 'put', 'patch'])
+
+/** `:param` → `{param}` and a trailing `/*` wildcard → `/{path}` for OpenAPI. */
+function toOpenApiPath(path: string): string {
+  return path
+    .replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, '{$1}')
+    .replace(/\/\*$/, '/{path}')
+}
+
+/** Path parameters declared in a route, in OpenAPI parameter-object form. */
+function pathParameters(path: string): Array<Record<string, unknown>> {
+  const params: Array<Record<string, unknown>> = []
+  const named = path.match(/:([a-zA-Z_][a-zA-Z0-9_]*)/g)
+  if (named) {
+    for (const p of named) {
+      params.push({ name: p.slice(1), in: 'path', required: true, schema: { type: 'string' } })
+    }
+  }
+  // Trailing wildcard becomes a single {path} segment.
+  if (/\/\*$/.test(path)) {
+    params.push({ name: 'path', in: 'path', required: true, schema: { type: 'string' } })
+  }
+  return params
+}
+
+function buildOperation(route: RouteMetadata): OpenApiOperation {
+  const method = route.method.toLowerCase()
+
+  const operation: OpenApiOperation = {
+    summary: route.description || `${route.method} ${route.path}`,
+    tags: [route.category],
+    responses: {
+      '200': {
+        description: 'Successful response',
+        content: { 'application/json': { schema: { type: 'object' } } },
+      },
+    },
+  }
+
+  // Authenticated routes advertise the bearer scheme. `'unknown'` is left open.
+  if (route.authentication === true) {
+    operation.security = [{ bearerAuth: [] }]
+  }
+
+  const params = pathParameters(route.path)
+  if (params.length > 0) {
+    operation.parameters = params
+  }
+
+  if (BODY_METHODS.has(method)) {
+    operation.requestBody = {
+      content: { 'application/json': { schema: { type: 'object' } } },
+    }
+  }
+
+  return operation
+}
+
+/**
+ * Build an OpenAPI 3.0 document from the live route list.
+ *
+ * @param routes    result of `buildRouteList(getAppInstance())`
+ * @param serverUrl origin the spec is served from (for the `servers` block)
+ * @param version   SonicJS core version (for `info.version`)
+ */
+export function buildApiDocsOpenApiSpec(
+  routes: RouteMetadata[],
+  serverUrl: string,
+  version: string,
+): object {
+  // Tags from the categories actually in use, enriched from CATEGORY_INFO.
+  const tagSet = new Set<string>()
+  for (const r of routes) tagSet.add(r.category)
+  const tags = Array.from(tagSet)
+    .sort()
+    .map((name) => ({ name, description: CATEGORY_INFO[name]?.description ?? '' }))
+
+  // Paths: group operations by OpenAPI-shaped path.
+  const paths: Record<string, Record<string, unknown>> = {}
+  for (const route of routes) {
+    const openApiPath = toOpenApiPath(route.path)
+    if (!paths[openApiPath]) paths[openApiPath] = {}
+    paths[openApiPath]![route.method.toLowerCase()] = buildOperation(route)
+  }
+
+  return {
+    openapi: '3.0.0',
+    info: {
+      title: 'SonicJS AI API',
+      version,
+      description:
+        'RESTful API for SonicJS — a modern, AI-powered headless CMS built on Cloudflare Workers. Auto-discovered from the registered route table.',
+      contact: { name: 'SonicJS Support', url: `${serverUrl}/docs`, email: 'support@sonicjs.com' },
+      license: { name: 'MIT', url: 'https://opensource.org/licenses/MIT' },
+    },
+    servers: [{ url: serverUrl, description: 'Current server' }],
+    tags,
+    paths,
+    components: {
+      securitySchemes: {
+        bearerAuth: { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+      },
+    },
+  }
+}

--- a/packages/core/src/plugins/core-plugins/index.ts
+++ b/packages/core/src/plugins/core-plugins/index.ts
@@ -46,6 +46,8 @@ export { versioningPlugin, createVersioningPlugin } from './versioning-plugin'
 export { mcpPlugin, createMcpPlugin } from './mcp-plugin'
 export type { McpConfigInput, McpConfig } from './mcp-plugin'
 export { menuPlugin, createMenuPlugin } from './menu-plugin'
+export { apiDocsPlugin, createApiDocsPlugin } from './api-docs-plugin'
+export { buildApiDocsOpenApiSpec } from './api-docs-plugin/services/openapi-builder'
 
 // Core plugins list - now imported from auto-generated registry
 export const CORE_PLUGIN_IDS = [
@@ -70,6 +72,7 @@ export const CORE_PLUGIN_IDS = [
   'multi-tenant',
   'versioning',
   'menu',
+  'api-docs',
 ] as const
 
 export type CorePluginNames = (typeof CORE_PLUGIN_IDS)[number]

--- a/packages/core/src/plugins/manifest-registry.ts
+++ b/packages/core/src/plugins/manifest-registry.ts
@@ -70,6 +70,30 @@ export const PLUGIN_REGISTRY: Record<string, PluginRegistryEntry> = {
     }
   },
 
+  'api-docs': {
+    "id": "api-docs",
+    "codeName": "api-docs",
+    "displayName": "API Documentation",
+    "description": "Interactive API reference — an auto-discovered endpoint catalog, a Scalar API explorer, and a live OpenAPI 3.0 spec generated from the running route table.",
+    "version": "1.0.0-beta.1",
+    "author": "SonicJS Team",
+    "category": "developer-tools",
+    "iconEmoji": "📖",
+    "is_core": true,
+    "defaultActive": true,
+    "permissions": [
+      "api-docs:view"
+    ],
+    "dependencies": [],
+    "defaultSettings": {},
+    "adminMenu": {
+      "label": "API Reference",
+      "icon": "book-open",
+      "path": "/admin/plugins/api-docs",
+      "order": 90
+    }
+  },
+
   'api-keys': {
     "id": "api-keys",
     "codeName": "api-keys",


### PR DESCRIPTION
## Description

Adds an **API Documentation** core plugin: an interactive API reference in the admin panel, backed by a live OpenAPI 3.0 spec generated from the running route table.

SonicJS already ships the *endpoints-list* half of this (the `route-metadata` service + `/admin/api-reference` page), and a hand-written static `GET /api` spec (8 paths). This plugin adds the two missing pieces on top of that existing machinery — an **auto-generating OpenAPI builder** over the real ~130-route surface, and an embedded **Scalar** explorer — packaged as a deactivatable core plugin rather than core surgery.

Fixes # <!-- N/A — new feature contribution -->

## Changes

**New plugin** (`packages/core/src/plugins/core-plugins/api-docs-plugin/`, additive):
- `services/openapi-builder.ts` — a pure transform from the core `buildRouteList()` output into an OpenAPI 3.0 document (`:param`→`{param}`, `/*`→`/{path}`, bearer security on authenticated routes, request bodies for POST/PUT/PATCH, tags from `CATEGORY_INFO`). SonicJS-branded. Reuses the existing `route-metadata` registry — no duplicate service.
- `routes/admin.ts` — the admin sub-app: the API Reference page and `GET /admin/plugins/api-docs/openapi.json` (the live spec).
- `components/api-docs-page.ts` — a two-tab page rendered in the shared `renderAdminLayoutCatalyst` chrome:
  - **Endpoints** — auto-discovered catalog grouped by category, with search + category filter and stats. All route-derived strings are HTML-escaped.
  - **Interactive** — a Scalar explorer, lazy-loaded, pointed at the plugin's own spec.
- `manifest.json` + `index.ts` (`definePlugin`) — mirrors the `security-audit-plugin` conventions; ships active by default (`is_core: true` + `defaultActive: true`).
- `__tests__/` — 19 tests (builder, page/escaping, admin gate, registration).

**Wiring** (3 files):
- `app.ts` — registered in `corePluginsBeforeCatchAll`.
- `plugins/core-plugins/index.ts` — export + added to `CORE_PLUGIN_IDS`.
- `plugins/manifest-registry.ts` — regenerated to include the plugin (purely additive; the manual `core-cache` `defaultActive` override is preserved).

**Security posture:**
- All plugin routes live under `/admin/plugins/api-docs/*`, so they inherit the global `requireAuth` + `requireRbac('portal','access')` gate. The generated spec enumerates the admin surface, so it must never be public — verified: **unauthenticated → `401`, no spec content leaked**; the ~23 `/admin/*` paths in the spec are reachable **only** by an authenticated admin. The existing public `GET /api` stub is untouched.
- The sub-app adds `requireAuth` (defense-in-depth) and a **deactivate→404** gate — `isPluginActive() → c.notFound()` (the boolean helper, not the throwing one that would 500). Best-effort across warm isolates (the per-isolate status cache is documented in-code).
- Scalar is pinned to an exact version with a Subresource Integrity (SRI) hash + `crossorigin`, not an unpinned `latest`.

## Testing

### Unit Tests
- [x] Added/updated unit tests — 19 plugin tests (OpenAPI builder shape/branding/params/security; page rendering incl. an XSS-escaping probe; admin gate: deactivate→404 both directions, unauth→401, active→200, spec inherits the gate; boot-registration into the assembled app).
- [x] All unit tests passing — **210 passed** (this plugin's 19 + the existing `__tests__/plugins` suite of 191, i.e. no boot/wiring regression). `tsc --noEmit`: **0 errors**.

### E2E Tests
- [ ] Added/updated E2E tests — N/A (admin-only UI; behaviour is covered by the assembled gate tests against real SQLite D1).
- [ ] All E2E tests passing

### Manual / live verification
Booted locally (`wrangler dev --local`) on a greenfield D1: the plugin auto-activates (`defaultActive`), the API Reference page renders both tabs, the Scalar explorer loads the live spec, and the gate holds (unauthenticated spec fetch → `401`, deactivated → `404`).

## Screenshots/Videos

**Endpoints tab** — auto-discovered catalog, categorized, with stats + filters:

<img width="1568" height="559" alt="screenshot-1784854570448-1" src="https://github.com/user-attachments/assets/550a1de6-0e8e-484f-b90c-8ed8a1bfee3f" />


**Interactive tab** — Scalar explorer over the live OpenAPI spec:

<img width="1568" height="559" alt="screenshot-1784854609638-2" src="https://github.com/user-attachments/assets/7c843637-0d5f-42c2-be0c-5308a0242229" />


## Checklist
- [x] Code follows project conventions (mirrors the `security-audit-plugin` structure; `definePlugin`; permissions in `manifest.json`; renders in `renderAdminLayoutCatalyst`)
- [x] Tests added/updated and passing
- [x] Type checking passes (`tsc --noEmit` = 0)
- [x] No console errors or warnings
- [ ] Documentation updated (if needed)

## Notes for reviewers
- The generated spec is currently the "thin" shape (summaries, tags, path params, generic JSON bodies, per-route security). Injecting per-collection field schemas from D1 is a deliberate follow-up.
- The plugin leaves the existing public `GET /api` stub as-is; a future option is to have it serve the generated spec, but that changes a public route and is out of scope here.
