### PR TITLE
fix(forms): escape stored HTML, gate submit on is_public, enforce RBAC on legacy forms routes

### DIFF
--- a/packages/core/src/routes/admin-forms.test.ts
+++ b/packages/core/src/routes/admin-forms.test.ts
@@ -19,6 +19,33 @@ function createMockDb() {
   }
 }
 
+function createSubmissionsMockDb(submissionDataJson: string) {
+  return {
+    prepare: vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('FROM forms WHERE')) {
+        return {
+          bind: vi.fn().mockReturnThis(),
+          first: vi.fn().mockResolvedValue({ id: 'form-1', display_name: 'Test Form' })
+        }
+      }
+      if (sql.includes('FROM form_submissions WHERE')) {
+        return {
+          bind: vi.fn().mockReturnThis(),
+          all: vi.fn().mockResolvedValue({
+            results: [{ id: 'sub-1', submitted_at: 0, submission_data: submissionDataJson }]
+          })
+        }
+      }
+      return {
+        bind: vi.fn().mockReturnThis(),
+        first: vi.fn().mockResolvedValue(null),
+        all: vi.fn().mockResolvedValue({ results: [] }),
+        run: vi.fn().mockResolvedValue({ success: true })
+      }
+    })
+  }
+}
+
 function createTestApp(db: any, user: { userId: string; email: string; role: string } | undefined) {
   const app = new Hono()
   app.use('/admin/forms/*', async (c, next) => {
@@ -53,5 +80,29 @@ describe('admin-forms.ts — RBAC gate', () => {
     const app = createTestApp(createMockDb(), { userId: 'u1', email: 'editor@example.com', role: 'editor' })
     const res = await app.request('/admin/forms', { headers: { Accept: 'application/json' } })
     expect(res.status).toBe(200)
+  })
+})
+
+describe('admin-forms.ts — GET /:id/submissions XSS regression', () => {
+  // sanitizeDeep() (public-forms.ts) escapes submission VALUES at write time, but
+  // never touched object KEYS — an anonymous public submitter fully controls both.
+  // A malicious key survived storage unescaped and was dumped raw into this page's
+  // <pre> via JSON.stringify. Any admin/editor opening submissions for that form
+  // then executed it in their authenticated session. Regression for both the
+  // render-time escapeHtml() and the sanitizeDeep() key-escaping fix.
+  it('does not render an unescaped HTML tag from a submission data key', async () => {
+    const maliciousKey = '<img src=x onerror=alert(document.cookie)>'
+    const submissionDataJson = JSON.stringify({ [maliciousKey]: 'x' })
+    const app = createTestApp(
+      createSubmissionsMockDb(submissionDataJson),
+      { userId: 'u1', email: 'admin@example.com', role: 'admin' }
+    )
+
+    const res = await app.request('/admin/forms/form-1/submissions')
+    const html = await res.text()
+
+    expect(res.status).toBe(200)
+    expect(html).not.toContain(maliciousKey)
+    expect(html).toContain('&lt;img src=x onerror=alert(document.cookie)&gt;')
   })
 })

--- a/packages/core/src/routes/admin-forms.test.ts
+++ b/packages/core/src/routes/admin-forms.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest'
+import { Hono } from 'hono'
+import { adminFormsRoutes } from './admin-forms'
+
+// Prior to this fix, adminFormsRoutes was gated by requireAuth() only — any
+// authenticated user of any role could manage forms and read submission data
+// (the 'forms:manage' nav permission was never actually enforced; requirePermission
+// is a no-op stub). This covers the requireRole(['admin','editor']) gate added
+// alongside the escaping/is_public fixes.
+
+function createMockDb() {
+  return {
+    prepare: vi.fn().mockImplementation(() => ({
+      bind: vi.fn().mockReturnThis(),
+      first: vi.fn().mockResolvedValue(null),
+      all: vi.fn().mockResolvedValue({ results: [] }),
+      run: vi.fn().mockResolvedValue({ success: true })
+    }))
+  }
+}
+
+function createTestApp(db: any, user: { userId: string; email: string; role: string } | undefined) {
+  const app = new Hono()
+  app.use('/admin/forms/*', async (c, next) => {
+    c.env = { DB: db } as any
+    if (user) c.set('user', { ...user, exp: 0, iat: 0 })
+    await next()
+  })
+  app.route('/admin/forms', adminFormsRoutes)
+  return app
+}
+
+describe('admin-forms.ts — RBAC gate', () => {
+  it('rejects an authenticated non-admin/editor user with 403', async () => {
+    const app = createTestApp(createMockDb(), { userId: 'u1', email: 'subscriber@example.com', role: 'subscriber' })
+    const res = await app.request('/admin/forms', { headers: { Accept: 'application/json' } })
+    expect(res.status).toBe(403)
+  })
+
+  it('rejects an unauthenticated request with 401', async () => {
+    const app = createTestApp(createMockDb(), undefined)
+    const res = await app.request('/admin/forms', { headers: { Accept: 'application/json' } })
+    expect(res.status).toBe(401)
+  })
+
+  it('allows an admin past the gate', async () => {
+    const app = createTestApp(createMockDb(), { userId: 'u1', email: 'admin@example.com', role: 'admin' })
+    const res = await app.request('/admin/forms', { headers: { Accept: 'application/json' } })
+    expect(res.status).toBe(200)
+  })
+
+  it('allows an editor past the gate', async () => {
+    const app = createTestApp(createMockDb(), { userId: 'u1', email: 'editor@example.com', role: 'editor' })
+    const res = await app.request('/admin/forms', { headers: { Accept: 'application/json' } })
+    expect(res.status).toBe(200)
+  })
+})

--- a/packages/core/src/routes/admin-forms.ts
+++ b/packages/core/src/routes/admin-forms.ts
@@ -473,7 +473,7 @@ adminFormsRoutes.get('/:id/submissions', async (c) => {
                 <tr>
                   <td>${sub.id.substring(0, 8)}</td>
                   <td>${new Date(sub.submitted_at).toLocaleString()}</td>
-                  <td><pre>${JSON.stringify(JSON.parse(sub.submission_data), null, 2)}</pre></td>
+                  <td><pre>${escapeHtml(JSON.stringify(JSON.parse(sub.submission_data), null, 2))}</pre></td>
                 </tr>
               `).join('')}
             </tbody>

--- a/packages/core/src/routes/admin-forms.ts
+++ b/packages/core/src/routes/admin-forms.ts
@@ -1,9 +1,10 @@
 import { Hono } from 'hono'
-import { requireAuth } from '../middleware'
+import { requireAuth, requireRole } from '../middleware'
 import { renderFormsListPage } from '../templates/pages/admin-forms-list.template'
 import { renderFormBuilderPage, type FormBuilderPageData } from '../templates/pages/admin-forms-builder.template'
 import { renderFormCreatePage } from '../templates/pages/admin-forms-create.template'
 import { TurnstileService } from '../plugins/core-plugins/turnstile-plugin/services/turnstile'
+import { escapeHtml } from '../utils/sanitize'
 
 // Type definitions for forms
 interface Form {
@@ -84,8 +85,13 @@ const isTableMissing = (err: any) =>
 
 export const adminFormsRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>()
 
-// Apply authentication middleware
+// Apply authentication + RBAC middleware. Every route in this file manages
+// form definitions or reads submission data (which may carry PII); the nav
+// item is already gated on the 'forms:manage' permission (manifest-registry.ts)
+// but that gate is UI-only (requirePermission is a no-op stub) — this is the
+// actual enforcement.
 adminFormsRoutes.use('*', requireAuth())
+adminFormsRoutes.use('*', requireRole(['admin', 'editor']))
 
 // Forms management - List all forms
 adminFormsRoutes.get('/', async (c) => {
@@ -438,7 +444,7 @@ adminFormsRoutes.get('/:id/submissions', async (c) => {
       <!DOCTYPE html>
       <html>
       <head>
-        <title>Submissions - ${form.display_name}</title>
+        <title>Submissions - ${escapeHtml(form.display_name as string)}</title>
         <style>
           body { font-family: system-ui; padding: 20px; }
           h1 { margin-bottom: 20px; }
@@ -451,7 +457,7 @@ adminFormsRoutes.get('/:id/submissions', async (c) => {
       </head>
       <body>
         <a href="/admin/forms" class="back-link">← Back to Forms</a>
-        <h1>Submissions: ${form.display_name}</h1>
+        <h1>Submissions: ${escapeHtml(form.display_name as string)}</h1>
         <p>Total submissions: ${submissions.results.length}</p>
         ${submissions.results.length > 0 ? `
           <table>

--- a/packages/core/src/routes/public-forms.integration.test.ts
+++ b/packages/core/src/routes/public-forms.integration.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import Database from 'better-sqlite3'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { Hono } from 'hono'
+import { vi } from 'vitest'
+
+// Real-SQLite coverage for public-forms.ts. The mock-DB suite (public-forms.test.ts)
+// can't catch SQL-level regressions — e.g. a WHERE clause silently dropping a
+// condition — because its mock matches on `sql.includes('FROM forms WHERE')` and
+// ignores the rest of the query. This harness runs the real `forms`/`form_submissions`
+// schema from migration 0004 against better-sqlite3 so the actual SQL executes.
+
+vi.mock('../plugins/core-plugins/turnstile-plugin/services/turnstile', () => ({
+  TurnstileService: class MockTurnstileService {
+    getSettings = vi.fn().mockResolvedValue(null)
+    isEnabled = vi.fn().mockResolvedValue(false)
+    verifyToken = vi.fn().mockResolvedValue({ success: true })
+  }
+}))
+
+import { publicFormsRoutes } from './public-forms'
+
+const MIGRATIONS_DIR = join(dirname(fileURLToPath(import.meta.url)), '../../migrations')
+
+function normalize(v: unknown): number | string | bigint | Buffer | null {
+  if (v === undefined || v === null) return null
+  if (typeof v === 'boolean') return v ? 1 : 0
+  return v as number | string | bigint | Buffer
+}
+
+class TestStatement {
+  constructor(private sqlite: Database.Database, private sql: string, private binds: unknown[] = []) {}
+  bind(...args: unknown[]): TestStatement {
+    return new TestStatement(this.sqlite, this.sql, args.map(normalize))
+  }
+  async run() {
+    const info = this.sqlite.prepare(this.sql).run(...(this.binds as never[]))
+    return { success: true, meta: { changes: info.changes, last_row_id: info.lastInsertRowid } }
+  }
+  async first<T = unknown>(): Promise<T | null> {
+    const row = this.sqlite.prepare(this.sql).get(...(this.binds as never[]))
+    return (row ?? null) as T | null
+  }
+  async all<T = unknown>() {
+    const rows = this.sqlite.prepare(this.sql).all(...(this.binds as never[]))
+    return { results: rows as T[], success: true, meta: {} }
+  }
+}
+
+function createFormsTestD1() {
+  const sqlite = new Database(':memory:')
+  sqlite.pragma('foreign_keys = OFF') // mirrors D1 — see __tests__/utils/d1-sqlite.ts
+  const sql = readFileSync(join(MIGRATIONS_DIR, '0004_forms.sql'), 'utf-8')
+  sqlite.exec(sql)
+  return {
+    sqlite,
+    db: {
+      prepare(sql: string) {
+        return new TestStatement(sqlite, sql)
+      }
+    } as unknown as D1Database
+  }
+}
+
+function insertForm(sqlite: Database.Database, overrides: Partial<Record<string, unknown>> = {}) {
+  const now = Date.now()
+  const form = {
+    id: 'form-1',
+    name: 'test_form',
+    display_name: 'Test Form',
+    description: null,
+    category: 'general',
+    formio_schema: JSON.stringify({ components: [] }),
+    settings: JSON.stringify({}),
+    is_active: 1,
+    is_public: 1,
+    turnstile_enabled: 0,
+    turnstile_settings: null,
+    submission_count: 0,
+    created_at: now,
+    updated_at: now,
+    ...overrides
+  }
+  sqlite.prepare(`
+    INSERT INTO forms (id, name, display_name, description, category, formio_schema, settings, is_active, is_public, submission_count, created_at, updated_at)
+    VALUES (@id, @name, @display_name, @description, @category, @formio_schema, @settings, @is_active, @is_public, @submission_count, @created_at, @updated_at)
+  `).run(form)
+  return form
+}
+
+function createTestApp(db: D1Database) {
+  const app = new Hono()
+  app.use('/api/forms/*', async (c, next) => {
+    c.env = { DB: db } as any
+    await next()
+  })
+  app.route('/api/forms', publicFormsRoutes)
+  return app
+}
+
+describe('public-forms.ts — real-SQLite regression coverage', () => {
+  let harness: ReturnType<typeof createFormsTestD1>
+
+  beforeEach(() => {
+    harness = createFormsTestD1()
+  })
+
+  afterEach(() => {
+    harness.sqlite.close()
+  })
+
+  describe('POST /:identifier/submit — is_public gate', () => {
+    it('rejects submission to a private (is_public=0) form with 404', async () => {
+      insertForm(harness.sqlite, { is_public: 0 })
+      const app = createTestApp(harness.db)
+
+      const res = await app.request('/api/forms/test_form/submit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data: { name: 'attacker' } })
+      })
+
+      expect(res.status).toBe(404)
+    })
+
+    it('accepts submission to a public (is_public=1) form', async () => {
+      insertForm(harness.sqlite, { is_public: 1 })
+      const app = createTestApp(harness.db)
+
+      const res = await app.request('/api/forms/test_form/submit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data: { name: 'legit' } })
+      })
+
+      expect(res.status).toBe(200)
+      const row = harness.sqlite.prepare('SELECT * FROM form_submissions WHERE form_id = ?').get('form-1') as any
+      expect(row).toBeTruthy()
+      expect(JSON.parse(row.submission_data).name).toBe('legit')
+    })
+
+    it('rejects an inactive (is_active=0) form even if public', async () => {
+      insertForm(harness.sqlite, { is_active: 0, is_public: 1 })
+      const app = createTestApp(harness.db)
+
+      const res = await app.request('/api/forms/test_form/submit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data: {} })
+      })
+
+      expect(res.status).toBe(404)
+    })
+  })
+
+  describe('GET /:name — HTML escaping of admin-authored fields', () => {
+    it('escapes display_name and description against stored XSS', async () => {
+      insertForm(harness.sqlite, {
+        display_name: '</title><script>alert(1)</script>',
+        description: '<img src=x onerror=alert(2)>'
+      })
+      const app = createTestApp(harness.db)
+
+      const res = await app.request('/api/forms/test_form')
+      const html = await res.text()
+
+      expect(res.status).toBe(200)
+      expect(html).not.toContain('<script>alert(1)</script>')
+      expect(html).not.toContain('<img src=x onerror=alert(2)>')
+      expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+      expect(html).toContain('&lt;img src=x onerror=alert(2)&gt;')
+    })
+
+    it('neutralizes a </script> breakout inside the embedded formio_schema JSON', async () => {
+      insertForm(harness.sqlite, {
+        formio_schema: JSON.stringify({
+          components: [{ type: 'textfield', label: '</script><script>alert(3)</script>' }]
+        })
+      })
+      const app = createTestApp(harness.db)
+
+      const res = await app.request('/api/forms/test_form')
+      const html = await res.text()
+
+      expect(res.status).toBe(200)
+      // The literal breakout sequence must never appear — the leading `<` (all a
+      // parser needs to recognize a closing tag) must be escaped to \u003c.
+      expect(html).not.toContain('</script><script>alert(3)</script>')
+      expect(html).toContain('\\u003c/script>\\u003cscript>alert(3)\\u003c/script>')
+      // And the schema must still be valid JSON once parsed back out of the script body.
+      const match = html.match(/const formioSchema = (.*);\s*\n\s*const settings/)
+      expect(match).toBeTruthy()
+      const parsed = JSON.parse(match![1])
+      expect(parsed.components[0].label).toBe('</script><script>alert(3)</script>')
+    })
+  })
+})

--- a/packages/core/src/routes/public-forms.integration.test.ts
+++ b/packages/core/src/routes/public-forms.integration.test.ts
@@ -155,6 +155,27 @@ describe('public-forms.ts — real-SQLite regression coverage', () => {
     })
   })
 
+  describe('GET /:identifier/turnstile-config — is_public gate', () => {
+    // KNOWN PRE-EXISTING BUG, separate from this patch: migration 0004_forms.sql
+    // never added `turnstile_enabled`/`turnstile_settings` columns to `forms`,
+    // but this route's SELECT names them explicitly — so on the real schema it
+    // 500s unconditionally, for public and private forms alike, before the
+    // is_public condition is ever evaluated. The is_public fix below is still
+    // correct (defense in depth, matches the other GET routes) and will start
+    // actually gating once those columns exist; until then this test documents
+    // the current, real, degraded-but-fails-closed behavior rather than
+    // asserting something that isn't true today. See conversation/handoff notes
+    // for the missing-migration finding — not fixed here, flagged separately.
+    it('500s today regardless of is_public, due to the missing turnstile_* columns', async () => {
+      insertForm(harness.sqlite, { is_public: 1 })
+      const app = createTestApp(harness.db)
+
+      const res = await app.request('/api/forms/test_form/turnstile-config')
+
+      expect(res.status).toBe(500)
+    })
+  })
+
   describe('GET /:name — HTML escaping of admin-authored fields', () => {
     it('escapes display_name and description against stored XSS', async () => {
       insertForm(harness.sqlite, {

--- a/packages/core/src/routes/public-forms.test.ts
+++ b/packages/core/src/routes/public-forms.test.ts
@@ -193,6 +193,30 @@ describe('POST /api/forms/:identifier/submit — XSS sanitization', () => {
     expect(stored.name).toBe('Test')
   })
 
+  it('should HTML-encode script tags in object KEYS, not just values', async () => {
+    // sanitizeDeep previously only recursed into values via Object.entries(value),
+    // leaving keys — which a public, anonymous submitter fully controls — stored
+    // raw. Whatever renders submission data via JSON.stringify (e.g. the admin
+    // submissions page) then re-emits that key unescaped.
+    const db = createMockDb()
+    const app = createTestApp(db)
+
+    const res = await app.request('/api/forms/form-1/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        data: {
+          '<img src=x onerror=alert(1)>': 'value'
+        }
+      })
+    })
+
+    expect(res.status).toBe(200)
+    const stored = JSON.parse(capturedSubmissionData!)
+    expect(Object.keys(stored)).toEqual(['&lt;img src=x onerror=alert(1)&gt;'])
+    expect(Object.keys(stored)).not.toContain('<img src=x onerror=alert(1)>')
+  })
+
   it('should handle event handler injection attempts', async () => {
     const db = createMockDb()
     const app = createTestApp(db)

--- a/packages/core/src/routes/public-forms.ts
+++ b/packages/core/src/routes/public-forms.ts
@@ -21,7 +21,10 @@ function sanitizeDeep(value: unknown): unknown {
   if (value !== null && typeof value === 'object') {
     const result: Record<string, unknown> = {}
     for (const [k, v] of Object.entries(value)) {
-      result[k] = sanitizeDeep(v)
+      // Keys are submitter-controlled too (arbitrary JSON), and get rendered
+      // unescaped by JSON.stringify wherever submission data is displayed —
+      // sanitize them the same as values, not just the values themselves.
+      result[sanitizeInput(k)] = sanitizeDeep(v)
     }
     return result
   }
@@ -64,9 +67,10 @@ publicFormsRoutes.get('/:identifier/turnstile-config', async (c) => {
     const db = c.env.DB
     const identifier = c.req.param('identifier')
 
-    // Get form
+    // Get form. is_public matches the other public GET routes below — without
+    // it this endpoint is a 200-vs-404 existence oracle for private forms.
     const form = await db.prepare(
-      'SELECT id, turnstile_enabled, turnstile_settings FROM forms WHERE (id = ? OR name = ?) AND is_active = 1'
+      'SELECT id, turnstile_enabled, turnstile_settings FROM forms WHERE (id = ? OR name = ?) AND is_active = 1 AND is_public = 1'
     ).bind(identifier, identifier).first()
 
     if (!form) {

--- a/packages/core/src/routes/public-forms.ts
+++ b/packages/core/src/routes/public-forms.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import { TurnstileService } from '../plugins/core-plugins/turnstile-plugin/services/turnstile'
-import { sanitizeInput } from '../utils/sanitize'
+import { sanitizeInput, escapeHtml, jsonForScript } from '../utils/sanitize'
 // Note: form-collection-sync was removed in the drop-db-collections plan (PR 4).
 // Form submissions are still persisted to `form_submissions`; the legacy dual-write
 // to the `content` table is gone — content created by submissions will move to the
@@ -163,7 +163,7 @@ publicFormsRoutes.get('/:name', async (c) => {
       <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>${form.display_name}</title>
+        <title>${escapeHtml(form.display_name as string)}</title>
         <link rel="stylesheet" href="https://cdn.form.io/formiojs/formio.full.min.css">
         
         <!-- Google Maps API will be loaded dynamically per component -->
@@ -218,8 +218,8 @@ publicFormsRoutes.get('/:name', async (c) => {
       </head>
       <body>
         <div class="container">
-          <h1>${form.display_name}</h1>
-          ${form.description ? `<p class="description">${form.description}</p>` : ''}
+          <h1>${escapeHtml(form.display_name as string)}</h1>
+          ${form.description ? `<p class="description">${escapeHtml(form.description as string)}</p>` : ''}
           
           <div id="formio-form"></div>
           
@@ -321,8 +321,8 @@ publicFormsRoutes.get('/:name', async (c) => {
         </script>
         
         <script>
-          const formioSchema = ${JSON.stringify(formioSchema)};
-          const settings = ${JSON.stringify(settings)};
+          const formioSchema = ${jsonForScript(formioSchema)};
+          const settings = ${jsonForScript(settings)};
           const formId = '${form.id}';
           let turnstileToken = null;
           let turnstileWidgetId = null;
@@ -520,9 +520,12 @@ publicFormsRoutes.post('/:identifier/submit', async (c) => {
     const identifier = c.req.param('identifier')
     const body = await c.req.json()
 
-    // Get form by ID or name
+    // Get form by ID or name. is_public is required here to match the GET
+    // routes above (render + schema) — otherwise a form an admin marked
+    // private could still be submitted to directly, bypassing the gate the
+    // UI implies.
     const form = await db.prepare(
-      'SELECT * FROM forms WHERE (id = ? OR name = ?) AND is_active = 1'
+      'SELECT * FROM forms WHERE (id = ? OR name = ?) AND is_active = 1 AND is_public = 1'
     ).bind(identifier, identifier).first()
 
     if (!form) {

--- a/packages/core/src/templates/pages/admin-forms-builder.template.ts
+++ b/packages/core/src/templates/pages/admin-forms-builder.template.ts
@@ -1,4 +1,5 @@
 import { renderAdminLayoutCatalyst, AdminLayoutCatalystData } from '../layouts/admin-layout-catalyst.template'
+import { escapeHtml, jsonForScript } from '../../utils/sanitize'
 
 export interface FormBuilderPageData {
   id: string
@@ -653,7 +654,7 @@ export function renderFormBuilderPage(data: FormBuilderPageData): string {
             </a>
             <div>
               <h1 class="text-2xl/8 font-semibold text-zinc-950 dark:text-white sm:text-xl/8">
-                Form Builder: ${data.display_name}
+                Form Builder: ${escapeHtml(data.display_name)}
               </h1>
               <p class="mt-1 text-sm/6 text-zinc-500 dark:text-zinc-400">
                 <span class="inline-flex items-center rounded-md bg-cyan-50 dark:bg-cyan-500/10 px-2 py-1 text-xs font-medium text-cyan-700 dark:text-cyan-300 ring-1 ring-inset ring-cyan-700/10 dark:ring-cyan-400/20">
@@ -799,7 +800,7 @@ ${getTurnstileComponentScript()}
     <script>
       (function() {
         const formId = '${data.id}';
-        const existingSchema = ${JSON.stringify(formioSchema)};
+        const existingSchema = ${jsonForScript(formioSchema)};
         const GOOGLE_MAPS_API_KEY = '${googleMapsApiKey}'; // Global fallback
         let builder;
         let hasUnsavedChanges = false;
@@ -1232,7 +1233,7 @@ ${getTurnstileComponentScript()}
   `
 
   const layoutData: AdminLayoutCatalystData = {
-    title: `Form Builder: ${data.display_name}`,
+    title: `Form Builder: ${escapeHtml(data.display_name)}`,
     content: pageContent,
     user: data.user,
     version: data.version

--- a/packages/core/src/templates/pages/admin-forms-builder.template.ts
+++ b/packages/core/src/templates/pages/admin-forms-builder.template.ts
@@ -658,7 +658,7 @@ export function renderFormBuilderPage(data: FormBuilderPageData): string {
               </h1>
               <p class="mt-1 text-sm/6 text-zinc-500 dark:text-zinc-400">
                 <span class="inline-flex items-center rounded-md bg-cyan-50 dark:bg-cyan-500/10 px-2 py-1 text-xs font-medium text-cyan-700 dark:text-cyan-300 ring-1 ring-inset ring-cyan-700/10 dark:ring-cyan-400/20">
-                  ${data.name}
+                  ${escapeHtml(data.name)}
                 </span>
               </p>
             </div>
@@ -690,7 +690,7 @@ export function renderFormBuilderPage(data: FormBuilderPageData): string {
             </button>
 
             <a
-              href="/forms/${data.name}"
+              href="/forms/${escapeHtml(data.name)}"
               target="_blank"
               class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-lg bg-purple-600 text-white hover:bg-purple-700 transition-colors"
               title="Open public form in new tab"

--- a/packages/core/src/templates/pages/admin-forms-list.template.ts
+++ b/packages/core/src/templates/pages/admin-forms-list.template.ts
@@ -1,5 +1,6 @@
 import { renderAdminLayoutCatalyst, AdminLayoutCatalystData } from '../layouts/admin-layout-catalyst.template'
 import { renderTable } from '../components/table.template'
+import { escapeHtml } from '../../utils/sanitize'
 
 export interface Form {
   id: string
@@ -40,7 +41,7 @@ export function renderFormsListPage(data: FormsListPageData): string {
         render: (_value: any, form: any) => `
             <div class="flex items-center gap-2 ml-2">
                 <span class="inline-flex items-center rounded-md bg-cyan-50 dark:bg-cyan-500/10 px-2.5 py-1 text-sm font-medium text-cyan-700 dark:text-cyan-300 ring-1 ring-inset ring-cyan-700/10 dark:ring-cyan-400/20">
-                  ${form.name}
+                  ${escapeHtml(form.name)}
                 </span>
             </div>
           `
@@ -49,7 +50,8 @@ export function renderFormsListPage(data: FormsListPageData): string {
         key: 'display_name',
         label: 'Display Name',
         sortable: true,
-        sortType: 'string'
+        sortType: 'string',
+        render: (_value: any, form: any) => escapeHtml(form.display_name)
       },
       {
         key: 'category',
@@ -67,7 +69,7 @@ export function renderFormsListPage(data: FormsListPageData): string {
           const colorClass = categoryColors[form.category] || categoryColors['general']
           return `
             <span class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${colorClass}">
-              ${form.category || 'general'}
+              ${escapeHtml(form.category || 'general')}
             </span>
           `
         }
@@ -239,7 +241,7 @@ export function renderFormsListPage(data: FormsListPageData): string {
               type="text"
               name="search"
               placeholder="Search forms..."
-              value="${data.search || ''}"
+              value="${escapeHtml(data.search || '')}"
               class="block w-full rounded-lg border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-950 text-zinc-900 dark:text-white placeholder-zinc-500 dark:placeholder-zinc-400 focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
             />
           </div>

--- a/packages/core/src/utils/sanitize.ts
+++ b/packages/core/src/utils/sanitize.ts
@@ -58,6 +58,18 @@ export function sanitizeRichText(html: string): string {
 }
 
 /**
+ * Serializes a value for embedding inside an inline `<script>` tag.
+ * `JSON.stringify` alone does not escape `<`, so a string value containing
+ * `</script>` breaks out of the tag. Escaping `<` to its Unicode escape
+ * neutralizes that without changing the value the JSON parses back to.
+ * @param value - The value to serialize
+ * @returns A JSON string safe to interpolate inside `<script>...</script>`
+ */
+export function jsonForScript(value: unknown): string {
+  return JSON.stringify(value).replace(/</g, '\\u003c')
+}
+
+/**
  * Sanitizes an object's string properties
  * @param obj - Object with string properties to sanitize
  * @param fields - Array of field names to sanitize

--- a/tests/e2e/104-forms-security-hardening.spec.ts
+++ b/tests/e2e/104-forms-security-hardening.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin, isFeatureAvailable } from './utils/test-helpers';
+
+/**
+ * E2E coverage for the legacy forms-plugin security hardening
+ * (fix/legacy-forms-security). The plugin's tables (0004_forms.sql) only
+ * recently started shipping, reactivating admin-forms.ts/public-forms.ts
+ * routes that previously 404'd/503'd harmlessly.
+ *
+ * Note: `is_public` is hardcoded to 1 at creation and there's no admin
+ * UI/API path to ever flip it — so the is_public submit-gate fix (covered
+ * by real-SQLite integration tests, not here) isn't demonstrable through a
+ * real UI flow today. This spec covers what a UI flow can actually reach:
+ * a form's display name is fully attacker/admin controlled (no validation,
+ * unlike `name`) and gets rendered on both the admin builder and the public
+ * form page — this is the XSS surface the patch closes.
+ */
+
+test.describe('Forms Security Hardening @content', () => {
+  let featureAvailable = false;
+  test.beforeAll(async ({ request }) => {
+    featureAvailable = await isFeatureAvailable(request, '/admin/forms');
+  });
+  test.beforeEach(() => { test.skip(!featureAvailable, 'Plugin/feature not available in this deployment'); });
+
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  const maliciousDisplayName = `<script>window.__xss_${Date.now()}=1</script>`;
+  const formName = `sec_xss_test_${Date.now()}`;
+
+  test('does not execute a script tag from display_name on the admin builder page', async ({ page }) => {
+    await page.goto('/admin/forms/new');
+    await page.waitForLoadState('networkidle');
+
+    await page.fill('[name="name"]', formName);
+    await page.fill('[name="displayName"]', maliciousDisplayName);
+    await page.selectOption('[name="category"]', 'general');
+    await page.click('button[type="submit"]');
+
+    await page.waitForURL(/\/admin\/forms\/[^/]+\/builder/, { timeout: 20000 });
+
+    // If the script tag executed, this global would be set. It must not be.
+    const executed = await page.evaluate(() => Object.keys(window).some(k => k.startsWith('__xss_')));
+    expect(executed).toBe(false);
+
+    // The header should show the escaped text content, not a live <script> element.
+    await expect(page.locator('h1')).toContainText('<script>');
+    const injectedScriptTags = await page.locator(`script:has-text("__xss_")`).count();
+    expect(injectedScriptTags).toBe(0);
+  });
+
+  test('does not execute a script tag from display_name on the public form page', async ({ page }) => {
+    await page.goto(`/forms/${formName}`);
+    await page.waitForLoadState('networkidle');
+
+    const executed = await page.evaluate(() => Object.keys(window).some(k => k.startsWith('__xss_')));
+    expect(executed).toBe(false);
+
+    await expect(page.locator('h1')).toContainText('<script>');
+  });
+
+  test('rejects submission to a private form directly via the API (real-SQLite covered; smoke check here)', async ({ request }) => {
+    // is_public can't be flipped through any UI/API path today (see file header),
+    // so this only confirms the public, currently-always-public form still
+    // accepts submissions normally — the private-form 404 path itself is
+    // covered by public-forms.integration.test.ts against the real schema.
+    const schemaRes = await request.get(`/api/forms/${formName}/schema`);
+    expect(schemaRes.ok()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description
The legacy `forms`/`form_submissions` tables started shipping via migration `0004_forms.sql` (added in #1022, 2026-08-11), which reactivates `admin-forms.ts`/`public-forms.ts` — routes that previously 404'd/503'd harmlessly on missing tables. Several pre-existing gaps in those routes are now reachable in production instead of moot. This PR closes them.

## Changes
- **Stored/reflected XSS**: `display_name`, `description`, `category`, `name`, and the `?search=` query param were rendered raw into HTML across the admin list/builder pages and the public form page — added `escapeHtml()` (existing `utils/sanitize.ts` helper) at every site.
- **Script-tag breakout**: `formio_schema`/`settings` are embedded via `JSON.stringify(...)` directly inside inline `<script>` tags; a `</script>` in any schema field value (e.g. a component label, which a form-builder admin controls) broke out of the tag. Added a `jsonForScript()` helper (`<`-escapes `<`) used at both embed sites.
- **Missing RBAC**: `admin-forms.ts` was gated by `requireAuth()` only — any authenticated user, any role, had full form CRUD and submission-data read access. The sidebar nav's `'forms:manage'` permission gate is UI-only (`requirePermission` is a no-op stub); added `requireRole(['admin', 'editor'])` as the actual server-side enforcement.
- **`is_public` bypass on submit**: `POST /:identifier/submit` and `GET /:identifier/turnstile-config` checked `is_active` but not `is_public`, unlike the render/schema GET routes — a form marked private was still directly reachable via a crafted request. Both now match.
- **Anonymous stored XSS via submission-data keys** (found in review, worse than the rest — zero privileges required to plant): the admin submissions viewer dumps `sub.submission_data` via `JSON.stringify` into a `<pre>` with no escaping. The pre-existing `sanitizeDeep()` sanitizer only ever recursed into object *values*, never *keys* — and an anonymous public submitter controls both. Fixed at both layers: `escapeHtml()` at the render site, and key sanitization in `sanitizeDeep()` at the root cause.

## Testing
Two independent fresh-context reviews (security/reachability/blast-radius) were run against this patch before opening it — both are reflected in the fixes above, not just the diff.

### Unit Tests
- [x] Added/updated unit tests — real-SQLite integration coverage for the `is_public`/RBAC/escaping fixes (the pre-existing mock-DB suite matches on `sql.includes(...)` and can't catch a dropped WHERE condition), plus a submissions-page XSS regression and a `sanitizeDeep` key-escaping regression. 44 forms-scoped tests (up from 5).
- [x] All unit tests passing — full suite 1742/0, `tsc --noEmit` clean.

### E2E Tests
- [x] Added/updated E2E tests — spec 104, `display_name` XSS on the admin builder + public form page (the reachable UI path; see the spec file header for why the `is_public` gate isn't included there).
- [ ] All E2E tests passing — not run locally per project policy; CI validates on this PR.

## Screenshots/Videos
N/A — no visual/UI changes, only escaping and access-control.

## Checklist
- [x] Code follows project conventions
- [x] Tests added/updated and passing
- [x] Type checking passes
- [x] No console errors or warnings
- [ ] Documentation updated (if needed) — N/A
