### PR TITLE
Fix: plugins not visible

### DIFF
--- a/packages/core/src/__tests__/routes/admin-plugins.test.ts
+++ b/packages/core/src/__tests__/routes/admin-plugins.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { Hono } from 'hono'
 import { adminPluginRoutes } from '../../routes/admin-plugins'
+import { setPluginDefinitions, resetPluginDefinitions } from '../../services/plugin-definition-registry'
 
 // Helper to create mock user with specific role
 const createMockUser = (role: string = 'admin') => ({
@@ -62,6 +63,19 @@ const createDefaultPlugins = () => [
     rating: 5.0
   }
 ]
+
+// A definePlugin()-style plugin definition, as populated into the
+// plugin-definition-registry by setPluginDefinitions() at app construction.
+const createDefinedPlugin = (overrides: Record<string, any> = {}) => ({
+  id: 'example-plugin',
+  name: 'example-plugin',
+  version: '1.0.0',
+  description: 'A user plugin registered via definePlugin',
+  author: { name: 'Acme', email: 'acme@example.com' },
+  capabilities: [],
+  dependencies: [],
+  ...overrides,
+})
 
 // Mock the requireAuth middleware to bypass authentication in tests
 vi.mock('../../middleware', () => ({
@@ -172,6 +186,7 @@ describe('Admin Plugins Routes', () => {
     vi.clearAllMocks()
     mockEnv = createMockEnv()
     mockUserRole = 'admin'
+    resetPluginDefinitions()
 
     // Reset all mock functions
     mockGetAllPlugins = vi.fn().mockResolvedValue(createDefaultPlugins())
@@ -648,4 +663,82 @@ describe('Admin Plugins Routes', () => {
   // Note: formatLastUpdated is tested implicitly through the plugin list page tests.
   // Direct unit tests for formatLastUpdated would require exporting the function,
   // which is currently a private helper in admin-plugins.ts
+
+  describe('definePlugin-registered plugins (no manifest.json)', () => {
+    it('includes an installed definePlugin plugin that has a DB record', async () => {
+      setPluginDefinitions([createDefinedPlugin()])
+
+      mockGetAllPlugins = vi.fn().mockResolvedValue([
+        ...createDefaultPlugins(),
+        {
+          id: 'example-plugin',
+          name: 'example-plugin',
+          display_name: 'Example Plugin',
+          description: 'A user plugin registered via definePlugin',
+          version: '1.0.0',
+          author: 'Acme',
+          category: 'utilities',
+          icon: '🚀',
+          status: 'active',
+          is_core: false,
+          permissions: [],
+          dependencies: [],
+          installed_at: Date.now(),
+          last_updated: Math.floor(Date.now() / 1000),
+          download_count: 0,
+          rating: 0
+        }
+      ])
+
+      const res = await app.request('/admin/plugins', { method: 'GET' })
+
+      expect(res.status).toBe(200)
+      const html = await res.text()
+      expect(html).toContain('Example Plugin')
+      expect(html).toContain('data-status="active"')
+    })
+
+    it('shows an uninstalled definePlugin plugin as an available plugin', async () => {
+      setPluginDefinitions([createDefinedPlugin()])
+
+      // mockGetAllPlugins still returns only the default (email/auth) plugins
+      const res = await app.request('/admin/plugins', { method: 'GET' })
+
+      expect(res.status).toBe(200)
+      const html = await res.text()
+      expect(html).toContain('example-plugin')
+      expect(html).toContain('data-status="uninstalled"')
+    })
+
+    it('installs a definePlugin plugin that is not in the manifest registry', async () => {
+      setPluginDefinitions([createDefinedPlugin()])
+
+      const res = await app.request('/admin/plugins/install', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'example-plugin' })
+      })
+
+      expect(res.status).toBe(200)
+      const json = await res.json()
+      expect(json.success).toBe(true)
+      expect(mockInstallPlugin).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'example-plugin',
+        display_name: 'example-plugin',
+        is_core: false
+      }))
+    })
+
+    it('returns 404 for an unknown plugin even when definitions exist', async () => {
+      setPluginDefinitions([createDefinedPlugin()])
+
+      const res = await app.request('/admin/plugins/install', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'unknown-plugin' })
+      })
+
+      expect(res.status).toBe(404)
+    })
+  })
 })

--- a/packages/core/src/routes/admin-plugins.ts
+++ b/packages/core/src/routes/admin-plugins.ts
@@ -5,7 +5,9 @@ import { renderPluginSettingsPage, PluginSettingsPageData } from '../templates/p
 import { SettingsService } from '../services/settings'
 import { PluginService } from '../services'
 import { PLUGIN_REGISTRY, findPluginByCodeName } from '../plugins/manifest-registry'
-import { getPluginDefinition } from '../services/plugin-definition-registry'
+import type { PluginRegistryEntry } from '../plugins/manifest-registry'
+import { getPluginDefinition, getAllPluginDefinitions } from '../services/plugin-definition-registry'
+import type { RegisterablePlugin } from '../plugins/sdk/register-plugins'
 import { getUserProfileConfig } from '../plugins/core-plugins/user-profiles'
 import {
   renderSchemaFields,
@@ -20,22 +22,70 @@ const adminPluginRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>
 // Apply authentication middleware
 adminPluginRoutes.use('*', requireAuth())
 
-// Build available plugins list from the auto-generated registry.
-// To add a new plugin to this list, create a manifest.json in the plugin directory
-// and run: node packages/scripts/generate-plugin-registry.mjs
-const AVAILABLE_PLUGINS = Object.values(PLUGIN_REGISTRY).map(p => ({
-  id: p.id,
-  name: p.codeName,
-  display_name: p.displayName,
-  description: p.description,
-  version: p.version,
-  author: p.author,
-  category: p.category,
-  icon: p.iconEmoji,
-  permissions: p.permissions,
-  dependencies: p.dependencies,
-  is_core: p.is_core
-}))
+// Build the available plugins list from the manifest registry (core plugins)
+// PLUS code-registered definePlugin plugins. The latter is computed per-request
+// because setPluginDefinitions() runs at app construction, after module import.
+// Without it, active user plugins with DB records (via ensurePlugin) were
+// silently filtered out of the admin list because they never enter PLUGIN_REGISTRY.
+function getAvailablePlugins() {
+  const registryPlugins = Object.values(PLUGIN_REGISTRY).map(p => ({
+    id: p.id,
+    name: p.codeName,
+    display_name: p.displayName,
+    description: p.description,
+    version: p.version,
+    author: p.author,
+    category: p.category,
+    icon: p.iconEmoji,
+    permissions: p.permissions,
+    dependencies: p.dependencies,
+    is_core: p.is_core
+  }))
+
+  // definePlugin-registered plugins with no manifest entry (registry wins on overlap).
+  const definedPlugins = getAllPluginDefinitions()
+    .filter(p => !PLUGIN_REGISTRY[p.id])
+    .map(p => {
+      const d = p as { description?: string; author?: string | { name?: string }; category?: string; iconEmoji?: string; permissions?: string[] }
+      return {
+        id: p.id,
+        name: p.name ?? p.id,
+        display_name: p.name ?? p.id,
+        description: d.description ?? '',
+        version: p.version,
+        author: typeof d.author === 'object' ? d.author?.name ?? '' : (d.author ?? ''),
+        category: d.category ?? 'general',
+        icon: d.iconEmoji ?? '🔌',
+        permissions: d.permissions ?? [],
+        dependencies: p.dependencies ?? [],
+        is_core: false
+      }
+    })
+
+  return [...registryPlugins, ...definedPlugins]
+}
+
+// Convert a code-registered (definePlugin) plugin to the registry-entry shape
+// used by the install route, so the install handler keeps a single contract.
+function toRegistryEntry(p: RegisterablePlugin | undefined): PluginRegistryEntry | undefined {
+  if (!p) return undefined
+  const d = p as { description?: string; author?: string | { name?: string }; category?: string; iconEmoji?: string; permissions?: string[] }
+  return {
+    id: p.id,
+    codeName: p.name ?? p.id,
+    displayName: p.name ?? p.id,
+    description: d.description ?? '',
+    version: p.version,
+    author: typeof d.author === 'object' ? d.author?.name ?? '' : (d.author ?? ''),
+    category: d.category ?? 'general',
+    iconEmoji: d.iconEmoji ?? '🔌',
+    is_core: false,
+    permissions: d.permissions ?? [],
+    dependencies: p.dependencies ?? [],
+    defaultSettings: {},
+    adminMenu: null,
+  }
+}
 
 // Plugin list page
 adminPluginRoutes.get('/', async (c) => {
@@ -64,6 +114,7 @@ adminPluginRoutes.get('/', async (c) => {
     }
 
     // Filter out DB records whose IDs no longer exist in the registry (e.g. renamed plugins)
+    const AVAILABLE_PLUGINS = getAvailablePlugins()
     const registryIds = new Set(AVAILABLE_PLUGINS.map(p => p.id))
     const validInstalledPlugins = installedPlugins.filter(p => registryIds.has(p.id))
 
@@ -404,8 +455,9 @@ adminPluginRoutes.post('/:id/deactivate', async (c) => {
   }
 })
 
-// Generic install handler - uses the auto-generated plugin registry.
-// No per-plugin switch/case needed. Adding a manifest.json is enough.
+// Generic install handler - looks up the auto-generated plugin registry AND
+// code-registered (definePlugin) definitions. No per-plugin switch/case needed.
+// Adding a manifest.json is enough for registry-backed plugins.
 adminPluginRoutes.post('/install', async (c) => {
   try {
     const user = c.get('user')
@@ -419,11 +471,16 @@ adminPluginRoutes.post('/install', async (c) => {
     const body = await c.req.json()
     const pluginService = new PluginService(db)
 
-    // Look up plugin in registry by codeName (what the frontend sends as body.name)
-    // or by id
+    // Look up plugin by codeName (what the frontend sends as body.name) or by id,
+    // across BOTH the manifest registry and code-registered (definePlugin) plugins.
     const registryEntry = findPluginByCodeName(body.name)
       || PLUGIN_REGISTRY[body.name]
       || PLUGIN_REGISTRY[body.id]
+      || toRegistryEntry(
+          getAllPluginDefinitions()
+            .filter(p => !PLUGIN_REGISTRY[p.id])
+            .find(p => p.id === body.name || p.id === body.id)
+        )
 
     if (!registryEntry) {
       return c.json({ error: 'Plugin not found in registry' }, 404)

--- a/packages/core/src/routes/admin-plugins.ts
+++ b/packages/core/src/routes/admin-plugins.ts
@@ -22,11 +22,27 @@ const adminPluginRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>
 // Apply authentication middleware
 adminPluginRoutes.use('*', requireAuth())
 
+// Fields that exist on RegisterablePlugin at runtime but aren't in the
+// structural type (they come from definePlugin's options bag, not MountablePlugin).
+type DefinedPluginExtras = {
+  description?: string
+  author?: string | { name?: string }
+  category?: string
+  iconEmoji?: string
+  permissions?: string[]
+}
+
+function resolveAuthor(d: DefinedPluginExtras): string {
+  return typeof d.author === 'object' ? d.author?.name ?? '' : (d.author ?? '')
+}
+
+function getDefinedPlugins(): ReadonlyArray<RegisterablePlugin> {
+  return getAllPluginDefinitions().filter(p => !PLUGIN_REGISTRY[p.id])
+}
+
 // Build the available plugins list from the manifest registry (core plugins)
-// PLUS code-registered definePlugin plugins. The latter is computed per-request
-// because setPluginDefinitions() runs at app construction, after module import.
-// Without it, active user plugins with DB records (via ensurePlugin) were
-// silently filtered out of the admin list because they never enter PLUGIN_REGISTRY.
+// PLUS code-registered definePlugin plugins. Computed per-request because
+// setPluginDefinitions() runs at app construction, after module import.
 function getAvailablePlugins() {
   const registryPlugins = Object.values(PLUGIN_REGISTRY).map(p => ({
     id: p.id,
@@ -42,18 +58,16 @@ function getAvailablePlugins() {
     is_core: p.is_core
   }))
 
-  // definePlugin-registered plugins with no manifest entry (registry wins on overlap).
-  const definedPlugins = getAllPluginDefinitions()
-    .filter(p => !PLUGIN_REGISTRY[p.id])
+  const definedPlugins = getDefinedPlugins()
     .map(p => {
-      const d = p as { description?: string; author?: string | { name?: string }; category?: string; iconEmoji?: string; permissions?: string[] }
+      const d = p as DefinedPluginExtras
       return {
         id: p.id,
         name: p.name ?? p.id,
-        display_name: p.name ?? p.id,
+        display_name: p.displayName ?? p.name ?? p.id,
         description: d.description ?? '',
         version: p.version,
-        author: typeof d.author === 'object' ? d.author?.name ?? '' : (d.author ?? ''),
+        author: resolveAuthor(d),
         category: d.category ?? 'general',
         icon: d.iconEmoji ?? '🔌',
         permissions: d.permissions ?? [],
@@ -69,14 +83,14 @@ function getAvailablePlugins() {
 // used by the install route, so the install handler keeps a single contract.
 function toRegistryEntry(p: RegisterablePlugin | undefined): PluginRegistryEntry | undefined {
   if (!p) return undefined
-  const d = p as { description?: string; author?: string | { name?: string }; category?: string; iconEmoji?: string; permissions?: string[] }
+  const d = p as DefinedPluginExtras
   return {
     id: p.id,
     codeName: p.name ?? p.id,
-    displayName: p.name ?? p.id,
+    displayName: p.displayName ?? p.name ?? p.id,
     description: d.description ?? '',
     version: p.version,
-    author: typeof d.author === 'object' ? d.author?.name ?? '' : (d.author ?? ''),
+    author: resolveAuthor(d),
     category: d.category ?? 'general',
     iconEmoji: d.iconEmoji ?? '🔌',
     is_core: false,
@@ -477,8 +491,7 @@ adminPluginRoutes.post('/install', async (c) => {
       || PLUGIN_REGISTRY[body.name]
       || PLUGIN_REGISTRY[body.id]
       || toRegistryEntry(
-          getAllPluginDefinitions()
-            .filter(p => !PLUGIN_REGISTRY[p.id])
+          getDefinedPlugins()
             .find(p => p.id === body.name || p.id === body.id)
         )
 


### PR DESCRIPTION
## Summary
Cherry-picked from #1044 by @LukeSeers

Updates the admin plugins page to support plugins registered through `definePlugin()` that do not have a `manifest.json` entry. Previously, these plugins could exist in the database but were filtered out of the admin plugins list because the page only recognised plugins from the generated manifest registry.

- Added `definePlugin()` registered plugins to the available plugins list alongside manifest-backed plugins
- Build the available plugins list per request so plugin definitions registered during application startup are included
- Added conversion from a `RegisterablePlugin` definition to the registry entry format expected by the install route
- Updated the generic install route to resolve plugins from both the manifest registry and the plugin definition registry

## Changes by Maintainer
- Fixed `displayName` fallback: was using `name ?? id`, now correctly falls back `displayName → name → id` (matching `register-plugins.ts` behavior)
- Extracted shared `DefinedPluginExtras` type alias and `resolveAuthor`/`getDefinedPlugins` helpers to remove duplicated type casts and filter logic

## Attribution
- Original PR: #1044
- Original Author: @LukeSeers

## Testing
- All 36 admin-plugins route tests pass
- TypeScript type-check clean

Closes #1044

🤖 Generated with [Claude Code](https://claude.com/claude-code)