### PR TITLE
fix(ci): use Granular Access Token via NODE_AUTH_TOKEN secret for npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,11 @@ jobs:
         run: npm ci
 
       - name: Clear npm auth token (OIDC trusted publishing handles auth)
-        run: npm config delete //registry.npmjs.org/:_authToken || true
+        run: |
+          # setup-node writes to $NPM_CONFIG_USERCONFIG; remove the _authToken line
+          # so npm's OIDC trusted publishing exchange can take over
+          sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG" || true
+          cat "$NPM_CONFIG_USERCONFIG"
 
       - name: Build core
         run: npm run build:core

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,16 +33,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Remove cached npm auth token (let npm auto-detect OIDC trusted publishing)
-        run: |
-          if [ -n "$NPM_CONFIG_USERCONFIG" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
-            sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
-            echo "Cleaned npmrc:"
-            cat "$NPM_CONFIG_USERCONFIG"
-          else
-            echo "NPM_CONFIG_USERCONFIG not set or file missing, skipping"
-          fi
-
       - name: Build core
         run: npm run build:core
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,14 +33,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Get OIDC token for npm trusted publishing
+      - name: Remove cached npm auth token (let npm auto-detect OIDC trusted publishing)
         run: |
-          OIDC_TOKEN=$(curl -s \
-            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://registry.npmjs.org" \
-            | jq -r '.value')
-          echo "::add-mask::$OIDC_TOKEN"
-          echo "NODE_AUTH_TOKEN=$OIDC_TOKEN" >> "$GITHUB_ENV"
+          if [ -n "$NPM_CONFIG_USERCONFIG" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
+            sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
+            echo "Cleaned npmrc:"
+            cat "$NPM_CONFIG_USERCONFIG"
+          else
+            echo "NPM_CONFIG_USERCONFIG not set or file missing, skipping"
+          fi
 
       - name: Build core
         run: npm run build:core

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,17 +33,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Remove cached npm auth token (OIDC trusted publishing handles auth)
+      - name: Get OIDC token for npm trusted publishing
         run: |
-          # setup-node with registry-url writes _authToken=${NODE_AUTH_TOKEN} to
-          # $NPM_CONFIG_USERCONFIG. Remove it so npm's OIDC exchange can take over.
-          if [ -n "$NPM_CONFIG_USERCONFIG" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
-            sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
-            echo "Cleaned npmrc:"
-            cat "$NPM_CONFIG_USERCONFIG"
-          else
-            echo "NPM_CONFIG_USERCONFIG not set or file missing, skipping"
-          fi
+          OIDC_TOKEN=$(curl -s \
+            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://registry.npmjs.org" \
+            | jq -r '.value')
+          echo "::add-mask::$OIDC_TOKEN"
+          echo "NODE_AUTH_TOKEN=$OIDC_TOKEN" >> "$GITHUB_ENV"
 
       - name: Build core
         run: npm run build:core

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,16 +28,22 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+          registry-url: 'https://registry.npmjs.org/'
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Clear npm auth token (OIDC trusted publishing handles auth)
+      - name: Remove cached npm auth token (OIDC trusted publishing handles auth)
         run: |
-          # setup-node writes to $NPM_CONFIG_USERCONFIG; remove the _authToken line
-          # so npm's OIDC trusted publishing exchange can take over
-          sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG" || true
-          cat "$NPM_CONFIG_USERCONFIG"
+          # setup-node with registry-url writes _authToken=${NODE_AUTH_TOKEN} to
+          # $NPM_CONFIG_USERCONFIG. Remove it so npm's OIDC exchange can take over.
+          if [ -n "$NPM_CONFIG_USERCONFIG" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
+            sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
+            echo "Cleaned npmrc:"
+            cat "$NPM_CONFIG_USERCONFIG"
+          else
+            echo "NPM_CONFIG_USERCONFIG not set or file missing, skipping"
+          fi
 
       - name: Build core
         run: npm run build:core


### PR DESCRIPTION
## Summary

- Removes all the sed/OIDC hacks — npm OIDC auto-detection does not trigger in practice
- `setup-node` with `registry-url` writes `_authToken=${NODE_AUTH_TOKEN}` to the npmrc
- A Granular Access Token (GAT) stored as `NODE_AUTH_TOKEN` repo secret provides auth without needing `bypass2fa` (which npm deprecated July 2026)

## Prerequisite
Add a `NODE_AUTH_TOKEN` secret to this repo:
1. npmjs.com → Account → Access Tokens → Generate New Token → **Granular Access Token**
2. Select packages: `@sonicjs-cms/core`, `@sonicjs-cms/sdk`, `create-sonicjs` → Read and write
3. GitHub → Settings → Secrets → Actions → New secret: `NODE_AUTH_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)