### PR TITLE
fix(ci): explicitly fetch GitHub OIDC token for npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,11 @@ jobs:
         run: npm ci
 
       - name: Clear npm auth token (OIDC trusted publishing handles auth)
-        run: npm config delete //registry.npmjs.org/:_authToken || true
+        run: |
+          # setup-node writes to $NPM_CONFIG_USERCONFIG; remove the _authToken line
+          # so npm's OIDC trusted publishing exchange can take over
+          sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG" || true
+          cat "$NPM_CONFIG_USERCONFIG"
 
       - name: Build core
         run: npm run build:core

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,17 +33,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Remove cached npm auth token (OIDC trusted publishing handles auth)
+      - name: Get OIDC token for npm trusted publishing
         run: |
-          # setup-node with registry-url writes _authToken=${NODE_AUTH_TOKEN} to
-          # $NPM_CONFIG_USERCONFIG. Remove it so npm's OIDC exchange can take over.
-          if [ -n "$NPM_CONFIG_USERCONFIG" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
-            sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
-            echo "Cleaned npmrc:"
-            cat "$NPM_CONFIG_USERCONFIG"
-          else
-            echo "NPM_CONFIG_USERCONFIG not set or file missing, skipping"
-          fi
+          OIDC_TOKEN=$(curl -s \
+            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://registry.npmjs.org" \
+            | jq -r '.value')
+          echo "::add-mask::$OIDC_TOKEN"
+          echo "NODE_AUTH_TOKEN=$OIDC_TOKEN" >> "$GITHUB_ENV"
 
       - name: Build core
         run: npm run build:core

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,16 +28,22 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+          registry-url: 'https://registry.npmjs.org/'
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Clear npm auth token (OIDC trusted publishing handles auth)
+      - name: Remove cached npm auth token (OIDC trusted publishing handles auth)
         run: |
-          # setup-node writes to $NPM_CONFIG_USERCONFIG; remove the _authToken line
-          # so npm's OIDC trusted publishing exchange can take over
-          sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG" || true
-          cat "$NPM_CONFIG_USERCONFIG"
+          # setup-node with registry-url writes _authToken=${NODE_AUTH_TOKEN} to
+          # $NPM_CONFIG_USERCONFIG. Remove it so npm's OIDC exchange can take over.
+          if [ -n "$NPM_CONFIG_USERCONFIG" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
+            sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
+            echo "Cleaned npmrc:"
+            cat "$NPM_CONFIG_USERCONFIG"
+          else
+            echo "NPM_CONFIG_USERCONFIG not set or file missing, skipping"
+          fi
 
       - name: Build core
         run: npm run build:core


### PR DESCRIPTION
## Summary

- npm CLI does not automatically exchange OIDC tokens — the token must be explicitly fetched from GitHub's OIDC endpoint and set as `NODE_AUTH_TOKEN`
- `setup-node` already writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` to the npmrc; populating `NODE_AUTH_TOKEN` with the GitHub OIDC JWT lets the npm registry validate it against the Trusted Publisher config
- Replaces the sed-based `_authToken` removal approach with an explicit OIDC token fetch step

## Test plan
- [ ] Trigger the publish workflow via workflow_dispatch (dry_run: false) after merging to confirm auth succeeds
- [ ] Verify `@sonicjs-cms/core@3.0.0-beta.28` and `create-sonicjs@3.0.0-beta.28` appear on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)