### PR TITLE
ci(publish): fix OIDC auth - sed _authToken from NPM_CONFIG_USERCONFIG

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,11 @@ jobs:
         run: npm ci
 
       - name: Clear npm auth token (OIDC trusted publishing handles auth)
-        run: npm config delete //registry.npmjs.org/:_authToken || true
+        run: |
+          # setup-node writes to $NPM_CONFIG_USERCONFIG; remove the _authToken line
+          # so npm's OIDC trusted publishing exchange can take over
+          sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG" || true
+          cat "$NPM_CONFIG_USERCONFIG"
 
       - name: Build core
         run: npm run build:core


### PR DESCRIPTION
npm config delete targets wrong file. setup-node writes to $NPM_CONFIG_USERCONFIG; sed directly on that file removes the _authToken line so OIDC trusted publishing can take over.