### PR TITLE
fix(test): tighten waitForURL in E2E spec 100 to match edit redirect

### DIFF
--- a/tests/e2e/100-content-title-preserved-on-edit.spec.ts
+++ b/tests/e2e/100-content-title-preserved-on-edit.spec.ts
@@ -58,11 +58,11 @@ test.describe('Content title preserved after edit @content', () => {
     await page.fill('input[name="emoji"]', '🧪')
     await page.fill('input[name="description"]', 'E2E test mood')
 
-    // Save
+    // Save — POST success redirects to /admin/content/<ID>/edit, not the list
     await page.click('button:has-text("Save")')
-    await page.waitForURL(/\/admin\/content/, { timeout: 15000 })
+    await page.waitForURL(/\/admin\/content\/[^?]+\/edit/, { timeout: 15000 })
 
-    // Verify the list shows the name as the title
+    // Navigate to the Example collection list page
     await page.goto('/admin/content?collection=example')
     await page.waitForSelector('table')
 


### PR DESCRIPTION
## Problem

`waitForURL(/\/admin\/content/)` in the create test matched the current URL `/admin/content/new?collection=example` immediately — before the HTMX form submission completed. The subsequent `page.goto('/admin/content?collection=example')` raced with the in-flight POST, causing `net::ERR_ABORTED`.

## Fix

Wait for the POST success redirect pattern `/admin/content/<ID>/edit` instead. The create handler redirects to `/admin/content/${doc.rootId}/edit?success=...` on success, which is unambiguous.

## Test plan
- [ ] CI passes for E2E spec 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)