### PR TITLE
fix(auth): gate /auth/seed-admin to non-production environments

### DIFF
--- a/packages/core/src/__tests__/routes/seed-admin-gate.test.ts
+++ b/packages/core/src/__tests__/routes/seed-admin-gate.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest'
+import { Hono } from 'hono'
+
+// The seed-admin endpoint mints a fixed-credential admin. These tests pin the
+// fail-closed environment gate that keeps it off real deployments: only explicit
+// non-production ENVIRONMENT values may reach the handler; 'production' and an
+// unset value are denied with 403.
+
+vi.mock('../../middleware', () => ({
+  requireAuth: () => async (_c: any, next: any) => { await next() },
+  AuthManager: {
+    hashPassword: vi.fn().mockResolvedValue('pbkdf2:100000:aa:bb'),
+    generateToken: vi.fn(),
+    verifyToken: vi.fn(),
+  },
+  generateCsrfToken: vi.fn().mockResolvedValue('csrf'),
+  rateLimit: () => async (_c: any, next: any) => { await next() },
+}))
+
+vi.mock('../../middleware/auth', () => ({
+  getJwtExpirySecondsFromDb: vi.fn().mockResolvedValue(3600),
+  getJwtRefreshGraceSecondsFromDb: vi.fn().mockResolvedValue(86400),
+}))
+
+vi.mock('../../templates/pages/auth-login.template', () => ({ renderLoginPage: () => '', LoginPageData: {} }))
+vi.mock('../../templates/pages/auth-register.template', () => ({ renderRegisterPage: () => '', RegisterPageData: {} }))
+vi.mock('../../services', () => ({ getCacheService: vi.fn().mockReturnValue(null), CACHE_CONFIGS: {} }))
+vi.mock('../../services/auth-validation', () => ({
+  authValidationService: {},
+  isRegistrationEnabled: vi.fn().mockResolvedValue(true),
+  isFirstUserRegistration: vi.fn().mockResolvedValue(false),
+}))
+vi.mock('../../plugins/core-plugins/user-profiles', () => ({
+  getUserProfileConfig: vi.fn().mockReturnValue(null),
+  getRegistrationFields: vi.fn().mockReturnValue([]),
+  getProfileFieldDefaults: vi.fn().mockReturnValue({}),
+  sanitizeCustomData: vi.fn().mockReturnValue({}),
+  saveCustomData: vi.fn(),
+  getCustomData: vi.fn(),
+}))
+vi.mock('../../services/rbac', () => ({
+  RbacService: class {
+    ensureSystemRbacSeed = vi.fn().mockResolvedValue(undefined)
+    addUserRoleByName = vi.fn().mockResolvedValue(undefined)
+  },
+}))
+vi.mock('../../services/document-types-seed', () => ({
+  bootstrapDocumentTypes: vi.fn().mockResolvedValue(undefined),
+}))
+
+import authRoutes from '../../routes/auth'
+
+function makeDb() {
+  const stmt = {
+    bind: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue(null),
+    run: vi.fn().mockResolvedValue({}),
+  }
+  return { prepare: vi.fn().mockReturnValue(stmt), batch: vi.fn().mockResolvedValue([]) }
+}
+
+const app = new Hono()
+app.route('/auth', authRoutes)
+
+const post = (env: Record<string, unknown>) =>
+  app.request('/auth/seed-admin', { method: 'POST' }, env as any)
+
+describe('POST /auth/seed-admin environment gate @auth', () => {
+  it('denies (403) when ENVIRONMENT is production', async () => {
+    const res = await post({ DB: makeDb(), ENVIRONMENT: 'production' })
+    expect(res.status).toBe(403)
+  })
+
+  it('denies (403) when ENVIRONMENT is unset', async () => {
+    const res = await post({ DB: makeDb() })
+    expect(res.status).toBe(403)
+  })
+
+  it('denies (403) for an unrecognized ENVIRONMENT value', async () => {
+    const res = await post({ DB: makeDb(), ENVIRONMENT: 'staging' })
+    expect(res.status).toBe(403)
+  })
+
+  it('is case-insensitive on the production denial', async () => {
+    const res = await post({ DB: makeDb(), ENVIRONMENT: 'Production' })
+    expect(res.status).toBe(403)
+  })
+
+  it('allows the seed to run in development (gate does not block)', async () => {
+    const res = await post({ DB: makeDb(), ENVIRONMENT: 'development' })
+    expect(res.status).not.toBe(403)
+    const body = await res.json() as { message?: string }
+    expect(body.message).toBe('Seed complete')
+  })
+
+  it.each(['test', 'e2e', 'preview', 'local'])('allows the seed to run in %s', async (env) => {
+    const res = await post({ DB: makeDb(), ENVIRONMENT: env })
+    expect(res.status).not.toBe(403)
+  })
+})

--- a/packages/core/src/routes/auth.ts
+++ b/packages/core/src/routes/auth.ts
@@ -741,10 +741,26 @@ authRoutes.post('/login/form',
   }
 })
 
-// Test seeding endpoint (only for development/testing)
+// Environments where the known-credential admin seed is permitted. Anything else
+// (including 'production' and an unset value) is denied — same fail-closed allowlist
+// the test-cleanup routes use.
+const SEED_ADMIN_ALLOWED_ENVIRONMENTS = new Set(['development', 'test', 'e2e', 'preview', 'local'])
+
+// Test seeding endpoint (development/testing only).
+//
+// SECURITY: this endpoint has no authentication and upserts a fixed-credential
+// admin (`admin@sonicjs.com` / `sonicjs!`), overwriting an existing admin's
+// password. It must never be reachable on a real deployment, so it is gated
+// fail-closed to explicit non-production environments — an unset or 'production'
+// ENVIRONMENT is denied, so a default `wrangler deploy` cannot expose it.
+// Production admin provisioning goes through the bootstrap seed path, not this route.
 authRoutes.post('/seed-admin',
   rateLimit({ max: 10, windowMs: 60 * 1000, keyPrefix: 'seed-admin' }),
   async (c) => {
+  const environment = (c.env?.ENVIRONMENT ?? '').toString().toLowerCase()
+  if (!SEED_ADMIN_ALLOWED_ENVIRONMENTS.has(environment)) {
+    return c.json({ error: 'Seed endpoint not available in this environment' }, 403)
+  }
   try {
     const db = c.env.DB
     // Ensure document_types FK targets exist before RBAC seed — D1 enforces the FK

--- a/tests/e2e/108-seed-admin-env-gate.spec.ts
+++ b/tests/e2e/108-seed-admin-env-gate.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test'
+
+// The seed-admin endpoint is now gated fail-closed to non-production environments.
+// The E2E preview runs with ENVIRONMENT=development (an allowed value), so this
+// spec is a regression guard: the gate must NOT break the seeding path that the
+// rest of the suite (and first-boot login) depends on. The denied path
+// (production/unset → 403) is covered by the unit test seed-admin-gate.test.ts,
+// since the preview environment cannot be flipped to production here.
+
+test.describe('seed-admin environment gate @smoke @auth', () => {
+  test('seed-admin still succeeds in the development preview', async ({ request }) => {
+    const res = await request.post('/auth/seed-admin')
+    expect(res.ok()).toBe(true)
+    const body = await res.json()
+    expect(body.message).toBe('Seed complete')
+  })
+
+  test('the seeded admin can log in after gating', async ({ request }) => {
+    await request.post('/auth/seed-admin')
+    const res = await request.post('/auth/login', {
+      data: { email: 'admin@sonicjs.com', password: 'sonicjs!' },
+    })
+    expect(res.ok()).toBe(true)
+    const body = await res.json()
+    expect(body.user?.email).toBe('admin@sonicjs.com')
+  })
+})


### PR DESCRIPTION
## Summary

`POST /auth/seed-admin` was mounted on every deployment with **no authentication and no environment guard** — only a rate limit — despite its "development/testing only" comment. On any live instance an anonymous request would create `admin@sonicjs.com` with a fixed password and role `admin`, and for an already-existing admin it would **overwrite that account's credential password**. That is an unauthenticated admin-takeover path requiring zero misconfiguration.

## Fix

Gate the endpoint **fail-closed** to explicit non-production `ENVIRONMENT` values (`development` / `test` / `e2e` / `preview` / `local`), matching the existing `test-cleanup` routes. An unset or `production` `ENVIRONMENT` is denied with `403`, so a default `wrangler deploy` cannot expose it. Production admin provisioning continues to go through the bootstrap seed path, not this route.

## Compatibility

The CI preview and local dev both run with `ENVIRONMENT=development` (an allowed value), so the seeding path the E2E suite and first-boot login depend on is unchanged.

## Tests

- `packages/core/src/__tests__/routes/seed-admin-gate.test.ts` — 9 cases: `production` / unset / unrecognized / mixed-case denied (403); `development` / `test` / `e2e` / `preview` / `local` allowed.
- `tests/e2e/108-seed-admin-env-gate.spec.ts` — regression guard that seeding + login still succeed in the development preview.
- Full core suite green (1746 passed); type-check clean.

> Marked draft pending maintainer review of the disclosure/coordination approach.
