### PR TITLE
fix: User plugin /api routes take precedence over catch all /api route

### DIFF
--- a/packages/core/src/__tests__/app.test.ts
+++ b/packages/core/src/__tests__/app.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { createSonicJSApp } from '../app';
+import { createRedirectPlugin } from '../plugins/redirect-management';
+
+describe('createSonicJSApp — plugin route ordering', () => {
+  it('GET /api/redirects reaches the redirect plugin, not the /:collection catch-all', async () => {
+    const app = createSonicJSApp({
+      plugins: {
+        register: [createRedirectPlugin() as any],
+      },
+    });
+
+    // Simulate a request with a minimal env (DB stub, development mode for open API access)
+    const res = await app.request(
+      '/api/redirects',
+      {
+        headers: { 'x-test-role': 'admin' },
+      },
+      {
+        DB: {
+          prepare: () => ({
+            bind: (..._args: unknown[]) => ({
+              all: async () => ({ results: [] }),
+              first: async () => null,
+              run: async () => ({ success: true }),
+            }),
+            all: async () => ({ results: [] }),
+          }),
+          batch: async () => [],
+        },
+        ENVIRONMENT: 'development',
+      },
+    );
+
+    const body = await res.json();
+
+    // The redirect plugin should handle this request.
+    // If the catch-all shadows it, we get { error: "Collection not found" } with 404.
+    expect(res.status).not.toBe(404);
+    expect(body).not.toHaveProperty('error', 'Collection not found');
+  });
+});

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -628,6 +628,29 @@ export function createSonicJSApp(config: SonicJSConfig = {}): SonicJSApp {
   app.route('/api/media', apiMediaRoutes)
   app.route('/api/system', apiSystemRoutes)
   app.route('/api/documents', apiDocumentsRoutes)
+
+  // ── Plugin routes (before the /api catch-all) ─────────────────────────────
+  // All plugin route mounting flows through registerPluginRoutes() (see
+  // plugins/mount.ts), which mounts each plugin's declarative routes[] and/or
+  // synchronous register(app) hook. These MUST be mounted before both the bare
+  // `/api` catch-all (whose /:collection param shadows /api/* plugin routes) and
+  // the `/admin` catch-all so plugin-owned pages are not shadowed.
+  //
+  // `disableAll` turns off every plugin — core AND user — for a bare core app.
+  if (!config.plugins?.disableAll) {
+    registerPluginRoutes(app, corePluginsBeforeCatchAll, { source: 'core' })
+
+    // Plugin routes - Cache (dashboard and management API)
+    // Fixes GitHub Issue #461: Cache routes were not registered
+    app.route('/admin/cache', cachePlugin.getRoutes())
+
+    // User-supplied plugins. Mounted here — before the catch-all — so consumers
+    // never have to edit core or hand-mount routes (#829, #621, #758).
+    if (config.plugins?.register && config.plugins.register.length > 0) {
+      registerPluginRoutes(app, config.plugins.register, { source: 'user' })
+    }
+  }
+
   app.route('/api', apiRoutes)
   app.route('/admin/documents', adminDocumentsRoutes)
 
@@ -645,27 +668,6 @@ export function createSonicJSApp(config: SonicJSConfig = {}): SonicJSApp {
   app.route('/admin/media', adminMediaRoutes)
   // Security audit middleware - logs auth events (login, register, logout)
   app.use('/auth/*', securityAuditMiddleware())
-
-  // ── Plugin routes (before the /admin catch-all) ───────────────────────────
-  // All plugin route mounting flows through registerPluginRoutes() (see
-  // plugins/mount.ts), which mounts each plugin's declarative routes[] and/or
-  // synchronous register(app) hook. These MUST be mounted before the bare
-  // `/admin` catch-all so plugin-owned `/admin/<x>` pages are not shadowed.
-  //
-  // `disableAll` turns off every plugin — core AND user — for a bare core app.
-  if (!config.plugins?.disableAll) {
-    registerPluginRoutes(app, corePluginsBeforeCatchAll, { source: 'core' })
-
-    // Plugin routes - Cache (dashboard and management API)
-    // Fixes GitHub Issue #461: Cache routes were not registered
-    app.route('/admin/cache', cachePlugin.getRoutes())
-
-    // User-supplied plugins. Mounted here — before the catch-all — so consumers
-    // never have to edit core or hand-mount routes (#829, #621, #758).
-    if (config.plugins?.register && config.plugins.register.length > 0) {
-      registerPluginRoutes(app, config.plugins.register, { source: 'user' })
-    }
-  }
 
   // Public event tracking API — POST /api/events (open), GET /api/events (admin)
   app.route('/api/events', eventsApiRoutes)


### PR DESCRIPTION
## Description
Moved the /api catch all route after the user defined plugins. This allows the redirect plugins `/api/redirects` to be used

Fixes #1067

## Changes
<!-- List the main changes made in this PR -->
- Moves the /api catch all route after the user defined plugins

## Testing
Tested with the added unit test. (Red/green phase)

### Unit Tests
- [x] Added/updated unit tests
- [x] All unit tests passing

### E2E Tests
- [ ] Added/updated E2E tests
- [ ] All E2E tests passing

## Screenshots/Videos
<!-- If this PR includes UI changes, add screenshots or videos -->

## Checklist
- [ ] Code follows project conventions
- [x] Tests added/updated and passing
- [x] Type checking passes
- [x] No console errors or warnings
- [ ] Documentation updated (if needed)

---
Generated with Claude Code in Conductor
