### PR TITLE
docs: Postgres portability — Kysely spike (compile-only)

### DIFF
--- a/docs/ai/plans/portability-analysis.md
+++ b/docs/ai/plans/portability-analysis.md
@@ -4,7 +4,12 @@
 > Cloudflare-specific services, and the deployment targets it would unlock.
 >
 > **Status:** Tier 1 implemented — all 5 adapter steps shipped.
-> **Date:** 2026-06-17 (updated 2026-06-30)
+> **Date:** 2026-06-17 (updated 2026-06-30; Postgres/Kysely re-measure 2026-09-02)
+>
+> **Postgres (Tier 2) update:** counts re-verified + a compile-only Kysely spike
+> measured the two chokepoint paths (read `list()` + write `saveDraft()`). Both
+> compile to SQLite **and** Postgres from one builder. Revised estimate **~5–9 weeks**,
+> lower risk. See [`postgres-portability-poc/`](postgres-portability-poc/README.md).
 
 ## TL;DR
 

--- a/docs/ai/plans/postgres-implementation-plan.md
+++ b/docs/ai/plans/postgres-implementation-plan.md
@@ -1,0 +1,151 @@
+# SonicJS → Postgres — Implementation Plan (Tier 2)
+
+> Ordered, phased runbook to add **Postgres as a supported database backend**
+> alongside Cloudflare D1 / SQLite, without dropping the edge flagship.
+>
+> **Companions:** [`portability-analysis.md`](portability-analysis.md) (feasibility + effort),
+> [`postgres-portability-poc/`](postgres-portability-poc/README.md) (Kysely spike proving both chokepoints port).
+>
+> **Status:** proposed. No code written. This is the go/no-go design.
+> **Est:** ~7–10 engineer-weeks to GA + dual-dialect test matrix.
+
+---
+
+## 1. Goal / non-goals
+
+**Goal:** `DB_DRIVER=postgres` (+ `DATABASE_URL`) boots a fully-working SonicJS —
+documents, versioning, ACL, media, plugins, auth — on Postgres. D1/SQLite stays
+the default and the recommended edge path. One codebase, dialect chosen at runtime.
+
+**Non-goals:** dropping D1/SQLite; multi-DB in one process; sharding; a query-builder
+rewrite of all 743 `.prepare()` sites (Kysely adoption is an *optional* quality track — §9).
+
+## 2. Strategy — keep `D1Database` as the universal seam
+
+Every service is typed `private db: D1Database` and a **D1-compatible driver over
+better-sqlite3 already exists** (`src/adapters/db/sqlite-driver.ts`). The port is
+therefore *not* a rewrite — it is **one more driver + the residual dialect SQL**:
+
+```
+services (unchanged, typed against D1Database)
+     │
+     ├── D1 (Workers)              ← today
+     ├── sqlite-driver (better-sqlite3)  ← today (self-host)
+     └── postgres-driver (NEW)     ← this plan
+```
+
+Three decisions keep the residual small — each removes a whole class of edits:
+
+| Decision | Effect |
+|---|---|
+| **PG keeps `0/1` integer columns for booleans** (`is_published integer`, not `boolean`) | the hundreds of `= 1` / `visible ? 1 : 0` comparisons need **zero change** |
+| **`q_*` stay real columns on PG** (`GENERATED … STORED`, not dropped for expression indexes) | `DocumentRepository.list()` — the read chokepoint — needs **zero change** |
+| **`postgres-driver` rewrites `?`→`$N` internally** | the 743 `.prepare('… ?')` sites run unchanged; only genuinely-divergent SQL is touched |
+
+Residual dialect surface after those three: **~20 `json_extract` files + 1 DDL
+generator + `INSERT OR IGNORE` (21 sites) + migrations + auth adapter.** Bounded.
+
+## 3. Phase 0 — Decisions & scaffolding  *(~0.5 wk)*
+
+- [ ] **PG client:** `postgres` (postgres.js) — no native build, Node/Bun/Deno, fast pipelining. (`pg` acceptable fallback.)
+- [ ] **Driver selection:** `DB_DRIVER = d1 | sqlite | postgres` read in `adapters/node-server.ts` + `my-sonicjs-app/src/self-host.ts`. Default `d1`.
+- [ ] **`data`/`metadata` column type on PG:** `jsonb` (needed so `->>` works). Driver returns them already-parsed; guard `rowToDocument`/projection `JSON.parse` to accept object-or-string (2 files: `document-repository.ts`, `document-projection.ts`).
+- [ ] **Gen-col strategy:** `GENERATED ALWAYS AS ((data->>'path')::cast) STORED` — preserves the `q_*` column contract. (`->>` is immutable → legal in STORED.)
+- [ ] **Dialect context:** a process-level `getDialect(): 'sqlite' | 'postgres'` (from `DB_DRIVER`) importable by the helpers in Phase 3. No threading through call sites.
+
+## 4. Phase 1 — Postgres driver (D1Database-compatible)  *(~1.5–2 wk)*
+
+New: `packages/core/src/adapters/db/postgres-driver.ts`, mirroring `sqlite-driver.ts`'s public shape.
+
+- [ ] Implement `prepare(sql)` → statement with `.bind(...args)`, `.first<T>()`, `.all<T>()`, `.run()`, `.raw()`.
+- [ ] **Placeholder rewrite `?`→`$1..$n`** — sequential over *unquoted* `?` only (skip `?` inside `'…'` string literals / jsonb text). Ship a fuzz test. **(Highest-risk item — §8.)**
+- [ ] **`.batch([...])` → one transaction** (`BEGIN; … COMMIT;`), returns the array-of-results shape, atomic rollback on any failure (matches D1 batch atomicity — R1/R7 depend on it).
+- [ ] **`.run()` meta** — `{ changes, last_row_id, duration }` from `rowCount` / `RETURNING`. Audit `last_row_id` consumers (documents use nanoid PKs → likely none).
+- [ ] Result mapping: rows → plain objects; `jsonb` → JS object; `null` handling; `bigint` epoch → `number`.
+- [ ] Wire into `node-server.ts` middleware + `self-host.ts` by `DB_DRIVER`.
+- [ ] Unit tests: placeholder rewrite (incl. literal-embedded `?`), batch rollback, `.first`/`.all`/`.run` meta, jsonb round-trip.
+
+**Exit:** a standard-SQL query (`getById`, `list` with no divergent SQL) returns correct rows on PG.
+
+## 5. Phase 2 — Postgres schema & migrations  *(~1–1.5 wk)*
+
+- [ ] `packages/core/migrations/pg/0001_core.sql`, `pg/0002_documents.sql` — PG dialect:
+  - keep `integer` 0/1 for boolean flags; text (nanoid) PKs (no `AUTOINCREMENT`).
+  - `data`/`metadata` → `jsonb`.
+  - `unixepoch()` default → `extract(epoch from now())::bigint`.
+  - **partial UNIQUE indexes port near-verbatim** — PG supports `… WHERE` (idx_documents_one_current_draft, one_published, unique_slug, one_translation_per_locale). R6 concurrency guarantee holds.
+  - drop the static VIRTUAL-col note (runtime-generated in Phase 3).
+- [ ] Extend `packages/core/scripts/generate-migrations.ts` to emit a **PG bundle** (`migrations-bundle.pg.ts`) beside the SQLite one; runner selects by dialect.
+- [ ] `MigrationService` dialect-aware: pick bundle + `information_schema` vs `pragma` self-heal path.
+- [ ] Re-sync `my-sonicjs-app/migrations/pg/` + regen bundle (R9 discipline, per-dialect).
+
+## 6. Phase 3 — Residual dialect SQL in services  *(~1.5–2 wk — the core work)*
+
+- [ ] **New `packages/core/src/utils/sql-dialect.ts`:** `jsonExtract(col, '$.path', {as?})` → `json_extract(col,'$.path')` (sqlite) / `col->>'path'` (pg); `upsertIgnore(table, cols, conflictCols)` → `INSERT OR IGNORE` / `INSERT … ON CONFLICT DO NOTHING`; `nowEpoch()`.
+- [ ] **`document-scalar-schema.ts`** — branch the generator:
+  - DDL: sqlite `… AS (json_extract(data,'$.p')) VIRTUAL` → pg `… GENERATED ALWAYS AS ((data->>'p')::<cast>) STORED`; `affinity()` → PG type map (`text`/`double precision`/`bigint`).
+  - Introspection: `pragma_table_xinfo('documents')` / `sqlite_master` → `information_schema.columns` / `pg_indexes`.
+  - **Column NAME + index DDL unchanged** → `list()` untouched.
+- [ ] **Replace the 38 `json_extract` sites (20 files)** with `jsonExtract()`. Targets:
+  `plugins/redirect-management/middleware/redirect.ts` (6), `services/plugin-service.ts` (3),
+  `routes/api.ts` (3), `utils/query-filter.ts` (2), `routes/admin-dashboard.ts` (2),
+  `routes/admin-content.ts` (2), `plugins/wire.ts` (2), `plugins/redirect-management/services/redirect.ts` (2),
+  `plugins/core-plugins/menu-plugin/services/menu-reconcile.ts` (2),
+  `plugins/core-plugins/email-reconciliation/index.ts` (2), `middleware/plugin-middleware.ts` (2),
+  + 9 single-hit files (`plugin-bootstrap`, `media-documents`, `api-media`, `webhooks`,
+  `security-audit-service`, `menu-repository`, `middleware/menu`, `document-scalar-schema`, `services/plugin-service`).
+- [ ] **Replace `INSERT OR IGNORE`/`OR REPLACE` (21 sites)** with `upsertIgnore()`.
+- [ ] No-change confirmations: `COALESCE(MAX)+1` (3 sites, standard SQL — R6), keyset pagination, ACL SQL.
+
+**Exit:** documents create/saveDraft/publish/unpublish/erase + media + plugins produce valid PG SQL. Spike (`postgres-portability-poc/`) already proved list + saveDraft compile.
+
+## 7. Phase 4 — Better Auth on Postgres  *(~0.5–1 wk)*
+
+- [ ] `src/auth/config.ts` — dialect branch: keep `withCloudflare(drizzle(D1))` on Workers; use Better Auth's native `pg`/Kysely adapter on PG, reusing the `auth_*` tables from `pg/0001_core.sql`.
+- [ ] Verify session + RBAC (`c.get('user')` shape) end-to-end on PG (the analysis flags this as the one untested seam).
+
+## 8. Phase 5 — Dual-dialect test matrix  *(~1.5–2 wk, overlaps 4–6)*
+
+- [ ] **`src/__tests__/utils/d1-postgres.ts`** — pg→D1 shim mirroring `d1-sqlite.ts`, backed by **`pglite`** (embedded PG, in-process — CI-friendly, no docker) or a testcontainer.
+- [ ] Parametrize `documents.sqlite.test.ts` + `**/*.integration.test.ts` over `DIALECT=sqlite|postgres` (R10 — real-DB coverage; mocks prove nothing).
+- [ ] New cases: driver placeholder-rewrite fuzz, batch rollback atomicity, STORED gen-col filter parity, `->>`/facet filter parity, `ON CONFLICT` upsert, partial-unique concurrent-version rejection (R6).
+- [ ] E2E: CI lane running existing Playwright specs against a PG-backed `self-host` (tag `@database`). New spec `tests/e2e/68-postgres-smoke.spec.ts` (R11) — write, don't run locally.
+
+## 9. Optional track — Kysely (quality, not on critical path)
+
+The merged spike proves Kysely compiles both chokepoints to both dialects and
+**deletes the R5 bind-counting bug class**. Adopt *incrementally* after GA, starting
+with `document-repository.ts` then `documents.ts`, to retire raw SQL for compile-time
+type safety + a single `sql\`\`` seam for the 20 json files. **Not required for PG GA** —
+the driver-shim + helpers path ships first and faster.
+
+## 10. Risk register
+
+| Risk | Sev | Mitigation |
+|---|---|---|
+| `?`→`$N` rewrite corrupts `?` inside string/jsonb literals | **High** | rewrite unquoted `?` only; fuzz test; consider requiring `$n` in new SQL |
+| D1 `.batch()` atomicity vs PG txn divergence (R1/R7) | Med | wrap batch in one txn; atomicity test with mid-batch failure |
+| STORED gen-col rejects non-immutable expr | Low | `->>` + `::cast` are immutable — verified legal |
+| `jsonb` double-parse in `rowToDocument` | Low | typeof guard (2 files) |
+| Auth adapter untested on PG | Med | Phase 4 e2e gate before GA |
+| Migration drift SQLite vs PG bundles | Med | per-dialect R9 regen + a schema-parity test |
+
+## 11. Effort roll-up
+
+| Phase | Weeks |
+|---|---|
+| 0 decisions/scaffold | 0.5 |
+| 1 PG driver | 1.5–2 |
+| 2 schema/migrations | 1–1.5 |
+| 3 residual dialect SQL | 1.5–2 |
+| 4 auth | 0.5–1 |
+| 5 test matrix | 1.5–2 (overlap) |
+| 6 docs/rollout | 0.5 |
+| **Total** | **~7–10 wk** (1 eng) |
+
+## 12. Rollout
+
+- Ships behind `DB_DRIVER` — default `d1`, PG strictly opt-in. Zero impact on existing installs.
+- Docs: `DATABASE_URL`, `docker-compose` PG service, self-host guide, "which tier" matrix update.
+- GA gate: full dual-dialect unit + integration + PG e2e green.
+```

--- a/docs/ai/plans/postgres-portability-poc/README.md
+++ b/docs/ai/plans/postgres-portability-poc/README.md
@@ -1,0 +1,110 @@
+# Postgres Portability — Kysely Spike (compile-only)
+
+> Measures the real effort of a SonicJS → Postgres port by porting the two
+> chokepoint code paths to **Kysely** and proving one TypeScript builder
+> compiles to correct **SQLite (D1)** *and* **Postgres** SQL.
+>
+> **Status:** spike / measurement only. No production code changed.
+> Companion to [`../portability-analysis.md`](../portability-analysis.md).
+
+## Run it
+
+```bash
+cd docs/ai/plans/postgres-portability-poc
+npm install          # pulls kysely only (isolated package.json)
+node list-read.mjs       # DocumentRepository.list() — the hot read path
+node saveDraft-write.mjs # documents.saveDraft() — the hardest write path
+```
+
+Compile-only: uses Kysely's `DummyDriver` + each dialect's `QueryCompiler`.
+No database connection, no Postgres install — it prints the compiled SQL +
+bound params for both dialects side by side.
+
+## Why these two paths
+
+- **`list()`** = the single read chokepoint (R4). Every list API/admin table goes through it.
+- **`saveDraft()`** = the hardest write: `.batch()` atomicity, the `COALESCE(MAX)+1`
+  version subquery (R6), the R5 hand-counted 27-bind `INSERT`, and a prune `DELETE`
+  with `NOT IN (… LIMIT ?)` subqueries.
+
+If both port cleanly, the rest of the 743 `.prepare()` sites are strictly easier.
+
+## Findings
+
+### 1. Placeholder rewrite — **FREE**
+`?` (SQLite) ↔ `$1..$N` (Postgres) handled entirely by the dialect compiler.
+This was a whole "medium" line item in the original estimate — it evaporates.
+
+### 2. Booleans — **isolated to one mapper**, not a repo-wide edit
+SonicJS stores `is_published`/`is_current_draft`/`visible` as `0/1` integers;
+Postgres wants real `boolean`. In the spike a single `bool()` helper flips the
+representation per-dialect:
+
+```
+SQLite : "is_published" = ?     params:[1]
+Postgres: "is_published" = $3    params:[true]
+```
+
+One helper injected at the value boundary — not 300 hand-edits.
+
+### 3. The `p`/alias string-prefix hack — **deleted**
+`list()` today concatenates a `'d.'` string prefix when it joins facets. Kysely
+resolves the `documents as d` alias itself, so that entire branch disappears.
+
+### 4. Dynamic identifiers (`q_*` cols, sort column) — **`sql.ref()`**, guard kept
+Generated-column filter/sort names are quoted per-dialect by `sql.ref()`. The
+existing `SAFE_IDENTIFIER` regex stays as defense-in-depth.
+
+### 5. The R5 27-bind INSERT — **the bug class is deleted**
+The raw `saveDraft` INSERT carries this comment:
+
+> `R5 arithmetic — keep balanced: 30 columns = 5 leading '?' + 1 version_number subquery + 3 literals + 21 trailing '?'. Total placeholders 27 MUST equal the 27 .bind() args.`
+
+Kysely's named `values({ col: value })` form — with the version subquery as just
+another named value — removes positional counting entirely. The `COALESCE(MAX)+1`
+correlated subquery (R6) stays in SQL, standard in both dialects:
+
+```
+values (?, ?, …, (select coalesce(max(version_number), 0) + 1 from "documents" where "root_id" = ?), …)
+```
+
+### 6. `.batch()` → `.transaction()`
+D1 `.batch([...])` maps to `db.transaction().execute(trx => …)`. On Workers the
+`kysely-d1` dialect maps transactions back onto D1 batch semantics, so the CF
+flagship keeps working from the same code.
+
+### 7. `json_extract` is **NOT** in either chokepoint
+`list()` filters pre-materialized `q_*` generated columns, not inline JSON.
+`grep json_extract document-repository.ts` = **0**. The 38 `json_extract` sites
+that genuinely need per-dialect `sql\`\`` fragments live in a **bounded ~20-file
+set** (scalar-schema DDL generator, projection, media-documents, a few plugins) —
+enumerable, not pervasive.
+
+## What Kysely does NOT solve (still hand-written, per dialect)
+
+| Concern | Why it stays manual |
+|---|---|
+| `json_extract` ↔ `data->>'x'` / `jsonb` (38 sites) | dialect JSON semantics differ; write `sql\`\`` fragments |
+| `VIRTUAL` generated columns (`document-scalar-schema.ts`) | Postgres has no `VIRTUAL`; branch to `STORED` **or** a native JSONB expression index |
+| Partial/expression UNIQUE indexes | *already* portable — Postgres supports them natively (near-free) |
+
+## Effort re-read (vs `portability-analysis.md`)
+
+Kysely does not slash the raw week-count — it **changes the risk profile**:
+
+- ~**743 `.prepare()` sites / 100 files** → mechanical, *typed*, dual-dialect conversion (compiler catches column typos the raw strings can't).
+- The genuinely-hard dialect SQL is confined to **~20 files** of `json_extract` + **1** DDL generator branch.
+- Bonus: Kysely compiles to **D1** (`kysely-d1`), **better-sqlite3**, **libSQL/Turso**, and **Postgres** from one query layer — the CF flagship, the Turso tier, and the PG tier share code.
+
+**Estimate:** ~**5–9 weeks** for full Postgres parity + a dual-dialect test matrix,
+at roughly half the defect risk of a raw hand-written SQL port.
+
+## Recommended sequencing (if Postgres is pursued)
+
+1. Adopt Kysely as the universal query layer behind `DocumentRepository` /
+   `DocumentsService`, compiling to **D1 first** — no behavior change, CF stays green.
+2. Branch the ~20 `json_extract` files to per-dialect `sql\`\`` fragments.
+3. Add the Postgres dialect + swap the `q_*` `VIRTUAL` generator to `STORED` /
+   JSONB expression indexes.
+4. Stand up the real-Postgres test harness alongside `better-sqlite3` (R10).
+```

--- a/docs/ai/plans/postgres-portability-poc/list-read.mjs
+++ b/docs/ai/plans/postgres-portability-poc/list-read.mjs
@@ -1,0 +1,130 @@
+// Compile-only Kysely prototype of DocumentRepository.list().
+// Proves ONE TypeScript builder compiles to correct SQLite AND Postgres SQL.
+// No DB connection — uses DummyDriver + each dialect's QueryCompiler.
+import {
+  Kysely, DummyDriver,
+  SqliteAdapter, SqliteQueryCompiler, SqliteIntrospector,
+  PostgresAdapter, PostgresQueryCompiler, PostgresIntrospector,
+  sql,
+} from 'kysely'
+
+// --- compile-only Kysely instances (never touch a real DB) ---
+const mk = (Adapter, Compiler, Introspector) =>
+  new Kysely({
+    dialect: {
+      createAdapter: () => new Adapter(),
+      createDriver: () => new DummyDriver(),
+      createIntrospector: (db) => new Introspector(db),
+      createQueryCompiler: () => new Compiler(),
+    },
+  })
+
+const sqlite = mk(SqliteAdapter, SqliteQueryCompiler, SqliteIntrospector)
+const pg = mk(PostgresAdapter, PostgresQueryCompiler, PostgresIntrospector)
+
+const SAFE_IDENTIFIER = /^[a-z_][a-z0-9_]*$/
+
+// Faithful port of DocumentRepository.list() — same branch structure, expressed in Kysely.
+// `bool` lets the PG build emit real booleans (`= true`) while SQLite stays `= 1`.
+function buildList(db, tenantId, opts = {}, { bool } = { bool: (n) => n }) {
+  const limit = Math.min(opts.limit ?? 50, 200)
+  const status = opts.status ?? 'published'
+  const useFacetJoin = !!opts.facetFilter
+
+  // Always alias documents as `d` — Kysely handles alias resolution, so the manual
+  // `p` string-prefix from the raw version disappears entirely.
+  let q = db.selectFrom('documents as d').selectAll('d')
+  if (useFacetJoin) q = q.innerJoin('document_facets as f', 'f.document_id', 'd.id')
+
+  q = q.where('d.tenant_id', '=', tenantId)
+       .where('d.deleted_at', 'is', null)
+
+  if (opts.typeId) q = q.where('d.type_id', '=', opts.typeId)
+
+  if (status === 'published') q = q.where('d.is_published', '=', bool(1))
+  else if (status === 'draft') q = q.where('d.is_current_draft', '=', bool(1))
+  else q = q.where((eb) => eb.or([
+    eb('d.is_published', '=', bool(1)),
+    eb('d.is_current_draft', '=', bool(1)),
+  ]))
+
+  if (opts.facetFilter) q = q
+    .where('f.field_name', '=', opts.facetFilter.field)
+    .where('f.value_text', '=', opts.facetFilter.value)
+
+  if (opts.timeWindow) {
+    const now = opts.now ?? 0
+    q = q.where((eb) => eb.and([
+      eb.or([eb('d.scheduled_at', 'is', null), eb('d.scheduled_at', '<=', now)]),
+      eb.or([eb('d.expires_at', 'is', null), eb('d.expires_at', '>', now)]),
+    ]))
+  }
+
+  if (opts.locale && opts.locale !== 'default') q = q.where('d.locale', '=', opts.locale)
+  if (opts.parentRootId !== undefined) q = q.where('d.parent_root_id', '=', opts.parentRootId)
+
+  // Dynamic generated-column filters. sql.ref() quotes the identifier per-dialect and
+  // rejects nothing on its own, so keep the format guard as defense-in-depth.
+  for (const sf of opts.scalarFilters ?? []) {
+    if (!SAFE_IDENTIFIER.test(sf.column)) throw new Error(`Unsafe filter column: ${sf.column}`)
+    q = q.where(sql.ref(`d.${sf.column}`), '=', sf.value)
+  }
+
+  // Keyset cursor.
+  if (opts.cursorUpdatedAt !== undefined && opts.cursorId) {
+    const c = opts.cursorUpdatedAt, id = opts.cursorId
+    q = q.where((eb) => eb.or([
+      eb('d.updated_at', '<', c),
+      eb.and([eb('d.updated_at', '=', c), eb('d.id', '<', id)]),
+    ]))
+  }
+
+  const dir = opts.sortDir === 'ASC' ? 'asc' : 'desc'
+  if (opts.sortColumn) {
+    if (!SAFE_IDENTIFIER.test(opts.sortColumn)) throw new Error(`Unsafe sort column: ${opts.sortColumn}`)
+    q = q.orderBy(sql.ref(`d.${opts.sortColumn}`), dir).orderBy('d.id', dir)
+  } else {
+    q = q.orderBy('d.updated_at', dir).orderBy('d.id', dir)
+  }
+
+  return q.limit(limit)
+}
+
+// Exercise EVERY branch at once.
+const opts = {
+  typeId: 'blog_post',
+  status: 'all',
+  locale: 'en',
+  parentRootId: 'root-123',
+  facetFilter: { field: 'tags', value: 'homepage' },
+  timeWindow: true,
+  now: 1_700_000_000,
+  scalarFilters: [{ column: 'q_tst_rating', value: 4 }],
+  cursorUpdatedAt: 1_699_000_000,
+  cursorId: 'doc-abc',
+  sortColumn: 'q_tst_rating',
+  sortDir: 'DESC',
+  limit: 50,
+}
+
+const show = (label, db, o) => {
+  const { sql: text, parameters } = buildList(db, 'default', o).compile()
+  console.log(`\n===== ${label} =====`)
+  console.log(text)
+  console.log('params:', JSON.stringify(parameters))
+}
+
+console.log('########## FULL-BRANCH QUERY (numeric booleans, both dialects) ##########')
+show('SQLite (D1)  — numeric bools', sqlite, opts)
+show('Postgres     — numeric bools', pg, opts)
+
+console.log('\n\n########## POSTGRES with REAL booleans (bool: n => n===1) ##########')
+{
+  const { sql: text, parameters } = buildList(pg, 'default', opts, { bool: (n) => n === 1 }).compile()
+  console.log(text)
+  console.log('params:', JSON.stringify(parameters))
+}
+
+console.log('\n\n########## SIMPLE published list (typical hot path) ##########')
+show('SQLite (D1)', sqlite, { typeId: 'blog_post', status: 'published', timeWindow: true, now: 1_700_000_000 })
+show('Postgres', pg, { typeId: 'blog_post', status: 'published', timeWindow: true, now: 1_700_000_000 })

--- a/docs/ai/plans/postgres-portability-poc/package.json
+++ b/docs/ai/plans/postgres-portability-poc/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "postgres-portability-poc",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Compile-only Kysely spike: proves DocumentRepository read + write paths compile to both SQLite (D1) and Postgres from one builder. Run: npm i && node list-read.mjs && node saveDraft-write.mjs",
+  "scripts": {
+    "read": "node list-read.mjs",
+    "write": "node saveDraft-write.mjs"
+  },
+  "dependencies": {
+    "kysely": "^0.27.0"
+  }
+}

--- a/docs/ai/plans/postgres-portability-poc/saveDraft-write.mjs
+++ b/docs/ai/plans/postgres-portability-poc/saveDraft-write.mjs
@@ -1,0 +1,99 @@
+// Compile-only Kysely prototype of the HARD write path: documents.saveDraft().
+// Covers the three gnarly statements the read path never touches:
+//   1. demote UPDATE
+//   2. INSERT with an inline COALESCE(MAX(version_number))+1 subquery  (the R5 27-bind statement)
+//   3. prune DELETE with two NOT IN (… LIMIT ?) subqueries
+// All three compile to correct SQLite AND Postgres. batch() -> transaction (noted, not run).
+import {
+  Kysely, DummyDriver,
+  SqliteAdapter, SqliteQueryCompiler, SqliteIntrospector,
+  PostgresAdapter, PostgresQueryCompiler, PostgresIntrospector,
+  sql,
+} from 'kysely'
+
+const mk = (Adapter, Compiler, Introspector) =>
+  new Kysely({ dialect: {
+    createAdapter: () => new Adapter(),
+    createDriver: () => new DummyDriver(),
+    createIntrospector: (db) => new Introspector(db),
+    createQueryCompiler: () => new Compiler(),
+  }})
+
+const sqlite = mk(SqliteAdapter, SqliteQueryCompiler, SqliteIntrospector)
+const pg = mk(PostgresAdapter, PostgresQueryCompiler, PostgresIntrospector)
+
+// --- fixture ---
+const t = 'default', rootId = 'root-1', prevId = 'doc-prev', newId = 'doc-new', now = 1_700_000_000
+const maxVersions = 20
+const nd = {
+  typeId: 'blog_post', typeVersion: 1, parentRootId: 'p-1', slug: 'hello', title: 'Hi',
+  zone: null, sortOrder: 0, visible: true, scheduledAt: null, expiresAt: null,
+  tenantId: t, locale: 'en', translationGroupId: '', data: { body: 'x' }, metadata: { seo: {} },
+  ownerId: 'u1', createdBy: 'u1', updatedBy: 'u1',
+}
+
+// bool mapper: SQLite keeps 0/1 ints, PG uses real booleans.
+const buildDemote  = (db, b = (n) => n) =>
+  db.updateTable('documents')
+    .set({ is_current_draft: b(0), updated_at: now })
+    .where('id', '=', prevId).where('tenant_id', '=', t)
+
+// The hardest statement. Raw version was INSERT…SELECT ?,?,…(subquery)…,1,0,'draft',… WHERE 1=1
+// with a hand-counted 27-bind budget (R5). Kysely's values({col: subquery}) form is both safer
+// (named columns, no positional counting) and dialect-neutral.
+const buildInsert = (db, b = (n) => n) =>
+  db.insertInto('documents').values({
+    id: newId, root_id: rootId, type_id: nd.typeId, type_version: nd.typeVersion, version_of_id: prevId,
+    // COALESCE(MAX)+1 stays in SQL (R6) — never computed in JS. Correlated subquery, standard SQL.
+    version_number: (eb) => eb.selectFrom('documents')
+      .select(sql`coalesce(max(version_number), 0) + 1`.as('v'))
+      .where('root_id', '=', rootId),
+    is_current_draft: b(1), is_published: b(0), status: 'draft',
+    parent_root_id: nd.parentRootId, slug: nd.slug, path: null, title: nd.title, zone: nd.zone,
+    sort_order: nd.sortOrder, visible: b(nd.visible ? 1 : 0), published_at: null,
+    scheduled_at: nd.scheduledAt, expires_at: nd.expiresAt, deleted_at: null,
+    tenant_id: nd.tenantId, locale: nd.locale, translation_group_id: nd.translationGroupId,
+    data: JSON.stringify(nd.data), metadata: JSON.stringify(nd.metadata),
+    owner_id: nd.ownerId, created_by: nd.createdBy, updated_by: nd.updatedBy,
+    created_at: now, updated_at: now,
+  })
+
+// prune DELETE: two NOT IN subqueries, one with ORDER BY + LIMIT.
+const buildPrune = (db, b = (n) => n) =>
+  db.deleteFrom('documents')
+    .where('root_id', '=', rootId).where('tenant_id', '=', t)
+    .where('is_current_draft', '=', b(0)).where('is_published', '=', b(0))
+    .where('id', 'not in', (eb) => eb.selectFrom('documents').select('id')
+      .where('root_id', '=', rootId).where('tenant_id', '=', t)
+      .where('is_current_draft', '=', b(0)).where('is_published', '=', b(0))
+      .orderBy('version_number', 'desc').limit(maxVersions))
+    .where('id', 'not in', (eb) => eb.selectFrom('documents').select('version_of_id')
+      .where('version_of_id', 'is not', null).where('root_id', '=', rootId).where('tenant_id', '=', t))
+
+const dump = (label, q) => {
+  const { sql: text, parameters } = q.compile()
+  console.log(`\n----- ${label} -----`)
+  console.log(text)
+  console.log('params:', JSON.stringify(parameters))
+}
+
+for (const [name, db, b] of [
+  ['SQLite (D1) — numeric bools', sqlite, (n) => n],
+  ['Postgres — REAL bools',       pg,     (n) => (typeof n === 'number' && (n === 0 || n === 1) ? n === 1 : n)],
+]) {
+  console.log(`\n########## ${name} ##########`)
+  dump('1. demote UPDATE', buildDemote(db, b))
+  dump('2. versioned INSERT (COALESCE(MAX)+1 subquery)', buildInsert(db, b))
+  dump('3. prune DELETE (NOT IN + LIMIT)', buildPrune(db, b))
+}
+
+console.log(`
+########## batch() -> transaction (idiom, not compiled here) ##########
+await db.transaction().execute(async (trx) => {
+  await buildDemote(trx).execute()
+  await buildInsert(trx).execute()
+  // ...derived facet/ref inserts...
+  await buildPrune(trx).execute()
+})
+// D1 .batch([...]) becomes one transaction. Kysely runs it on pg / better-sqlite3 / libsql;
+// on Workers D1 the kysely-d1 dialect maps .transaction() back onto D1 batch semantics.`)


### PR DESCRIPTION
## What

Re-measures the SonicJS → Postgres port effort with a **compile-only Kysely spike**. Ports the two data-access chokepoints to Kysely and proves **one TypeScript builder compiles to correct SQLite (D1) *and* Postgres SQL**:

- **Read** — `DocumentRepository.list()` (the R4 read chokepoint)
- **Write** — `documents.saveDraft()` (the hardest write: `.batch()`, `COALESCE(MAX)+1` version subquery, the R5 27-bind INSERT, prune `DELETE … NOT IN (… LIMIT ?)`)

Compile-only via Kysely `DummyDriver` + per-dialect `QueryCompiler`. **No DB, no production code touched.** Docs + a runnable spike only.

## Findings

| # | Result |
|---|---|
| 1 | `?` → `$N` placeholder rewrite is **free** (dialect compiler) |
| 2 | `0/1`-int vs real `boolean` collapses to **one per-dialect mapper**, not 300 edits |
| 3 | The `'d.'` alias string-prefix hack in `list()` is **deleted** (Kysely resolves aliases) |
| 4 | The **R5 27-bind INSERT bind-counting bug class disappears** with named `values({col})`; `COALESCE(MAX)+1` (R6) stays in SQL |
| 5 | `.batch()` → `.transaction()`; `kysely-d1` maps it back to D1 batch on Workers |
| 6 | `json_extract` is **absent** from both chokepoints; the 38 dialect-divergent sites are a bounded **~20-file** set |
| 7 | Kysely compiles to **D1 / better-sqlite3 / libSQL / Postgres** from one query layer |

## Revised estimate

**~5–9 weeks** to full Postgres parity + a dual-dialect test matrix, at ~half the defect risk of a raw hand-written SQL port. Kysely doesn't cut the week-count much — it changes the **risk profile** (typed, compiler-checked, dual-dialect).

## Files

- `docs/ai/plans/postgres-portability-poc/` — runnable spike (`npm i && node list-read.mjs && node saveDraft-write.mjs`) + README with full measurements
- `docs/ai/plans/portability-analysis.md` — status header + link to the spike

## Not in scope

No production code, no `packages/core/migrations/*` changes, no dependency added to the app (spike has its own isolated `package.json`). This is an RFC/measurement to decide whether to pursue Tier 2 (Postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)