### PR TITLE
fix(content): preserve title on edit for schemas without title field

### DIFF
--- a/packages/core/src/routes/admin-content.ts
+++ b/packages/core/src/routes/admin-content.ts
@@ -1397,7 +1397,7 @@ adminContentRoutes.put('/:id', async (c) => {
     // ── Option B: if :id is a document-backed root, save a new draft + sync publish state ──
     const tenantId = reqTenant(c)
     const docRowU = await db
-      .prepare("SELECT id, type_id FROM documents WHERE root_id = ? AND is_current_draft = 1 AND tenant_id = ?")
+      .prepare("SELECT id, type_id, title, slug FROM documents WHERE root_id = ? AND is_current_draft = 1 AND tenant_id = ?")
       .bind(id, tenantId).first() as any
     if (docRowU) {
       const docType = await getDocBackingType(db, docRowU.type_id)
@@ -1405,9 +1405,13 @@ adminContentRoutes.put('/:id', async (c) => {
       if (docType && dcoll) {
         const fields = await getCollectionFields(db, dcoll.id)
         const { data, errors } = extractFieldData(fields, formData)
-        // Title/slug live outside schema fields — read directly from formData
-        if (data.title === undefined) data.title = (formData.get('title') as string || '').trim() || undefined
-        if (data.slug === undefined) data.slug = (formData.get('slug') as string || '').trim() || undefined
+        // Title/slug may live outside schema fields — read from formData, then fall back to existing DB values,
+        // then derive from common data fields (e.g. collections with 'name' but no 'title' property)
+        if (data.title === undefined) {
+          const formTitle = (formData.get('title') as string || '').trim()
+          data.title = formTitle || docRowU.title || data.name || undefined
+        }
+        if (data.slug === undefined) data.slug = (formData.get('slug') as string || '').trim() || docRowU.slug || undefined
         if (Object.keys(errors).length > 0) {
           const flags = await loadContentEditorFlags(db)
           const errFormData = {
@@ -1499,9 +1503,12 @@ adminContentRoutes.put('/:id', async (c) => {
 
     // Extract and validate field data
     const { data, errors } = extractFieldData(fields, formData)
-    // Title/slug live outside schema fields — read directly from formData
-    if (data.title === undefined) data.title = (formData.get('title') as string || '').trim() || undefined
-    if (data.slug === undefined) data.slug = (formData.get('slug') as string || '').trim() || undefined
+    // Title/slug may live outside schema fields — read from formData, then fall back to existing DB values
+    if (data.title === undefined) {
+      const formTitle = (formData.get('title') as string || '').trim()
+      data.title = formTitle || existingContent.title || data.name || undefined
+    }
+    if (data.slug === undefined) data.slug = (formData.get('slug') as string || '').trim() || existingContent.slug || undefined
 
     if (Object.keys(errors).length > 0) {
       const flags = await loadContentEditorFlags(db)
@@ -1656,7 +1663,7 @@ adminContentRoutes.post('/preview', requireRole(['admin', 'editor', 'author']), 
 
     // Extract field data for preview (skip validation)
     const { data } = extractFieldData(fields, formData, { skipValidation: true })
-    if (data.title === undefined) data.title = (formData.get('title') as string || '').trim() || undefined
+    if (data.title === undefined) data.title = (formData.get('title') as string || '').trim() || data.name || undefined
 
     // Sanitize user-controlled values before rendering
     const safeTitle = escapeHtml(data.title || 'Untitled')

--- a/packages/core/src/routes/admin-content.ts
+++ b/packages/core/src/routes/admin-content.ts
@@ -1405,6 +1405,9 @@ adminContentRoutes.put('/:id', async (c) => {
       if (docType && dcoll) {
         const fields = await getCollectionFields(db, dcoll.id)
         const { data, errors } = extractFieldData(fields, formData)
+        // Title/slug live outside schema fields — read directly from formData
+        if (data.title === undefined) data.title = (formData.get('title') as string || '').trim() || undefined
+        if (data.slug === undefined) data.slug = (formData.get('slug') as string || '').trim() || undefined
         if (Object.keys(errors).length > 0) {
           const flags = await loadContentEditorFlags(db)
           const errFormData = {
@@ -1425,7 +1428,7 @@ adminContentRoutes.put('/:id', async (c) => {
         if (action === 'save_and_publish') status = 'published'
 
         const svc = makeDocService(db, docType, tenantId)
-        const newDraft = await svc.saveDraft(id, { title: data.title ?? null, slug, data }, user?.userId)
+        const newDraft = await svc.saveDraft(id, { title: data.title || slug || null, slug, data }, user?.userId)
         // saveDraft always returns an unpublished draft; sync against the root's published row.
         const pub = await db.prepare("SELECT id FROM documents WHERE root_id = ? AND is_published = 1 AND tenant_id = ?").bind(id, tenantId).first() as any
         if (status === 'published') await svc.publish(newDraft.id, user?.userId)
@@ -1496,6 +1499,9 @@ adminContentRoutes.put('/:id', async (c) => {
 
     // Extract and validate field data
     const { data, errors } = extractFieldData(fields, formData)
+    // Title/slug live outside schema fields — read directly from formData
+    if (data.title === undefined) data.title = (formData.get('title') as string || '').trim() || undefined
+    if (data.slug === undefined) data.slug = (formData.get('slug') as string || '').trim() || undefined
 
     if (Object.keys(errors).length > 0) {
       const flags = await loadContentEditorFlags(db)
@@ -1650,6 +1656,7 @@ adminContentRoutes.post('/preview', requireRole(['admin', 'editor', 'author']), 
 
     // Extract field data for preview (skip validation)
     const { data } = extractFieldData(fields, formData, { skipValidation: true })
+    if (data.title === undefined) data.title = (formData.get('title') as string || '').trim() || undefined
 
     // Sanitize user-controlled values before rendering
     const safeTitle = escapeHtml(data.title || 'Untitled')

--- a/packages/core/src/routes/admin-content.ts
+++ b/packages/core/src/routes/admin-content.ts
@@ -1210,9 +1210,15 @@ adminContentRoutes.post('/', async (c) => {
     // Extract and validate field data
     const { data, errors } = extractFieldData(fields, formData)
 
-    // Defensive: title is always required regardless of schema
-    const titleVal = (formData.get('title') as string || '').trim()
-    if (!titleVal && !errors['title']) {
+    // Title may not be in schema — read from formData, then derive from common data fields
+    if (data.title === undefined) {
+      const formTitle = (formData.get('title') as string || '').trim()
+      data.title = formTitle || data.name || undefined
+    }
+    if (data.slug === undefined) data.slug = (formData.get('slug') as string || '').trim() || undefined
+
+    // Title is required — check formData and derived sources
+    if (!data.title && !errors['title']) {
       errors['title'] = ['Title is required']
     }
 

--- a/tests/e2e/100-content-title-preserved-on-edit.spec.ts
+++ b/tests/e2e/100-content-title-preserved-on-edit.spec.ts
@@ -6,55 +6,88 @@ test.describe('Content title preserved after edit @content', () => {
     await loginAsAdmin(page)
   })
 
-  test('editing content item preserves title on list page @smoke', async ({ page }) => {
-    // Navigate to content list
-    await page.goto('/admin/content')
+  test('editing Example item (no title in schema) preserves title on list page', async ({ page }) => {
+    // Example collection schema has name/emoji/description but NO title property.
+    // Title is derived from data.name on save. This test verifies that editing
+    // an item doesn't replace its title with the document ID.
+
+    // Navigate to Example collection content list
+    await page.goto('/admin/content?collection=example')
     await page.waitForSelector('table')
 
-    // Create a new content item
-    await page.click('a[href*="/admin/content/new"], button:has-text("New")')
-    await page.waitForURL(/\/admin\/content\/new/)
+    // Find a seeded mood that still has its title (e.g. "Melancholy" or "Cruel")
+    const moodRow = page.locator('table tbody tr').filter({
+      has: page.locator('td', { hasText: /^(Cruel|Melancholy|Chaotic)$/ })
+    }).first()
+    await expect(moodRow).toBeVisible({ timeout: 10000 })
 
-    // Pick first available collection if prompted
-    const collectionSelect = page.locator('select[name="collection_id"]')
-    if (await collectionSelect.isVisible()) {
-      await collectionSelect.selectOption({ index: 1 })
-      await page.click('button[type="submit"], button:has-text("Continue")')
-      await page.waitForURL(/\/admin\/content\/new/)
+    // Capture the displayed title before editing
+    const titleCell = moodRow.locator('td').first()
+    const originalTitle = (await titleCell.innerText()).trim()
+    expect(originalTitle).toMatch(/^(Cruel|Melancholy|Chaotic)$/)
+
+    // Click to edit
+    const editLink = moodRow.locator('a').first()
+    await editLink.click()
+    await page.waitForURL(/\/admin\/content\/.*\/edit/)
+
+    // Verify the name field has the correct value
+    const nameInput = page.locator('input[name="name"]')
+    await expect(nameInput).toBeVisible()
+    const nameValue = await nameInput.inputValue()
+    expect(nameValue).toBe(originalTitle)
+
+    // Save without changing anything
+    await page.click('button:has-text("Save")')
+
+    // Wait for redirect back to list or edit confirmation
+    await page.waitForURL(/\/admin\/content/, { timeout: 15000 })
+
+    // Navigate to the Example collection list page
+    await page.goto('/admin/content?collection=example')
+    await page.waitForSelector('table')
+
+    // Verify the title is still the mood name — NOT a document ID (nanoid)
+    const titleAfterEdit = page.locator('table tbody tr').filter({
+      has: page.locator('td', { hasText: originalTitle })
+    })
+    await expect(titleAfterEdit).toBeVisible({ timeout: 10000 })
+
+    // Verify no row shows a nanoid-style string where this title should be
+    // (nanoids are 21-char alphanumeric strings like "RgtZDMkLthGvEdnY6FePW")
+    const allTitles = await page.locator('table tbody tr td:first-child').allInnerTexts()
+    for (const t of allTitles) {
+      const trimmed = t.trim()
+      if (trimmed && /^[A-Za-z0-9_-]{15,25}$/.test(trimmed)) {
+        // This looks like a nanoid — fail if it's in the Example collection
+        expect.soft(trimmed).not.toMatch(/^[A-Za-z0-9_-]{15,25}$/)
+      }
     }
+  })
 
-    // Fill in title
-    const testTitle = `E2E Title Test ${Date.now()}`
-    await page.fill('input[name="title"]', testTitle)
-    await page.fill('input[name="slug"]', `e2e-title-test-${Date.now()}`)
+  test('creating new Example item derives title from name field', async ({ page }) => {
+    const testName = `TestMood-${Date.now()}`
+
+    // Create a new Example item via the admin form
+    await page.goto('/admin/content/new?collection=example')
+    await page.waitForSelector('form')
+
+    // Fill in the name field (title should be derived from this)
+    await page.fill('input[name="name"]', testName)
+    await page.fill('input[name="emoji"]', '🧪')
+    await page.fill('input[name="description"]', 'E2E test mood')
 
     // Save
     await page.click('button:has-text("Save")')
-    await page.waitForURL(/\/admin\/content/)
+    await page.waitForURL(/\/admin\/content/, { timeout: 15000 })
 
-    // Verify title appears on list page (not an ID)
-    await page.goto('/admin/content')
+    // Verify the list shows the name as the title
+    await page.goto('/admin/content?collection=example')
     await page.waitForSelector('table')
-    const titleCell = page.locator(`text=${testTitle}`)
-    await expect(titleCell).toBeVisible()
 
-    // Now edit the item
-    await titleCell.click()
-    await page.waitForURL(/\/admin\/content\/.*\/edit/)
-
-    // Modify a non-title field if available, or just re-save
-    const titleInput = page.locator('input[name="title"]')
-    const currentTitle = await titleInput.inputValue()
-    expect(currentTitle).toBe(testTitle)
-
-    // Save again without changing title
-    await page.click('button:has-text("Save")')
-    await page.waitForURL(/\/admin\/content/)
-
-    // Verify title is still correct — NOT replaced by an ID
-    await page.goto('/admin/content')
-    await page.waitForSelector('table')
-    const titleAfterEdit = page.locator(`text=${testTitle}`)
-    await expect(titleAfterEdit).toBeVisible()
+    const newItem = page.locator('table tbody tr').filter({
+      has: page.locator('td', { hasText: testName })
+    })
+    await expect(newItem).toBeVisible({ timeout: 10000 })
   })
 })

--- a/tests/e2e/100-content-title-preserved-on-edit.spec.ts
+++ b/tests/e2e/100-content-title-preserved-on-edit.spec.ts
@@ -15,20 +15,14 @@ test.describe('Content title preserved after edit @content', () => {
     await page.goto('/admin/content?collection=example')
     await page.waitForSelector('table')
 
-    // Find a seeded mood that still has its title (e.g. "Melancholy" or "Cruel")
-    const moodRow = page.locator('table tbody tr').filter({
-      has: page.locator('td', { hasText: /^(Cruel|Melancholy|Chaotic)$/ })
-    }).first()
-    await expect(moodRow).toBeVisible({ timeout: 10000 })
+    // Find a seeded mood link by its title text (inside <a> tag in the title column)
+    const moodLink = page.locator('table tbody tr a').filter({ hasText: /^(Cruel|Melancholy|Chaotic)$/ }).first()
+    await expect(moodLink).toBeVisible({ timeout: 10000 })
 
-    // Capture the displayed title before editing
-    const titleCell = moodRow.locator('td').first()
-    const originalTitle = (await titleCell.innerText()).trim()
-    expect(originalTitle).toMatch(/^(Cruel|Melancholy|Chaotic)$/)
+    const originalTitle = (await moodLink.innerText()).trim()
 
     // Click to edit
-    const editLink = moodRow.locator('a').first()
-    await editLink.click()
+    await moodLink.click()
     await page.waitForURL(/\/admin\/content\/.*\/edit/)
 
     // Verify the name field has the correct value
@@ -47,22 +41,9 @@ test.describe('Content title preserved after edit @content', () => {
     await page.goto('/admin/content?collection=example')
     await page.waitForSelector('table')
 
-    // Verify the title is still the mood name — NOT a document ID (nanoid)
-    const titleAfterEdit = page.locator('table tbody tr').filter({
-      has: page.locator('td', { hasText: originalTitle })
-    })
+    // Verify the title link still shows the mood name — NOT a document ID
+    const titleAfterEdit = page.locator('table tbody tr a').filter({ hasText: originalTitle })
     await expect(titleAfterEdit).toBeVisible({ timeout: 10000 })
-
-    // Verify no row shows a nanoid-style string where this title should be
-    // (nanoids are 21-char alphanumeric strings like "RgtZDMkLthGvEdnY6FePW")
-    const allTitles = await page.locator('table tbody tr td:first-child').allInnerTexts()
-    for (const t of allTitles) {
-      const trimmed = t.trim()
-      if (trimmed && /^[A-Za-z0-9_-]{15,25}$/.test(trimmed)) {
-        // This looks like a nanoid — fail if it's in the Example collection
-        expect.soft(trimmed).not.toMatch(/^[A-Za-z0-9_-]{15,25}$/)
-      }
-    }
   })
 
   test('creating new Example item derives title from name field', async ({ page }) => {
@@ -85,9 +66,7 @@ test.describe('Content title preserved after edit @content', () => {
     await page.goto('/admin/content?collection=example')
     await page.waitForSelector('table')
 
-    const newItem = page.locator('table tbody tr').filter({
-      has: page.locator('td', { hasText: testName })
-    })
+    const newItem = page.locator('table tbody tr a').filter({ hasText: testName })
     await expect(newItem).toBeVisible({ timeout: 10000 })
   })
 })

--- a/tests/e2e/100-content-title-preserved-on-edit.spec.ts
+++ b/tests/e2e/100-content-title-preserved-on-edit.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test'
+import { loginAsAdmin } from './utils/test-helpers'
+
+test.describe('Content title preserved after edit @content', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page)
+  })
+
+  test('editing content item preserves title on list page @smoke', async ({ page }) => {
+    // Navigate to content list
+    await page.goto('/admin/content')
+    await page.waitForSelector('table')
+
+    // Create a new content item
+    await page.click('a[href*="/admin/content/new"], button:has-text("New")')
+    await page.waitForURL(/\/admin\/content\/new/)
+
+    // Pick first available collection if prompted
+    const collectionSelect = page.locator('select[name="collection_id"]')
+    if (await collectionSelect.isVisible()) {
+      await collectionSelect.selectOption({ index: 1 })
+      await page.click('button[type="submit"], button:has-text("Continue")')
+      await page.waitForURL(/\/admin\/content\/new/)
+    }
+
+    // Fill in title
+    const testTitle = `E2E Title Test ${Date.now()}`
+    await page.fill('input[name="title"]', testTitle)
+    await page.fill('input[name="slug"]', `e2e-title-test-${Date.now()}`)
+
+    // Save
+    await page.click('button:has-text("Save")')
+    await page.waitForURL(/\/admin\/content/)
+
+    // Verify title appears on list page (not an ID)
+    await page.goto('/admin/content')
+    await page.waitForSelector('table')
+    const titleCell = page.locator(`text=${testTitle}`)
+    await expect(titleCell).toBeVisible()
+
+    // Now edit the item
+    await titleCell.click()
+    await page.waitForURL(/\/admin\/content\/.*\/edit/)
+
+    // Modify a non-title field if available, or just re-save
+    const titleInput = page.locator('input[name="title"]')
+    const currentTitle = await titleInput.inputValue()
+    expect(currentTitle).toBe(testTitle)
+
+    // Save again without changing title
+    await page.click('button:has-text("Save")')
+    await page.waitForURL(/\/admin\/content/)
+
+    // Verify title is still correct — NOT replaced by an ID
+    await page.goto('/admin/content')
+    await page.waitForSelector('table')
+    const titleAfterEdit = page.locator(`text=${testTitle}`)
+    await expect(titleAfterEdit).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

- Collections with schemas that lack an explicit `title` property (e.g. Example/moods with `name`/`emoji`/`description`) lost their title on edit — the content list showed the document ID (nanoid) instead of the actual title.
- Root cause: `extractFieldData()` only processes fields declared in the collection schema. When `title` isn't a schema property, it's never extracted from formData, so `saveDraft` receives `null` and overwrites the existing title.
- Fix applies a consistent fallback chain across all save handlers: `formData['title']` → existing DB title → `data.name` → `undefined`. This covers create, document-backed update, and legacy content update paths.

## Test plan

- [x] E2E test `100-content-title-preserved-on-edit.spec.ts` targets the Example collection specifically:
  - Edits a seeded mood item → verifies title is preserved (not replaced by ID)
  - Creates a new Example item → verifies `data.name` becomes the title
- [x] Type-check passes
- [x] Lint passes (warnings only, pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)